### PR TITLE
fix: add WebTransport setting codepoints for Safari 26.4+

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `build-linux` Makefile target for cross-compiling mlmpub to linux/amd64
 - CENC encryption support (`cenc` and `cbcs` schemes) for video and audio tracks
 - ClearKey DRM with key/IV via CLI flags (`-kid`, `-cenckey`, `-iv`, `-scheme`)
 - Commercial DRM support via CPIX config file (`-drmpath`), including Widevine and FairPlay
 - DRM information included in the MSF/CMSF catalog
+
+### Fixed
+
+- Safari 26.4 WebTransport support by adding newer SETTINGS codepoints
+  ([warp-player#88](https://github.com/Eyevinn/warp-player/issues/88))
 
 ### Changed
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all build test coverage check check-licenses pre-commit pre-commit-install codespell clean install update
+.PHONY: all build build-linux test coverage check check-licenses pre-commit pre-commit-install codespell clean install update
 
 LDFLAGS = -X github.com/Eyevinn/moqlivemock/internal.commitVersion=$$(git describe --tags HEAD 2>/dev/null || echo dev-$$(git rev-parse --short HEAD)) \
           -X github.com/Eyevinn/moqlivemock/internal.commitDate=$$(git log -1 --format=%ct)
@@ -10,6 +10,9 @@ build: mlmpub mlmsub
 
 mlmpub mlmsub:
 	go build -ldflags "$(LDFLAGS)" -o out/$@ ./cmd/$@
+
+build-linux:
+	GOOS=linux GOARCH=amd64 go build -ldflags "$(LDFLAGS)" -o out/mlmpub-linux ./cmd/mlmpub
 
 test:
 	go test ./...

--- a/cmd/mlmpub/handler.go
+++ b/cmd/mlmpub/handler.go
@@ -61,6 +61,12 @@ func (h *moqHandler) runServer(ctx context.Context) error {
 		},
 	}
 	webtransport.ConfigureHTTP3Server(h3Server)
+	// Add newer WebTransport setting codepoints for Safari 26.4+ compatibility.
+	// webtransport-go only sends the old draft-02 setting (0x2b603742).
+	// Safari requires the draft-13/14 or draft-15 codepoint to recognize WebTransport support.
+	// See https://github.com/Eyevinn/warp-player/issues/88
+	h3Server.AdditionalSettings[0x14e9cd29] = 1 // SETTINGS_WT_MAX_SESSIONS (draft-13/14)
+	h3Server.AdditionalSettings[0x2c7cf000] = 1 // SETTINGS_WT_ENABLED (draft-15)
 	wt := webtransport.Server{
 		H3: h3Server,
 		CheckOrigin: func(r *http.Request) bool {


### PR DESCRIPTION
Safari 26.4 implements a newer WebTransport draft that requires SETTINGS_WT_MAX_SESSIONS (draft-13/14) or SETTINGS_WT_ENABLED (draft-15) to be present in the server SETTINGS frame. The webtransport-go library only sends the old draft-02 setting (0x2b603742) which Chrome recognizes but Safari does not.

Fixes https://github.com/Eyevinn/warp-player/issues/88
