### PR TITLE
V0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Nothing yet
+
+## [0.3.0] - 2025-05-25
+
 ### Changed
 
 - Catalog is now based on Github [catalog] of Feb. 28 2025
@@ -48,7 +52,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - initial version of the repo
 
-[Unreleased]: https://github.com/Eyevinn/mp2ts-tools/releases/tag/v0.2.0...HEAD
+[Unreleased]: https://github.com/Eyevinn/mp2ts-tools/releases/tag/v0.3.0...HEAD
+[0.3.0]: https://github.com/Eyevinn/mp2ts-tools/releases/tag/v0.2.0...v0.2.0
 [0.2.0]: https://github.com/Eyevinn/mp2ts-tools/releases/tag/v0.1.0...v0.2.0
 [0.1.0]: https://github.com/Eyevinn/mp2ts-tools/releases/tag/v0.1.0
 

--- a/internal/version.go
+++ b/internal/version.go
@@ -8,8 +8,8 @@ import (
 )
 
 var (
-	commitVersion string = "0.2.0"      // Should be updated during build
-	commitDate    string = "1745819115" // commitDate in Epoch seconds (can be filled/updated in during build)
+	commitVersion string = "0.3.0"      // Should be updated during build
+	commitDate    string = "1748208638" // commitDate in Epoch seconds (can be filled/updated in during build)
 )
 
 // GetVersion - get version, commitHash and  commitDate depending on what is inserted


### PR DESCRIPTION
### Changed

- Catalog is now based on Github [catalog] of Feb. 28 2025
- Now follows [draft-11 of MoQ Transport][moqt-d11] via [moqtransport][moqtransport] update
- mlmsub now autodetects webtransport from `-addr` argument starting with https://

### Added

- Configuration options for `audiobatch` and `videobatch` to control how many frames should be sent in every MoQ object/CMAF chunk
- systemd service script and helpers for mlmpub
- fingerprint endpoint of mlmpub to be used with WebTransport browser clients like [warp-player[wp]
- Certificate validation and auto-generation for WebTransport-compatible certificates (ECDSA, 14-day validity)