### PR TITLE
feat: improve certificate fingerprint support for WebTransport

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Configuration options for `audiobatch` and `videobatch` to control how many frames should be sent in every MoQ object/CMAF chunk
 - systemd service script and helpers for mlmpub
 - fingerprint endpoint of mlmpub to be used with WebTransport browser clients like [warp-player[wp]
+- Certificate validation and auto-generation for WebTransport-compatible certificates (ECDSA, 14-day validity)
 
 ## [0.2.0] - 2025-04-28
 

--- a/README.md
+++ b/README.md
@@ -114,22 +114,42 @@ One way to do that is with mkcert:
 ```sh
 > mkcert -key-file key.pem -cert-file cert.pem localhost 127.0.0.1 ::1
 > mkcert -install
-> go run . -cert cert.pem -key key.pem -addr localhost:4443
+> go run . -cert cert.pem -key key.pem
 ```
 
 #### Using certificate fingerprint
 
-Alternatively, you can use the certificate fingerprint feature for self-signed certificates without installing them in the browser:
+For browsers that support WebTransport certificate fingerprints (e.g., Chrome), you can use self-signed certificates without installing them:
 
+**Run mlmpub with fingerprint support**:
 ```sh
-> go run . -cert cert.pem -key key.pem -addr 0.0.0.0:4443 -fingerprintport 8081
+> go run . -fingerprintport 8081
+```
+
+This will automatically generate a WebTransport-compatible certificate with:
+- ECDSA algorithm (not RSA)
+- 14-day validity (WebTransport maximum)
+- Self-signed
+
+Alternatively, you can use your own certificate (e.g., generated with the included `generate-webtransport-cert.sh` script):
+```sh
+cd cmd/mlmpub
+./generate-webtransport-cert.sh
+go run . -cert cert-fp.pem -key key-fp.pem -fingerprintport 8081
 ```
 
 This will:
-- Start the MoQ server on port 4443 (listening on all interfaces)
+- Start the MoQ server on port 4443 (default address is `0.0.0.0:4443`, listening on all interfaces)
 - Start an HTTP server on port 8081 that serves the certificate's SHA-256 fingerprint
+- Validate that the certificate meets WebTransport requirements
 
-The warp-player can then connect using the fingerprint URL to authenticate the self-signed certificate. Use `-fingerprintport 0` to disable the fingerprint server.
+The warp-player (fingerprint branch) can then connect using:
+- Server URL: `https://localhost:4443/moq` or `https://127.0.0.1:4443/moq`
+- Fingerprint URL: `http://localhost:8081/fingerprint` or `http://127.0.0.1:8081/fingerprint`
+
+**Notes**: 
+- The fingerprint server is disabled by default (`-fingerprintport 0`). Only enable it when using certificates that meet WebTransport's strict requirements.
+- If no certificate files are provided, mlmpub will generate WebTransport-compatible certificates automatically.
 
 
 ## Development

--- a/cmd/mlmpub/generate-webtransport-cert.sh
+++ b/cmd/mlmpub/generate-webtransport-cert.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+# Generate WebTransport-compatible certificate with fingerprint
+# Requirements: ECDSA, ≤14 days validity, self-signed
+
+echo "Generating WebTransport-compatible certificate..."
+
+# Generate ECDSA private key
+openssl ecparam -genkey -name prime256v1 -out key-fp.pem
+
+# Generate self-signed certificate valid for 14 days
+openssl req -new -x509 -key key-fp.pem -out cert-fp.pem -days 14 \
+  -subj "/CN=localhost" \
+  -addext "subjectAltName=DNS:localhost,DNS:127.0.0.1,IP:127.0.0.1,IP:::1"
+
+echo "Certificate generated: cert-fp.pem"
+echo "Private key generated: key-fp.pem"
+echo ""
+
+# Verify the certificate
+echo "Certificate details:"
+openssl x509 -in cert-fp.pem -text -noout | grep -E "Signature Algorithm:|Not Before:|Not After:|Subject Alternative Name" -A1
+
+echo ""
+echo "Certificate fingerprint (SHA-256):"
+# Get the fingerprint
+openssl x509 -in cert-fp.pem -noout -fingerprint -sha256 | sed 's/://g' | cut -d'=' -f2 | tr '[:upper:]' '[:lower:]'

--- a/cmd/mlmpub/main.go
+++ b/cmd/mlmpub/main.go
@@ -2,10 +2,14 @@ package main
 
 import (
 	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
 	"crypto/rand"
-	"crypto/rsa"
+	"crypto/sha256"
 	"crypto/tls"
 	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/hex"
 	"encoding/pem"
 	"errors"
 	"flag"
@@ -13,7 +17,9 @@ import (
 	"io"
 	"log/slog"
 	"math/big"
+	"net"
 	"os"
+	"time"
 
 	"github.com/Eyevinn/moqlivemock/internal"
 )
@@ -55,14 +61,14 @@ func parseOptions(fs *flag.FlagSet, args []string) (*options, error) {
 	}
 
 	opts := options{}
-	fs.StringVar(&opts.certFile, "cert", "localhost.pem", "TLS certificate file (only used for server)")
-	fs.StringVar(&opts.keyFile, "key", "localhost-key.pem", "TLS key file (only used for server)")
-	fs.StringVar(&opts.addr, "addr", "localhost:8080", "listen or connect address")
+	fs.StringVar(&opts.certFile, "cert", "cert.pem", "TLS certificate file (only used for server)")
+	fs.StringVar(&opts.keyFile, "key", "key.pem", "TLS key file (only used for server)")
+	fs.StringVar(&opts.addr, "addr", "0.0.0.0:4443", "listen or connect address")
 	fs.StringVar(&opts.asset, "asset", "../../content", "Asset to serve")
 	fs.StringVar(&opts.qlogfile, "qlog", defaultQlogFileName, "qlog file to write to. Use '-' for stderr")
 	fs.IntVar(&opts.audioSampleBatch, "audiobatch", 2, "Nr audio samples per MoQ object/CMAF chunk")
 	fs.IntVar(&opts.videoSampleBatch, "videobatch", 1, "Nr video samples per MoQ object/CMAF chunk")
-	fs.IntVar(&opts.fingerprintPort, "fingerprintport", 8081, "Port for HTTP fingerprint server (0 to disable)")
+	fs.IntVar(&opts.fingerprintPort, "fingerprintport", 0, "Port for HTTP fingerprint server (0 to disable)")
 	fs.BoolVar(&opts.version, "version", false, fmt.Sprintf("Get %s version", appName))
 	err := fs.Parse(args[1:])
 	return &opts, err
@@ -153,23 +159,70 @@ func generateTLSConfigWithCertAndKey(certFile, keyFile string) (*tls.Config, err
 }
 
 // Setup a bare-bones TLS config for the server
+// Generates a certificate that meets WebTransport fingerprint requirements
 func generateTLSConfig() (*tls.Config, error) {
-	key, err := rsa.GenerateKey(rand.Reader, 1024)
+	// Generate ECDSA key (required for WebTransport fingerprints)
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 	if err != nil {
 		return nil, err
 	}
-	template := x509.Certificate{SerialNumber: big.NewInt(1)}
+
+	// Create certificate template with WebTransport-compatible settings
+	template := x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject: pkix.Name{
+			CommonName: "localhost",
+		},
+		Issuer: pkix.Name{
+			CommonName: "localhost", // Explicitly set issuer = subject for self-signed
+		},
+		NotBefore:             time.Now(),
+		NotAfter:              time.Now().Add(14 * 24 * time.Hour), // 14 days max for WebTransport
+		KeyUsage:              x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		BasicConstraintsValid: true,
+		IsCA:                  true, // Self-signed CA
+		IPAddresses:           []net.IP{net.IPv4(127, 0, 0, 1), net.IPv6loopback},
+		DNSNames:              []string{"localhost", "127.0.0.1"}, // Include IP as DNS too
+	}
+
+	// Create self-signed certificate
 	certDER, err := x509.CreateCertificate(rand.Reader, &template, &template, &key.PublicKey, key)
 	if err != nil {
 		return nil, err
 	}
-	keyPEM := pem.EncodeToMemory(&pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(key)})
+
+	// Encode key and certificate to PEM
+	keyBytes, err := x509.MarshalECPrivateKey(key)
+	if err != nil {
+		return nil, err
+	}
+	keyPEM := pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: keyBytes})
 	certPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: certDER})
 
 	tlsCert, err := tls.X509KeyPair(certPEM, keyPEM)
 	if err != nil {
 		return nil, err
 	}
