### PR TITLE
feat: add certificate fingerprint server to mlmpub

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Configuration options for `audiobatch` and `videobatch` to control how many frames should be sent in every MoQ object/CMAF chunk
 - systemd service script and helpers for mlmpub
+- fingerprint endpoint of mlmpub to be used with WebTransport browser clients like [warp-player[wp]
 
 ## [0.2.0] - 2025-04-28
 
@@ -53,3 +54,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [catalog]: https://moq-wg.github.io/warp-streaming-format/draft-ietf-moq-warp.html
 [moqt-d11]: https://datatracker.ietf.org/doc/draft-ietf-moq-transport/11/
 [moqtransport]: https://github.com/mengelbart/moqtransport
+[wp]: https://github.com/Eyevinn/warp-player

--- a/README.md
+++ b/README.md
@@ -107,13 +107,29 @@ video and audio.
 
 For that to work, one typically need better certificates.
 
-One way to do that is with mkcert
+#### Using mkcert (recommended for development)
+
+One way to do that is with mkcert:
 
 ```sh
 > mkcert -key-file key.pem -cert-file cert.pem localhost 127.0.0.1 ::1
 > mkcert -install
-> go run . -cert cert.pem -key key.pem -addr locahost:4443
+> go run . -cert cert.pem -key key.pem -addr localhost:4443
 ```
+
+#### Using certificate fingerprint
+
+Alternatively, you can use the certificate fingerprint feature for self-signed certificates without installing them in the browser:
+
+```sh
+> go run . -cert cert.pem -key key.pem -addr 0.0.0.0:4443 -fingerprintport 8081
+```
+
+This will:
+- Start the MoQ server on port 4443 (listening on all interfaces)
+- Start an HTTP server on port 8081 that serves the certificate's SHA-256 fingerprint
+
+The warp-player can then connect using the fingerprint URL to authenticate the self-signed certificate. Use `-fingerprintport 0` to disable the fingerprint server.
 
 
 ## Development

--- a/cmd/mlmpub/main.go
+++ b/cmd/mlmpub/main.go
@@ -43,6 +43,7 @@ type options struct {
 	qlogfile         string
 	audioSampleBatch int
 	videoSampleBatch int
+	fingerprintPort  int
 	version          bool
 }
 
@@ -61,6 +62,7 @@ func parseOptions(fs *flag.FlagSet, args []string) (*options, error) {
 	fs.StringVar(&opts.qlogfile, "qlog", defaultQlogFileName, "qlog file to write to. Use '-' for stderr")
 	fs.IntVar(&opts.audioSampleBatch, "audiobatch", 2, "Nr audio samples per MoQ object/CMAF chunk")
 	fs.IntVar(&opts.videoSampleBatch, "videobatch", 1, "Nr video samples per MoQ object/CMAF chunk")
+	fs.IntVar(&opts.fingerprintPort, "fingerprintport", 8081, "Port for HTTP fingerprint server (0 to disable)")
 	fs.BoolVar(&opts.version, "version", false, fmt.Sprintf("Get %s version", appName))
 	err := fs.Parse(args[1:])
 	return &opts, err
@@ -127,12 +129,13 @@ func runServer(opts *options) error {
 		defer fh.Close()
 	}
 	h := &moqHandler{
-		addr:      opts.addr,
-		tlsConfig: tlsConfig,
-		namespace: []string{internal.Namespace},
-		asset:     asset,
-		catalog:   catalog,
-		logfh:     logfh,
+		addr:            opts.addr,
+		tlsConfig:       tlsConfig,
+		namespace:       []string{internal.Namespace},
+		asset:           asset,
+		catalog:         catalog,
+		logfh:           logfh,
+		fingerprintPort: opts.fingerprintPort,
 	}
 
 	return h.runServer(context.TODO())


### PR DESCRIPTION
Add HTTP server that serves the certificate's SHA-256 fingerprint to enable WebTransport connections with self-signed certificates without browser trust.

- Add -fingerprintport flag to configure the HTTP server port (default: 8081)
- Server automatically extracts and serves the certificate fingerprint
- Add CORS headers for cross-origin access from web applications
- Update README with fingerprint usage instructions
- Update CHANGELOG with new feature details

This allows warp-player and other WebTransport clients to connect using the fingerprint for authentication, making development easier.