### PR TITLE
Disable dependabot, add govulncheck and latest-deps workflows

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,4 @@
+# Dependabot disabled in favor of govulncheck and latest-deps workflows.
+# See https://words.filippo.io/dependabot/
+version: 2
+updates: []

--- a/.github/workflows/govulncheck.yml
+++ b/.github/workflows/govulncheck.yml
@@ -1,0 +1,26 @@
+name: govulncheck
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: '37 8 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  govulncheck:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          persist-credentials: false
+      - uses: actions/setup-go@v6
+        with:
+          go-version: stable
+      - run: |
+          go run golang.org/x/vuln/cmd/govulncheck@latest ./...

--- a/.github/workflows/latest-deps.yml
+++ b/.github/workflows/latest-deps.yml
@@ -1,0 +1,24 @@
+name: Test with latest deps
+
+on:
+  schedule:
+    - cron: '37 8 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          persist-credentials: false
+      - uses: actions/setup-go@v6
+        with:
+          go-version: stable
+      - name: Update to latest dependencies
+        run: go get -u -t ./...
+      - name: Test
+        run: go test -v ./...


### PR DESCRIPTION
## Summary
- Disable dependabot version updates via `.github/dependabot.yml`
- Add `govulncheck` workflow: runs symbol-level vulnerability scanning on push, PR, and daily
- Add `latest-deps` workflow: daily test against latest dependencies

Replaces dependabot with the approach described in https://words.filippo.io/dependabot/ — matching the setup in Eyevinn/moqtransport.

Stale dependabot PRs #52, #31, #29 have been closed.