### PR TITLE
fix: use avc1/hvc1 instead of avc3/hev1 for FairPlay streaming

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -6,20 +6,23 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   coverage:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
-          go-version: "1.25"
+          go-version: stable
 
       - name: Generate coverage
-        run: go test -coverpkg=./... -coverprofile=profile.cov ./...
+        run: go test -race -coverpkg=./... -coverprofile=profile.cov ./...
 
       - name: Upload coverage
         uses: shogo82148/actions-goveralls@v1

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -6,27 +6,29 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
-        go-version: ["1.23", "1.25"]
+        go-version:
+          - stable
+          - oldstable
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version: ${{ matrix.go-version }}
-
-      - name: Download dependencies
-        run: go mod download
 
       - name: Build
         run: go build ./...
 
       - name: Test
-        run: go test ./...
+        run: go test -race ./...

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -15,12 +15,12 @@ jobs:
     name: lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
-          go-version: "1.25"
+          go-version: stable
 
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v7

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Switched video sample descriptors from `avc3`/`hev1` to `avc1`/`hvc1` to support
+  FairPlay streaming in Safari 26.4+. With `avc1`/`hvc1`, parameter sets (SPS/PPS
+  for AVC, VPS/SPS/PPS for HEVC) are stored in the init segment rather than
+  inlined in each sample
+
+### Changed
+
 - CI: added coverage workflow, updated Go to 1.25, aligned workflows with hi264
 
 ## [0.5.0] - 2026-01-27

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,6 +64,13 @@ Configuration via mlmpub flags:
 
 Track naming: `subs_wvtt_{lang}`, `subs_stpp_{lang}`
 
+### Video Codecs
+
+Video tracks use `avc1` (H.264) and `hvc1` (HEVC) sample descriptors. These store
+parameter sets (SPS/PPS for AVC, VPS/SPS/PPS for HEVC) in the init segment rather
+than inlining them in each sample. This is required for FairPlay DRM compatibility
+in Safari 26.4+.
+
 ## Testing
 
 The `internal/` package contains unit tests. Run with:

--- a/README.md
+++ b/README.md
@@ -13,6 +13,10 @@ audio tracks, and dynamically-generated subtitle tracks (WVTT and STPP),
 as well as a client that can receive these streams and even multiplex
 video and audio for playback with ffplay like `mlmsub -muxout - | ffplay -`.
 
+Video tracks use `avc1` (H.264) and `hvc1` (HEVC) sample descriptors with
+parameter sets stored in the init segment, which is required for FairPlay
+DRM support in Safari 26.4+.
+
 The input media is 10s of video and audio which is then disassembled
 into frames. One or more frames are then combined into a MoQ object as a CMAF chunk.
 How many frames are combined is configurable via the `-audiobatch` and `-videobatch` options.

--- a/README.md
+++ b/README.md
@@ -213,7 +213,7 @@ The warp-player can then connect using:
 ### Using DRM
 moqlivemock supports the use of DRM. Supported DRM systems are Widevine, PlayReady, FairPlay (untested) and ClearKey. To use ClearKey you need to add the `-kid`, `-iv`, and `-cenckey` flags with relevant values to the publisher. If no cenc key is provided the key-id will be used as the cenc key. The ClearKey license server is hosted on the fingerprint server on the path `/clearkey` so you also need to enable the fingerprint server with the  `-fingerprintport` flag.
 
