### PR TITLE
Combine frames in MoQ objects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Catalog is now based on Github [catalog] of Feb. 28 2025
 
+### Added
+
+- Configuration options for `audiobatch` and `videobatch` to control how many frames should be sent in every MoQ object/CMAF chunk
+
 ## [0.2.0] - 2025-04-28
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
-
 # moqlivemock
 
 ![Test](https://github.com/Eyevinn/moqlivemock/workflows/Go/badge.svg)
@@ -19,6 +18,8 @@ but it should be easy to combine a few frames into a chunk
 to lower the packaging overhead. LOC is currently not supported, but
 one possible scenario is to send LOC over the wire and then reassamble
 CMAF on the receiving side again.
+
+You can configure how many frames should be sent in every MoQ object/CMAF chunk using the `-audiobatch` and `-videobatch` options. This allows you to control the packaging overhead by batching multiple frames into a single chunk.
 
 This project uses [moqtransport][moqtransport] for the MoQ transport layer.
 As the MoQ transport layer is still work in progress, this project is also
@@ -70,6 +71,12 @@ You can also build the binary and then run it
 cd cmd/mlmpub
 go build .
 ./mlmpub
+```
+
+You can also specify options for the publisher:
+
+```shell
+./mlmpub -audiobatch 4 -videobatch 2
 ```
 
 In another shell, start the subscriber and choose if the video, the audio,

--- a/cmd/mlmpub/handler.go
+++ b/cmd/mlmpub/handler.go
@@ -180,7 +180,7 @@ func publishTrack(ctx context.Context, publisher moqtransport.Publisher, asset *
 			slog.Error("failed to open subgroup", "error", err)
 			return
 		}
-		mg := internal.GenMoQGroup(contentTrack, groupNr, internal.MoqGroupDurMS)
+		mg := internal.GenMoQGroup(contentTrack, groupNr, contentTrack.SampleBatch, internal.MoqGroupDurMS)
 		slog.Info("writing MoQ group", "group", groupNr, "objects", len(mg.MoQObjects))
 		err = internal.WriteMoQGroup(ctx, contentTrack, mg, sg.WriteObject)
 		if err != nil {

--- a/cmd/mlmpub/main.go
+++ b/cmd/mlmpub/main.go
@@ -108,7 +108,8 @@ func runServer(opts *options) error {
 	if err != nil {
 		return err
 	}
-	slog.Info("loaded asset", "path", opts.asset, "audioSampleBatch", opts.audioSampleBatch, "videoSampleBatch", opts.videoSampleBatch)
+	slog.Info("loaded asset", "path", opts.asset, "audioSampleBatch", opts.audioSampleBatch,
+		"videoSampleBatch", opts.videoSampleBatch)
 	catalog, err := asset.GenCMAFCatalogEntry()
 	if err != nil {
 		return err

--- a/cmd/mlmsub/handler.go
+++ b/cmd/mlmsub/handler.go
@@ -250,12 +250,12 @@ func (h *moqHandler) subscribeAndRead(ctx context.Context, s *moqtransport.Sessi
 				return
 			}
 			if o.ObjectID == 0 {
-				slog.Info("group start", "groupID", o.GroupID, "subGroupID", o.SubGroupID, "payloadLength", len(o.Payload))
+				slog.Info("group start", "track", trackname, "groupID", o.GroupID, "payloadLength", len(o.Payload))
 			} else {
 				slog.Debug("object",
+					"track", trackname,
 					"objectID", o.ObjectID,
 					"groupID", o.GroupID,
-					"subGroupID", o.SubGroupID,
 					"payloadLength", len(o.Payload))
 			}
 

--- a/internal/asset_test.go
+++ b/internal/asset_test.go
@@ -51,7 +51,7 @@ func TestPrepareTrack(t *testing.T) {
 		t.Run(tc.desc, func(t *testing.T) {
 			fh, err := os.Open(tc.filePath)
 			require.NoError(t, err)
-			ct, err := InitContentTrack(fh, tc.desc)
+			ct, err := InitContentTrack(fh, tc.desc, 1, 1)
 			require.NoError(t, err)
 			require.Equal(t, tc.contentType, ct.contentType, "contentType")
 			require.Equal(t, tc.timeScale, int(ct.timeScale), "timeScale")
@@ -65,7 +65,7 @@ func TestPrepareTrack(t *testing.T) {
 }
 
 func TestLoadAsset(t *testing.T) {
-	asset, err := LoadAsset("../content")
+	asset, err := LoadAsset("../content", 1, 1)
 	require.NoError(t, err)
 	require.NotNil(t, asset)
 
@@ -149,7 +149,7 @@ func TestLoadAsset(t *testing.T) {
 }
 
 func TestGen20sCMAFStreams(t *testing.T) {
-	asset, err := LoadAsset("../content")
+	asset, err := LoadAsset("../content", 1, 1)
 	require.NoError(t, err)
 	require.NotNil(t, asset)
 
@@ -177,8 +177,9 @@ func TestGen20sCMAFStreams(t *testing.T) {
 			_, err = ofh.Write(data)
 			require.NoError(t, err)
 			nrSamples := int(20 * tr.timeScale / tr.sampleDur)
+			groupNr := uint32(0)
 			for nr := 0; nr < nrSamples; nr++ {
-				chunk, err := tr.GetCMAFChunk(uint64(nr))
+				chunk, err := tr.GenCMAFChunk(groupNr, uint64(nr), uint64(nr+1))
 				require.NoError(t, err)
 				_, err = ofh.Write(chunk)
 				require.NoError(t, err)

--- a/internal/batch_test.go
+++ b/internal/batch_test.go
@@ -1,0 +1,248 @@
+package internal
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestCalcCmafBitrate(t *testing.T) {
+	testCases := []struct {
+		desc          string
+		sampleBitrate uint32
+		frameRate     float64
+		sampleBatch   int
+		expectedRate  int
+	}{
+		{
+			desc:          "video_batch_1",
+			sampleBitrate: 400000,
+			frameRate:     25.0,
+			sampleBatch:   1,
+			expectedRate:  402800, // 400000 + 8*112*25
+		},
+		{
+			desc:          "video_batch_2",
+			sampleBitrate: 400000,
+			frameRate:     25.0,
+			sampleBatch:   2,
+			expectedRate:  401500, // 400000 + 8*(112+8)*25/2
+		},
+		{
+			desc:          "audio_batch_1",
+			sampleBitrate: 128000,
+			frameRate:     46.875, // 48000/1024
+			sampleBatch:   1,
+			expectedRate:  130100, // 128000 + 8*112*46.875
+		},
+		{
+			desc:          "audio_batch_4",
+			sampleBitrate: 128000,
+			frameRate:     46.875,
+			sampleBatch:   4,
+			expectedRate:  128759, // 128000 + 8*(112+3*8)*46.875/4
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			rate := calcCmafBitrate(tc.sampleBitrate, tc.frameRate, tc.sampleBatch)
+			require.Equal(t, tc.expectedRate, rate)
+		})
+	}
+}
+
+func TestInitContentTrackWithBatch(t *testing.T) {
+	testCases := []struct {
+		desc             string
+		filePath         string
+		audioSampleBatch int
+		videoSampleBatch int
+		expectedBatch    int
+	}{
+		{
+			desc:             "video_400kbps_batch_1",
+			filePath:         "../content/video_400kbps.mp4",
+			audioSampleBatch: 2,
+			videoSampleBatch: 1,
+			expectedBatch:    1,
+		},
+		{
+			desc:             "video_400kbps_batch_3",
+			filePath:         "../content/video_400kbps.mp4",
+			audioSampleBatch: 2,
+			videoSampleBatch: 3,
+			expectedBatch:    3,
+		},
+		{
+			desc:             "audio_128kbps_batch_2",
+			filePath:         "../content/audio_monotonic_128kbps.mp4",
+			audioSampleBatch: 2,
+			videoSampleBatch: 3,
+			expectedBatch:    2,
+		},
+		{
+			desc:             "audio_128kbps_batch_4",
+			filePath:         "../content/audio_monotonic_128kbps.mp4",
+			audioSampleBatch: 4,
+			videoSampleBatch: 1,
+			expectedBatch:    4,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			fh, err := os.Open(tc.filePath)
+			require.NoError(t, err)
+			defer fh.Close()
+			
+			ct, err := InitContentTrack(fh, tc.desc, tc.audioSampleBatch, tc.videoSampleBatch)
+			require.NoError(t, err)
+			require.Equal(t, tc.expectedBatch, ct.SampleBatch, "SampleBatch")
+		})
+	}
+}
+
+func TestLoadAssetWithBatch(t *testing.T) {
+	testCases := []struct {
+		desc             string
+		audioSampleBatch int
+		videoSampleBatch int
+	}{
+		{
+			desc:             "default_batch_1_1",
+			audioSampleBatch: 1,
+			videoSampleBatch: 1,
+		},
+		{
+			desc:             "audio_batch_2_video_batch_1",
+			audioSampleBatch: 2,
+			videoSampleBatch: 1,
+		},
+		{
+			desc:             "audio_batch_4_video_batch_2",
+			audioSampleBatch: 4,
+			videoSampleBatch: 2,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			asset, err := LoadAsset("../content", tc.audioSampleBatch, tc.videoSampleBatch)
+			require.NoError(t, err)
+			require.NotNil(t, asset)
+
+			// Check that all tracks have the correct batch size
+			for _, group := range asset.groups {
+				for _, track := range group.tracks {
+					switch track.contentType {
+					case "audio":
+						require.Equal(t, tc.audioSampleBatch, track.SampleBatch, 
+							"Audio track %s should have batch size %d", track.name, tc.audioSampleBatch)
+					case "video":
+						require.Equal(t, tc.videoSampleBatch, track.SampleBatch, 
+							"Video track %s should have batch size %d", track.name, tc.videoSampleBatch)
+					}
+				}
+			}
+
+			// Test that the catalog bitrates are calculated correctly based on batch size
+			catalog, err := asset.GenCMAFCatalogEntry()
+			require.NoError(t, err)
+			require.NotNil(t, catalog)
+
+			// Verify that tracks exist in the catalog
+			require.Equal(t, 5, len(catalog.Tracks))
+
+			// Check that the bitrates in the catalog reflect the batch sizes
+			for _, track := range catalog.Tracks {
+				// Find the corresponding ContentTrack
+				var contentTrack *ContentTrack
+				for _, group := range asset.groups {
+					for i := range group.tracks {
+						if group.tracks[i].name == track.Name {
+							contentTrack = &group.tracks[i]
+							break
+						}
+					}
+					if contentTrack != nil {
+						break
+					}
+				}
+				require.NotNil(t, contentTrack, "Track %s should exist in asset", track.Name)
+
+				// Calculate expected bitrate
+				frameRate := float64(contentTrack.timeScale) / float64(contentTrack.sampleDur)
+				expectedBitrate := calcCmafBitrate(contentTrack.sampleBitrate, frameRate, contentTrack.SampleBatch)
+				
+				require.Equal(t, expectedBitrate, *track.Bitrate, 
+					"Track %s should have bitrate calculated with batch size %d", 
+					track.Name, contentTrack.SampleBatch)
+			}
+		})
+	}
+}
+
+func TestGenCMAFChunkWithBatch(t *testing.T) {
+	// Test different batch sizes for chunk generation
+	testCases := []struct {
+		desc             string
+		audioSampleBatch int
+		videoSampleBatch int
+	}{
+		{
+			desc:             "batch_1_1",
+			audioSampleBatch: 1,
+			videoSampleBatch: 1,
+		},
+		{
+			desc:             "batch_2_2",
+			audioSampleBatch: 2,
+			videoSampleBatch: 2,
+		},
+		{
+			desc:             "batch_4_3",
+			audioSampleBatch: 4,
+			videoSampleBatch: 3,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			asset, err := LoadAsset("../content", tc.audioSampleBatch, tc.videoSampleBatch)
+			require.NoError(t, err)
+			require.NotNil(t, asset)
+
+			// Test chunk generation for each track
+			for _, group := range asset.groups {
+				for _, track := range group.tracks {
+					// Test with different batch sizes
+					batchSize := track.SampleBatch
+					
+					// Generate a chunk with the configured batch size
+					chunk, err := track.GenCMAFChunk(0, 0, uint64(batchSize))
+					require.NoError(t, err)
+					require.NotNil(t, chunk)
+					
+					// For video tracks with batch > 1, the chunk should be larger than a single sample chunk
+					if track.contentType == "video" && batchSize > 1 {
+						// Generate a single sample chunk for comparison
+						singleChunk, err := track.GenCMAFChunk(0, 0, 1)
+						require.NoError(t, err)
+						
+						// The multi-sample chunk should be larger than the single sample chunk
+						// but not proportionally larger due to overhead sharing
+						require.Greater(t, len(chunk), len(singleChunk), 
+							"Multi-sample chunk should be larger than single sample chunk")
+						
+						// The chunk should be smaller than batchSize * single sample chunks
+						// due to shared overhead
+						require.Less(t, len(chunk), batchSize*len(singleChunk), 
+							"Multi-sample chunk should be smaller than batchSize * single sample chunks")
+					}
+				}
+			}
+		})
+	}
+}

--- a/internal/moqgroup.go
+++ b/internal/moqgroup.go
@@ -27,8 +27,8 @@ type MoQObject []byte
 // constant (average) duration of all MoQGroups for this track.
 func GenMoQGroup(track *ContentTrack, groupNr uint64, sampleBatch int, constantDurMS uint32) *MoQGroup {
 	startNr, endNr := calcMoQGroup(track, groupNr, constantDurMS)
-	startTime := startNr * uint64(track.sampleDur)
-	endTime := endNr * uint64(track.sampleDur)
+	startTime := startNr * uint64(track.SampleDur)
+	endTime := endNr * uint64(track.SampleDur)
 	mq := &MoQGroup{
 		id:         uint32(groupNr),
 		startTime:  startTime,
@@ -50,14 +50,14 @@ func GenMoQGroup(track *ContentTrack, groupNr uint64, sampleBatch int, constantD
 }
 
 func calcMoQGroup(track *ContentTrack, nr uint64, constantDurMS uint32) (startNr, endNr uint64) {
-	startTime := nr * uint64(constantDurMS) * uint64(track.timeScale) / 1000
-	endTime := (nr + 1) * uint64(constantDurMS) * uint64(track.timeScale) / 1000
-	startNr = startTime / uint64(track.sampleDur)
-	if startTime%uint64(track.sampleDur) != 0 {
+	startTime := nr * uint64(constantDurMS) * uint64(track.TimeScale) / 1000
+	endTime := (nr + 1) * uint64(constantDurMS) * uint64(track.TimeScale) / 1000
+	startNr = startTime / uint64(track.SampleDur)
+	if startTime%uint64(track.SampleDur) != 0 {
 		startNr++
 	}
-	endNr = endTime / uint64(track.sampleDur)
-	if endTime%uint64(track.sampleDur) != 0 {
+	endNr = endTime / uint64(track.SampleDur)
+	if endTime%uint64(track.SampleDur) != 0 {
 		endNr++
 	}
 	return startNr, endNr
@@ -72,13 +72,13 @@ func CurrMoQGroupNr(track *ContentTrack, nowMS uint64, constantDurMS uint32) uin
 // The MoQGroup is sent in the correct time order and at appropriate times if ongoing session.
 // If the context is done, the function returns the error from the context.
 func WriteMoQGroup(ctx context.Context, track *ContentTrack, moq *MoQGroup, cb ObjectWriter) error {
-	factorMS := 1000 / float64(track.timeScale)
+	factorMS := 1000 / float64(track.TimeScale)
 	for nr, moqObj := range moq.MoQObjects {
 		if ctx.Err() != nil {
 			return ctx.Err()
 		}
 		now := time.Now().UnixMilli()
-		objTimeMS := int64(float64(int64(moq.startTime)+int64(nr+1)*int64(track.sampleDur)) * factorMS)
+		objTimeMS := int64(float64(int64(moq.startTime)+int64(nr+1)*int64(track.SampleDur)) * factorMS)
 		waitTime := objTimeMS - now
 		if waitTime <= 0 {
 			_, err := cb(uint64(nr), moqObj)

--- a/internal/moqgroup_test.go
+++ b/internal/moqgroup_test.go
@@ -13,7 +13,7 @@ import (
 
 func TestGenMoQGroup_VideoAudio(t *testing.T) {
 	// Use similar setup as in asset_test.go
-	asset, err := LoadAsset("../content") // adjust path if needed
+	asset, err := LoadAsset("../content", 1, 1) // adjust path if needed
 	require.NoError(t, err)
 	require.NotNil(t, asset)
 
@@ -36,7 +36,7 @@ func TestGenMoQGroup_VideoAudio(t *testing.T) {
 	const groupDurMS = 1000 // 1 second per MoQGroup
 
 	// Video
-	vg := GenMoQGroup(videoTrack, groupNr, groupDurMS)
+	vg := GenMoQGroup(videoTrack, groupNr, 1, groupDurMS)
 	require.NotNil(t, vg)
 	// startTime and endTime should be aligned to sample duration
 	require.Equal(t, uint64(0), vg.startTime%uint64(videoTrack.sampleDur), "video startTime not aligned")
@@ -47,7 +47,7 @@ func TestGenMoQGroup_VideoAudio(t *testing.T) {
 	require.Equal(t, int(vg.endNr-vg.startNr), len(vg.MoQObjects), "video MoQObjects count")
 
 	// Audio
-	ag := GenMoQGroup(audioTrack, groupNr, groupDurMS)
+	ag := GenMoQGroup(audioTrack, groupNr, 1, groupDurMS)
 	require.NotNil(t, ag)
 	require.Equal(t, uint64(0), ag.startTime%uint64(audioTrack.sampleDur), "audio startTime not aligned")
 	require.Equal(t, uint64(0), ag.endTime%uint64(audioTrack.sampleDur), "audio endTime not aligned")
@@ -58,8 +58,8 @@ func TestGenMoQGroup_VideoAudio(t *testing.T) {
 func TestGenMoQStreams(t *testing.T) {
 	// StartNr corresponding to 2025-04-21T17:07:48Z
 	startNr := uint64(1745255189)
-	endNr := startNr + 15                 // 15 MoQGroups à 1s per MoQGroup
-	asset, err := LoadAsset("../content") // adjust path if needed
+	endNr := startNr + 15                       // 15 MoQGroups à 1s per MoQGroup
+	asset, err := LoadAsset("../content", 1, 1) // adjust path if needed
 	require.NoError(t, err)
 	require.NotNil(t, asset)
 	for _, group := range asset.groups {
@@ -79,7 +79,7 @@ func TestGenMoQStreams(t *testing.T) {
 				t.Fatalf("failed to write init data: %v", err)
 			}
 			for nr := startNr; nr < endNr; nr++ {
-				moq := GenMoQGroup(ct, nr, 1000)
+				moq := GenMoQGroup(ct, nr, 1, 1000)
 				if moq == nil {
 					t.Fatalf("failed to generate MoQ group")
 				}
@@ -95,7 +95,7 @@ func TestGenMoQStreams(t *testing.T) {
 }
 
 func TestWriteMoQGroupLive(t *testing.T) {
-	asset, err := LoadAsset("../content") // adjust path if needed
+	asset, err := LoadAsset("../content", 1, 1) // adjust path if needed
 	require.NoError(t, err)
 	require.NotNil(t, asset)
 	name := "video_400kbps"
@@ -123,7 +123,7 @@ func TestWriteMoQGroupLive(t *testing.T) {
 	groupNr := currGroupNr + 1 // Start stream on next group
 	endNr := groupNr + 1       // 1 MoQGroup à 1s per MoQGroup
 	for {
-		mg := GenMoQGroup(ct, groupNr, MoqGroupDurMS)
+		mg := GenMoQGroup(ct, groupNr, 1, MoqGroupDurMS)
 		err := WriteMoQGroup(context.Background(), ct, mg, cb)
 		if err != nil {
 			log.Printf("failed to write MoQ group: %v", err)

--- a/internal/moqgroup_test.go
+++ b/internal/moqgroup_test.go
@@ -18,13 +18,13 @@ func TestGenMoQGroup_VideoAudio(t *testing.T) {
 	require.NotNil(t, asset)
 
 	var videoTrack, audioTrack *ContentTrack
-	for _, group := range asset.groups {
-		for i := range group.tracks {
-			ct := &group.tracks[i]
-			if ct.contentType == "video" && videoTrack == nil {
+	for _, group := range asset.Groups {
+		for i := range group.Tracks {
+			ct := &group.Tracks[i]
+			if ct.ContentType == "video" && videoTrack == nil {
 				videoTrack = ct
 			}
-			if ct.contentType == "audio" && audioTrack == nil {
+			if ct.ContentType == "audio" && audioTrack == nil {
 				audioTrack = ct
 			}
 		}
@@ -39,8 +39,8 @@ func TestGenMoQGroup_VideoAudio(t *testing.T) {
 	vg := GenMoQGroup(videoTrack, groupNr, 1, groupDurMS)
 	require.NotNil(t, vg)
 	// startTime and endTime should be aligned to sample duration
-	require.Equal(t, uint64(0), vg.startTime%uint64(videoTrack.sampleDur), "video startTime not aligned")
-	require.Equal(t, uint64(0), vg.endTime%uint64(videoTrack.sampleDur), "video endTime not aligned")
+	require.Equal(t, uint64(0), vg.startTime%uint64(videoTrack.SampleDur), "video startTime not aligned")
+	require.Equal(t, uint64(0), vg.endTime%uint64(videoTrack.SampleDur), "video endTime not aligned")
 	// startNr and endNr should be integers
 	require.True(t, vg.startNr <= vg.endNr, "video startNr > endNr")
 	// The number of objects should match endNr-startNr
@@ -49,8 +49,8 @@ func TestGenMoQGroup_VideoAudio(t *testing.T) {
 	// Audio
 	ag := GenMoQGroup(audioTrack, groupNr, 1, groupDurMS)
 	require.NotNil(t, ag)
-	require.Equal(t, uint64(0), ag.startTime%uint64(audioTrack.sampleDur), "audio startTime not aligned")
-	require.Equal(t, uint64(0), ag.endTime%uint64(audioTrack.sampleDur), "audio endTime not aligned")
+	require.Equal(t, uint64(0), ag.startTime%uint64(audioTrack.SampleDur), "audio startTime not aligned")
+	require.Equal(t, uint64(0), ag.endTime%uint64(audioTrack.SampleDur), "audio endTime not aligned")
 	require.True(t, ag.startNr <= ag.endNr, "audio startNr > endNr")
 	require.Equal(t, int(ag.endNr-ag.startNr), len(ag.MoQObjects), "audio MoQObjects count")
 }
@@ -62,15 +62,15 @@ func TestGenMoQStreams(t *testing.T) {
 	asset, err := LoadAsset("../content", 1, 1) // adjust path if needed
 	require.NoError(t, err)
 	require.NotNil(t, asset)
-	for _, group := range asset.groups {
-		for i := range group.tracks {
-			ct := &group.tracks[i]
-			ofh, err := os.Create(fmt.Sprintf("%s.mp4", ct.name))
+	for _, group := range asset.Groups {
+		for i := range group.Tracks {
+			ct := &group.Tracks[i]
+			ofh, err := os.Create(fmt.Sprintf("%s.mp4", ct.Name))
 			if err != nil {
 				t.Fatalf("failed to create output file: %v", err)
 			}
 			defer ofh.Close()
-			init, err := ct.specData.GenCMAFInitData()
+			init, err := ct.SpecData.GenCMAFInitData()
 			if err != nil {
 				t.Fatalf("failed to generate init data: %v", err)
 			}
@@ -106,7 +106,7 @@ func TestWriteMoQGroupLive(t *testing.T) {
 		t.Fatalf("failed to create output file: %v", err)
 	}
 	defer ofh.Close()
-	init, err := ct.specData.GenCMAFInitData()
+	init, err := ct.SpecData.GenCMAFInitData()
 	if err != nil {
 		t.Fatalf("failed to generate init data: %v", err)
 	}


### PR DESCRIPTION
One can now combine more than one media frame into a MoQ object/CMAF chunk.
With the default value of 2, the bitrate overhead for audio is lowered from 40kbps to 20kbps and the object rate becomes roughly the same as video.

Also improved the group and object logging by adding the track name