### PR TITLE
ci: Align workflows, Makefile, and codespell with hi264

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,0 +1,28 @@
+name: Coverage
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  coverage:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: "1.25"
+
+      - name: Generate coverage
+        run: go test -coverpkg=./... -coverprofile=profile.cov ./...
+
+      - name: Upload coverage
+        uses: shogo82148/actions-goveralls@v1
+        with:
+          path-to-profile: profile.cov
+          github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -5,32 +5,28 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
-  # Allows you to run this workflow manually from the Actions tab
-  workflow_dispatch:
 
 jobs:
   build:
+    runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        platform: [macos-latest, ubuntu-latest, windows-latest]
-        go-version: ["1.23"]
-    runs-on: ${{ matrix.platform }}
+        os: [ubuntu-latest, macos-latest]
+        go-version: ["1.23", "1.25"]
+
     steps:
-      - name: Setup Go
+      - uses: actions/checkout@v4
+
+      - name: Set up Go
         uses: actions/setup-go@v5
         with:
           go-version: ${{ matrix.go-version }}
 
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Download Go dependencies
+      - name: Download dependencies
         run: go mod download
-        env:
-          GOPROXY: "https://proxy.golang.org"
 
       - name: Build
-        run: go build -v ./...
+        run: go build ./...
 
       - name: Test
-        run: go test -v ./...
+        run: go test ./...

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -1,24 +1,31 @@
 name: golangci-lint
+
 on:
   push:
+    branches: [main]
     tags:
       - v*
-    branches:
-      - main
   pull_request:
+
+permissions:
+  contents: read
+
 jobs:
   golangci:
     name: lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: "1.25"
 
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v7
         with:
           only-new-issues: true
 
-      - name: go-report-card
+      - name: Go Report Card
         uses: creekorful/goreportcard-action@v1.0
-        with:
-          only-new-issues: true

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ out/
 
 # Output of the make coverage target
 coverage.*