-To use any of the other DRM systems you need to add a CPIX file and a config JSON file (preferably in the gitignored directory `assets/drm/`) and add the flag `-drmpath` which points to the config JSON file. The config JSON file needs to be of the same format as the example file `assets/testdrm/drm_config_test.json`. 
+To use any of the other DRM systems you need to add a CPIX file and a config JSON file (preferably in the gitignored directory `assets/drm/`) and add the flag `-drmpath` which points to the config JSON file. The config JSON file needs to be of the same format as the example file `assets/testdrm/drm_config_test.json`.
 
 Example ClearKey publisher:
 ```sh

--- a/cmd/mlmsub/handler.go
+++ b/cmd/mlmsub/handler.go
@@ -13,8 +13,8 @@ import (
 	"strings"
 
 	"github.com/Eyevinn/moqlivemock/internal"
-	"github.com/Eyevinn/mp4ff/mp4"
 	"github.com/Eyevinn/moqtransport"
+	"github.com/Eyevinn/mp4ff/mp4"
 	"github.com/mengelbart/qlog"
 	"github.com/mengelbart/qlog/moqt"
 )

--- a/internal/asset.go
+++ b/internal/asset.go
@@ -15,7 +15,7 @@ import (
 
 const (
 	trackID           = 1
-	cmafOverheadBytes = 112                                    // moof + mdat header size for one sample
+	cmafOverheadBytes = 112 // moof + mdat header size for one sample
 )
 
 type ContentTrack struct {

--- a/internal/catalog_test.go
+++ b/internal/catalog_test.go
@@ -12,7 +12,7 @@ import (
 func TestCatalogGetTrackByName(t *testing.T) {
 	cat := &Catalog{
 		Tracks: []Track{
-			{Name: "video_400kbps_avc", Codec: "avc3"},
+			{Name: "video_400kbps_avc", Codec: "avc1"},
 			{Name: "audio_128kbps_aac", Codec: "mp4a"},
 		},
 	}
@@ -20,7 +20,7 @@ func TestCatalogGetTrackByName(t *testing.T) {
 	t.Run("found", func(t *testing.T) {
 		track := cat.GetTrackByName("video_400kbps_avc")
 		require.NotNil(t, track)
-		assert.Equal(t, "avc3", track.Codec)
+		assert.Equal(t, "avc1", track.Codec)
 	})
 
 	t.Run("not found", func(t *testing.T) {

--- a/internal/drm.go
+++ b/internal/drm.go
@@ -12,7 +12,7 @@ import (
 	"github.com/Eyevinn/mp4ff/mp4"
 )
 
-const CommonSystemID    = "1077efec-c0b2-4d02-ace3-3c1e52e2fb4b" //https://www.w3.org/TR/eme-initdata-cenc/#clear-key
+const CommonSystemID = "1077efec-c0b2-4d02-ace3-3c1e52e2fb4b" //https://www.w3.org/TR/eme-initdata-cenc/#clear-key
 
 var drmSystemIDs = map[string]string{
 	"widevine":  "edef8ba9-79d6-4ace-a3c8-27dcd51d21ed",

--- a/internal/media.go
+++ b/internal/media.go
@@ -86,27 +86,12 @@ func initAVCData(init *mp4.InitSegment, samples []mp4.FullSample) (*AVCData, err
 	if len(ad.Spss) != 1 || len(ad.Ppss) != 1 {
 		return nil, fmt.Errorf("not exactly one SPS and PPS nalus found")
 	}
-	for i := range samples {
-		if avc.GetNaluType(samples[i].Data[4]) == avc.NALU_IDR {
-			// Insert SPS and PPS
-			totSize := 4 + len(ad.Spss[0]) + 4 + len(ad.Ppss[0]) + len(samples[i].Data)
-			newData := make([]byte, 0, totSize)
-			binary.BigEndian.PutUint32(work, uint32(len(ad.Spss[0])))
-			newData = append(newData, work...)
-			newData = append(newData, ad.Spss[0]...)
-			binary.BigEndian.PutUint32(work, uint32(len(ad.Ppss[0])))
-			newData = append(newData, work...)
-			newData = append(newData, ad.Ppss[0]...)
-			newData = append(newData, samples[i].Data...)
-			samples[i].Data = newData
-		}
-	}
-
-	// Generate an output init segment with avc3 sample descriptor
+	// Generate an output init segment with avc1 sample descriptor
+	// With avc1, SPS/PPS are in the init segment, not in samples
 	ad.outInit = mp4.CreateEmptyInit()
 	timeScale := trak.Mdia.Mdhd.Timescale
 	ad.outInit.AddEmptyTrack(timeScale, "video", "und")
-	err := ad.outInit.Moov.Trak.SetAVCDescriptor("avc3", ad.Spss, ad.Ppss, true)
+	err := ad.outInit.Moov.Trak.SetAVCDescriptor("avc1", ad.Spss, ad.Ppss, true)
 	if err != nil {
 		return nil, fmt.Errorf("could not set AVC descriptor: %w", err)
 	}
@@ -114,7 +99,7 @@ func initAVCData(init *mp4.InitSegment, samples []mp4.FullSample) (*AVCData, err
 	if err != nil {
 		return nil, fmt.Errorf("could not decode SPS: %w", err)
 	}
-	ad.codec = avc.CodecString("avc3", sps)
+	ad.codec = avc.CodecString("avc1", sps)
 	ad.width = uint32(sps.Width)
 	ad.height = uint32(sps.Height)
 	return ad, nil
@@ -236,37 +221,14 @@ func initHEVCData(init *mp4.InitSegment, samples []mp4.FullSample) (*HEVCData, e
 		}
 	}
 
-	// Insert VPS/SPS/PPS before IRAP samples (NALU type 16–23)
-	for i := range samples {
-		if len(samples[i].Data) < 5 {
-			continue
-		}
-
-		if hevc.IsRAPSample(samples[i].Data) {
-			newData := make([]byte, 0)
-
-			for _, ps := range [][]byte{
-				hd.Vpss[0],
-				hd.Spss[0],
-				hd.Ppss[0],
-			} {
-				binary.BigEndian.PutUint32(work, uint32(len(ps)))
-				newData = append(newData, work...)
-				newData = append(newData, ps...)
-			}
-
-			newData = append(newData, samples[i].Data...)
-			samples[i].Data = newData
-		}
-	}
-
-	// Create CMAF-compliant init segment (hev1)
+	// Create CMAF-compliant init segment (hvc1)
+	// With hvc1, VPS/SPS/PPS are in the init segment, not in samples
 	hd.outInit = mp4.CreateEmptyInit()
 	timeScale := trak.Mdia.Mdhd.Timescale
 	hd.outInit.AddEmptyTrack(timeScale, "video", "und")
 
 	err := hd.outInit.Moov.Trak.SetHEVCDescriptor(
-		"hev1",
+		"hvc1",
 		hd.Vpss,
 		hd.Spss,
 		hd.Ppss,
@@ -283,7 +245,7 @@ func initHEVCData(init *mp4.InitSegment, samples []mp4.FullSample) (*HEVCData, e
 		return nil, fmt.Errorf("could not parse HEVC SPS: %w", err)
 	}
 
-	hd.codec = hevc.CodecString("hev1", sps)
+	hd.codec = hevc.CodecString("hvc1", sps)
 	hd.width = uint32(sps.PicWidthInLumaSamples)
 	hd.height = uint32(sps.PicHeightInLumaSamples)
 

--- a/internal/subtitle_test.go
+++ b/internal/subtitle_test.go
@@ -271,6 +271,7 @@ func TestGenSubtitleGroupWvtt(t *testing.T) {
 
 	if mg == nil {
 		t.Fatal("GenSubtitleGroup returned nil")
+		return
 	}
 
 	if len(mg.MoQObjects) != 1 {
@@ -317,6 +318,7 @@ func TestGenSubtitleGroupStpp(t *testing.T) {
 
 	if mg == nil {
 		t.Fatal("GenSubtitleGroup returned nil")
+		return
 	}
 
 	if len(mg.MoQObjects) != 1 {


### PR DESCRIPTION
Safari 26.4+ has WebTransport support. 
However, FairPlay does not support avc3 and hev1, so CMAF signaling is changed to avc1 and hvc1.
For future plain LOC transport, inband parameter sets using avc3 and hev1 are the way to go.