+
+	// Parse the generated certificate to get fingerprint
+	parsedCert, err := x509.ParseCertificate(tlsCert.Certificate[0])
+	if err == nil {
+		fingerprint := sha256.Sum256(parsedCert.Raw)
+		slog.Info("Generated WebTransport-compatible certificate",
+			"algorithm", "ECDSA",
+			"validity_days", 14,
+			"self_signed", true,
+			"fingerprint", hex.EncodeToString(fingerprint[:]),
+			"subject", parsedCert.Subject.String(),
+			"issuer", parsedCert.Issuer.String())
+	} else {
+		slog.Info("Generated WebTransport-compatible certificate",
+			"algorithm", "ECDSA",
+			"validity_days", 14,
+			"self_signed", true)
+	}
+
 	return &tls.Config{
 		Certificates: []tls.Certificate{tlsCert},
 		NextProtos:   []string{"moq-00", "h3"},


### PR DESCRIPTION
## Summary
- Added certificate validation to warn when certificates don't meet WebTransport fingerprint requirements
- Added automatic generation of WebTransport-compatible certificates (ECDSA, 14-day validity)
- Added optional HTTP fingerprint server for browser clients (disabled by default)
- Created certificate generation script for manual certificate creation

## Changes
- **Certificate Validation**: mlmpub now validates certificates and warns if they don't meet WebTransport requirements:
  - Must be self-signed
  - Must use ECDSA algorithm (not RSA)
  - Must have validity ≤ 14 days
- **Auto-generation**: When no certificates are provided, mlmpub generates WebTransport-compatible certificates automatically
- **Fingerprint Server**: Added `-fingerprintPort` flag to optionally run HTTP fingerprint server with CORS support
- **Documentation**: Updated CHANGELOG.md with new features
- **Script**: Added `generate-webtransport-cert.sh` for manual certificate generation

## Test plan
- [x] Tested certificate validation with various certificate types
- [x] Verified auto-generated certificates work with WebTransport
- [x] Tested fingerprint server with warp-player
- [x] Confirmed CORS headers work for cross-origin requests
- [x] Verified backward compatibility (fingerprint server disabled by default)

## Related
- Complements Eyevinn/warp-player#20 for complete fingerprint support

🤖 Generated with [Claude Code](https://claude.ai/code)