+!.github/workflows/coverage.yml
 
 # Output from video generation
 utils/videogen/output*

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # moqlivemock
 
 ![Test](https://github.com/Eyevinn/moqlivemock/workflows/Go/badge.svg)
-[![Coverage Status](https://coveralls.io/repos/github/Eyevinn/moqlivemock/badge.svg?branch=master)](https://coveralls.io/github/Eyevinn/moqlivemock?branch=master)
+[![Coverage Status](https://coveralls.io/repos/github/Eyevinn/moqlivemock/badge.svg?branch=main)](https://coveralls.io/github/Eyevinn/moqlivemock?branch=main)
 [![GoDoc](https://godoc.org/github.com/Eyevinn/moqlivemock?status.svg)](http://godoc.org/github.com/Eyevinn/moqlivemock)
 [![Go Report Card](https://goreportcard.com/badge/github.com/Eyevinn/moqlivemock)](https://goreportcard.com/report/github.com/Eyevinn/moqlivemock)
 [![license](https://img.shields.io/github/license/Eyevinn/moqlivemock.svg)](https://github.com/Eyevinn/moqlivemock/blob/master/LICENSE)
@@ -19,6 +19,19 @@ How many frames are combined is configurable via the `-audiobatch` and `-videoba
 
 Subtitles are generated on the fly and delivered as 1s groups with 1 object per group.
 That object is published at the start of each second in order to not increase the latency.
+
+### Wall-clock alignment
+
+All streams are aligned to UTC wall-clock time at two levels:
+
+1. **The 10-second asset loop** is aligned to UTC modulo 10 seconds.
+   The first sample of the clip maps to epoch times where `seconds % 10 == 0`.
+   This means every subscriber joining at the same wall-clock time receives
+   the same content, regardless of when the publisher was started.
+2. **MoQ groups** are aligned to full UTC seconds. Each group number is
+   `Unix_epoch_ms / 1000`, so group boundaries fall on exact second boundaries.
+   Audio is typically not compatible with integral seconds, so minimal
+   displacement is applied without accumulated drift over time.
 
 LOC is currently not supported, but one possible scenario is to send LOC over the wire and
 then reassamble CMAF on the receiving side again.
@@ -60,7 +73,7 @@ You can configure multiple languages:
 ./mlmpub -subswvtt "" -subsstpp ""
 ```
 
-Subitle track names follow the pattern `subs_wvtt_{lang}` and `subs_stpp_{lang}`.
+Subtitle track names follow the pattern `subs_wvtt_{lang}` and `subs_stpp_{lang}`.
 
 To receive subtitles with the mlmsub subscriber:
 
@@ -116,7 +129,7 @@ You can also specify options for the publisher:
 ```
 
 In another shell, start the subscriber and choose if the video, the audio,
-or a muxed combination should be output, e.g. 
+or a muxed combination should be output, e.g.
 
 ```shell
 cd cmd/mlmsub
@@ -188,7 +201,7 @@ The warp-player can then connect using:
 - Server URL: `https://localhost:4443/moq` or `https://127.0.0.1:4443/moq`
 - Fingerprint URL: `http://localhost:8081/fingerprint` or `http://127.0.0.1:8081/fingerprint`
 
-**Notes**: 
+**Notes**:
 - The fingerprint server is disabled by default (`-fingerprintport 0`).
   Only enable it when using certificates that meet WebTransport's strict requirements.
 - If no certificate files are provided, mlmpub will generate WebTransport-compatible certificates automatically.

--- a/cmd/mlmpub/main.go
+++ b/cmd/mlmpub/main.go
@@ -33,7 +33,7 @@ var usg = `%s acts as a MoQ server and publisher using MSF/CMSF to send
 mocked live video and audio tracks, synchronized with wall-clock time.
 It is intended to be a test-bed for MoQ and MSF/CMSF.
 
-The qlog logs are currently massive, and written to 
+The qlog logs are currently massive, and written to
 
 Usage of %s:
 `

--- a/cmd/mlmsub/main.go
+++ b/cmd/mlmsub/main.go
@@ -28,14 +28,14 @@ const (
 )
 
 var usg = `%s acts as a MoQ client and subscriber for MSF/CMSF.
-Should first subscribe to catalog. When receiving a catalog, it should choose one video and 
+Should first subscribe to catalog. When receiving a catalog, it should choose one video and
 one audio track and subscribe to these.
 
 When receiving the media, it can write out to concatenated CMAF tracks but also multiplex
 the tracks into a single CMAF file. By muxing the tracks and choosing muxout to "-" (stdout),
 it is possible to pipe the stream to ffplay get synchronized playback of video and audio.
 
-mlmsub -muxout - | ffplay - 
+mlmsub -muxout - | ffplay -
 
 Usage of %s:
 `

--- a/internal/batch_test.go
+++ b/internal/batch_test.go
@@ -96,7 +96,7 @@ func TestInitContentTrackWithBatch(t *testing.T) {
 			fh, err := os.Open(tc.filePath)
 			require.NoError(t, err)
 			defer fh.Close()
-			
+
 			ct, err := InitContentTrack(fh, tc.desc, tc.audioSampleBatch, tc.videoSampleBatch)
 			require.NoError(t, err)
 			require.Equal(t, tc.expectedBatch, ct.SampleBatch, "SampleBatch")
@@ -138,10 +138,10 @@ func TestLoadAssetWithBatch(t *testing.T) {
 				for _, track := range group.Tracks {
 					switch track.ContentType {
 					case "audio":
-						require.Equal(t, tc.audioSampleBatch, track.SampleBatch, 
+						require.Equal(t, tc.audioSampleBatch, track.SampleBatch,
 							"Audio track %s should have batch size %d", track.Name, tc.audioSampleBatch)
 					case "video":
-						require.Equal(t, tc.videoSampleBatch, track.SampleBatch, 
+						require.Equal(t, tc.videoSampleBatch, track.SampleBatch,
 							"Video track %s should have batch size %d", track.Name, tc.videoSampleBatch)
 					}
 				}
@@ -175,9 +175,9 @@ func TestLoadAssetWithBatch(t *testing.T) {
 				// Calculate expected bitrate
 				frameRate := float64(contentTrack.TimeScale) / float64(contentTrack.SampleDur)
 				expectedBitrate := calcCmafBitrate(contentTrack.SampleBitrate, frameRate, contentTrack.SampleBatch)
-				
-				require.Equal(t, expectedBitrate, *track.Bitrate, 
-					"Track %s should have bitrate calculated with batch size %d", 
+
+				require.Equal(t, expectedBitrate, *track.Bitrate,
+					"Track %s should have bitrate calculated with batch size %d",
 					track.Name, contentTrack.SampleBatch)
 			}
 		})
@@ -219,26 +219,26 @@ func TestGenCMAFChunkWithBatch(t *testing.T) {
 				for _, track := range group.Tracks {
 					// Test with different batch sizes
 					batchSize := track.SampleBatch
-					
+
 					// Generate a chunk with the configured batch size
 					chunk, err := track.GenCMAFChunk(0, 0, uint64(batchSize))
 					require.NoError(t, err)
 					require.NotNil(t, chunk)
-					
+
 					// For video tracks with batch > 1, the chunk should be larger than a single sample chunk
 					if track.ContentType == "video" && batchSize > 1 {
 						// Generate a single sample chunk for comparison
 						singleChunk, err := track.GenCMAFChunk(0, 0, 1)
 						require.NoError(t, err)
-						
+
 						// The multi-sample chunk should be larger than the single sample chunk
 						// but not proportionally larger due to overhead sharing
-						require.Greater(t, len(chunk), len(singleChunk), 
+						require.Greater(t, len(chunk), len(singleChunk),
 							"Multi-sample chunk should be larger than single sample chunk")
-						
+
 						// The chunk should be smaller than batchSize * single sample chunks
 						// due to shared overhead
-						require.Less(t, len(chunk), batchSize*len(singleChunk), 
+						require.Less(t, len(chunk), batchSize*len(singleChunk),
 							"Multi-sample chunk should be smaller than batchSize * single sample chunks")
 					}
 				}

--- a/internal/media.go
+++ b/internal/media.go
@@ -383,11 +383,11 @@ func initOpusData(init *mp4.InitSegment) (*OpusData, error) {
 
 	// Create new dOps box for output
 	dopsOut := &mp4.DopsBox{
-		Version:            dops.Version,
-		OutputChannelCount: dops.OutputChannelCount,
-		PreSkip:            dops.PreSkip,
-		InputSampleRate:    dops.InputSampleRate,
-		OutputGain:         dops.OutputGain,
+		Version:              dops.Version,
+		OutputChannelCount:   dops.OutputChannelCount,
+		PreSkip:              dops.PreSkip,
+		InputSampleRate:      dops.InputSampleRate,
+		OutputGain:           dops.OutputGain,
 		ChannelMappingFamily: dops.ChannelMappingFamily,
 	}
 	opusOut := mp4.CreateAudioSampleEntryBox("Opus",

--- a/internal/moqgroup_test.go
+++ b/internal/moqgroup_test.go
@@ -58,7 +58,7 @@ func TestGenMoQGroup_VideoAudio(t *testing.T) {
 func TestGenMoQStreams(t *testing.T) {
 	// StartNr corresponding to 2025-04-21T17:07:48Z
 	startNr := uint64(1745255189)
-	endNr := startNr + 15                       // 15 MoQGroups à 1s per MoQGroup
+	endNr := startNr + 15                              // 15 MoQGroups à 1s per MoQGroup
 	asset, err := LoadAsset("../assets/test10s", 1, 1) // adjust path if needed
 	require.NoError(t, err)
 	require.NotNil(t, asset)

--- a/systemd/README.md
+++ b/systemd/README.md
@@ -136,7 +136,7 @@ If you're using Caddy server to manage Let's Encrypt certificates, you can autom
    ```bash
    sudo crontab -e
    ```
-   
+
    Add the following line:
    ```cron
    30 3 * * * DOMAIN=moqlivemock.demo.osaas.io /usr/local/bin/moqlivemock-update-certs

--- a/systemd/update-certs.sh
+++ b/systemd/update-certs.sh
@@ -18,7 +18,7 @@ log_message() {
 }
 
 # Check if running as root
-if [ "$EUID" -ne 0 ]; then 
+if [ "$EUID" -ne 0 ]; then
     echo "This script must be run as root or with sudo"
     exit 1
 fi
@@ -39,13 +39,13 @@ log_message "Copying certificates for ${DOMAIN}..."
 
 if cp "${CADDY_CERT_DIR}/${DOMAIN}.crt" "${MOQLIVE_CERT_DIR}/cert.pem" && \
    cp "${CADDY_CERT_DIR}/${DOMAIN}.key" "${MOQLIVE_CERT_DIR}/key.pem"; then
-    
+
     # Set proper ownership and permissions
     chown ${MOQLIVE_USER}:${MOQLIVE_GROUP} "${MOQLIVE_CERT_DIR}/cert.pem" "${MOQLIVE_CERT_DIR}/key.pem"
     chmod 640 "${MOQLIVE_CERT_DIR}/cert.pem" "${MOQLIVE_CERT_DIR}/key.pem"
-    
+
     log_message "SUCCESS: Certificates copied and permissions set"
-    
+
     # Restart moqlivemock service if it's running
     if systemctl is-active --quiet moqlivemock; then
         log_message "Restarting moqlivemock service..."


### PR DESCRIPTION
## Summary                                                                                                                                              
                                                                                                                                                       
  - Fix Coveralls badge URL to use main branch instead of master                                                                                       
  - Align GitHub workflows with hi264: add Go 1.25 to test matrix, drop Windows, update actions, add coverage workflow
  - Align Makefile with hi264: extract LDFLAGS, add pre-commit, codespell targets, exclude references/ from codespell                                  
  - Add wall-clock alignment documentation to README
  - Fix typo and trailing whitespace

## Tests done

  - Verify CI workflows pass on GitHub Actions
  - Verify Coveralls badge renders correctly
  - Run make codespell locally to confirm no false positives