### PR TITLE
FETCH support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Use `role` instead of `mimeType` in catalog per CMSF/MSF spec
 - Refactored `cmd/mlmpub` and `cmd/mlmsub` into thin wrappers over `internal/pub` and `internal/sub`
 - Bumped Go version to 1.25
 - Publisher goroutines now use proper context propagation instead of `context.TODO()`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- FETCH support for catalog retrieval as an alternative to SUBSCRIBE (`-fetchcatalog` flag in mlmsub)
+- Configurable MoQ namespace via `-namespace` flag in mlmsub
+- Default port (443) when no port is specified in mlmsub address
 - Deterministic integration tests using in-memory transport and `synctest` (catalog, video, audio, subtitles, muxing)
 - `internal/pub` package with exported publisher handler logic
 - `internal/sub` package with exported subscriber handler, CMAF muxer, and DRM decryption logic

--- a/cmd/mlmsub/handler.go
+++ b/cmd/mlmsub/handler.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"crypto/tls"
 	"io"
+	"net"
+	"net/url"
 
 	"github.com/Eyevinn/moqlivemock/internal/sub"
 	"github.com/Eyevinn/moqtransport"
@@ -30,7 +32,27 @@ func runClientWithDial(
 	return h.RunWithConn(ctx, conn)
 }
 
+func ensurePort(addr, defaultPort string) string {
+	if _, _, err := net.SplitHostPort(addr); err != nil {
+		return net.JoinHostPort(addr, defaultPort)
+	}
+	return addr
+}
+
+func ensureURLPort(rawURL, defaultPort string) string {
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return rawURL
+	}
+	if u.Port() == "" {
+		u.Host = net.JoinHostPort(u.Hostname(), defaultPort)
+		return u.String()
+	}
+	return rawURL
+}
+
 func dialQUIC(ctx context.Context, addr string) (moqtransport.Connection, error) {
+	addr = ensurePort(addr, "443")
 	conn, err := quic.DialAddr(ctx, addr, &tls.Config{
 		InsecureSkipVerify: true,
 		NextProtos:         []string{"moq-00"},
@@ -54,7 +76,7 @@ func dialWebTransport(ctx context.Context, addr string) (moqtransport.Connection
 			EnableStreamResetPartialDelivery: true,
 		},
 	}
-	_, session, err := dialer.Dial(ctx, addr, nil)
+	_, session, err := dialer.Dial(ctx, ensureURLPort(addr, "443"), nil)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/mlmsub/main.go
+++ b/cmd/mlmsub/main.go
@@ -48,8 +48,10 @@ type options struct {
 	videoname  string
 	audioname  string
 	subsname   string
-	loglevel   string
-	version    bool
+	namespace    string
+	loglevel     string
+	fetchCatalog bool
+	version      bool
 }
 
 func parseOptions(fs *flag.FlagSet, args []string) (*options, error) {
@@ -73,7 +75,9 @@ func parseOptions(fs *flag.FlagSet, args []string) (*options, error) {
 	fs.StringVar(&opts.videoname, "videoname", "_avc", "Substring to match for video track (default AVC)")
 	fs.StringVar(&opts.audioname, "audioname", "_aac", "Substring to match for audio track (default AAC)")
 	fs.StringVar(&opts.subsname, "subsname", "", "Substring to match for selecting subtitle track (e.g. 'wvtt' or 'stpp')")
+	fs.StringVar(&opts.namespace, "namespace", internal.Namespace, "MoQ namespace to use")
 	fs.StringVar(&opts.loglevel, "loglevel", "info", "Log level: debug, info, warning, error")
+	fs.BoolVar(&opts.fetchCatalog, "fetchcatalog", false, "Use FETCH instead of SUBSCRIBE for catalog")
 
 	err := fs.Parse(args[1:])
 	return &opts, err
@@ -162,11 +166,12 @@ func runClient(ctx context.Context, opts *options) error {
 	useWebTransport := strings.HasPrefix(opts.addr, "https://")
 
 	h := &sub.Handler{
-		Namespace: []string{internal.Namespace},
+		Namespace: []string{opts.namespace},
 		Logfh:     logfh,
 		VideoName: opts.videoname,
 		AudioName: opts.audioname,
 		SubsName:  opts.subsname,
+		UseFetch:  opts.fetchCatalog,
 	}
 
 	outs := make(map[string]io.Writer)

--- a/go.mod
+++ b/go.mod
@@ -4,8 +4,8 @@ go 1.25.0
 
 require (
 	github.com/Dash-Industry-Forum/livesim2 v1.9.0
-	github.com/Eyevinn/moqtransport v0.5.1-0.20260329172749-9602b83aa701
-	github.com/Eyevinn/mp4ff v0.50.0
+	github.com/Eyevinn/moqtransport v0.6.0
+	github.com/Eyevinn/mp4ff v0.51.0
 	github.com/mengelbart/qlog v0.1.0
 	github.com/quic-go/quic-go v0.59.0
 	github.com/quic-go/webtransport-go v0.10.0

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.25.0
 
 require (
 	github.com/Dash-Industry-Forum/livesim2 v1.9.0
-	github.com/Eyevinn/moqtransport v0.6.0
+	github.com/Eyevinn/moqtransport v0.6.1
 	github.com/Eyevinn/mp4ff v0.51.0
 	github.com/mengelbart/qlog v0.1.0
 	github.com/quic-go/quic-go v0.59.0

--- a/go.sum
+++ b/go.sum
@@ -1,9 +1,13 @@
 github.com/Dash-Industry-Forum/livesim2 v1.9.0 h1:7NTv3f+9gszh9mX7p6ltaTJmLlR400S+R4pjWrzpLKQ=
 github.com/Dash-Industry-Forum/livesim2 v1.9.0/go.mod h1:AtqFe2WBX6TSoHlpHw7Hh/IWttqDRnoN+VnysQyssiA=
-github.com/Eyevinn/moqtransport v0.5.1-0.20260329172749-9602b83aa701 h1:Pj+Q404a+YPo+NZYefUD+N/lHCVktTri7cdyA7sdmMo=
-github.com/Eyevinn/moqtransport v0.5.1-0.20260329172749-9602b83aa701/go.mod h1:xzseX5ZPFBxV0o+wZFqJNJCg3K+6qD+jFy0Qsch1K2M=
+github.com/Eyevinn/moqtransport v0.5.1-0.20260407190120-39d65bd1cd09 h1:I70e7ekavhF9IlDrwcKNyJmd7hhnoOqFdAwChkbkzlc=
+github.com/Eyevinn/moqtransport v0.5.1-0.20260407190120-39d65bd1cd09/go.mod h1:xzseX5ZPFBxV0o+wZFqJNJCg3K+6qD+jFy0Qsch1K2M=
+github.com/Eyevinn/moqtransport v0.6.0 h1:E2Zarh5PSpFMksHR6af2ZOEUqp/kz55cxcNWPP1jjzI=
+github.com/Eyevinn/moqtransport v0.6.0/go.mod h1:xzseX5ZPFBxV0o+wZFqJNJCg3K+6qD+jFy0Qsch1K2M=
 github.com/Eyevinn/mp4ff v0.50.0 h1:vFlsvpQh5Jfz++cuaeTI90vbID5dAabebvvN/l9lom0=
 github.com/Eyevinn/mp4ff v0.50.0/go.mod h1:hJNUUqOBryLAzUW9wpCJyw2HaI+TCd2rUPhafoS5lgg=
+github.com/Eyevinn/mp4ff v0.51.0 h1:ZYdHFXEcB3kJkCeCHMHl/tbCm64FJsD2XOU0Sj+ME2M=
+github.com/Eyevinn/mp4ff v0.51.0/go.mod h1:hJNUUqOBryLAzUW9wpCJyw2HaI+TCd2rUPhafoS5lgg=
 github.com/beevik/etree v1.5.0 h1:iaQZFSDS+3kYZiGoc9uKeOkUY3nYMXOKLl6KIJxiJWs=
 github.com/beevik/etree v1.5.0/go.mod h1:gPNJNaBGVZ9AwsidazFZyygnd+0pAU38N4D+WemwKNs=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=

--- a/go.sum
+++ b/go.sum
@@ -1,11 +1,7 @@
 github.com/Dash-Industry-Forum/livesim2 v1.9.0 h1:7NTv3f+9gszh9mX7p6ltaTJmLlR400S+R4pjWrzpLKQ=
 github.com/Dash-Industry-Forum/livesim2 v1.9.0/go.mod h1:AtqFe2WBX6TSoHlpHw7Hh/IWttqDRnoN+VnysQyssiA=
-github.com/Eyevinn/moqtransport v0.5.1-0.20260407190120-39d65bd1cd09 h1:I70e7ekavhF9IlDrwcKNyJmd7hhnoOqFdAwChkbkzlc=
-github.com/Eyevinn/moqtransport v0.5.1-0.20260407190120-39d65bd1cd09/go.mod h1:xzseX5ZPFBxV0o+wZFqJNJCg3K+6qD+jFy0Qsch1K2M=
-github.com/Eyevinn/moqtransport v0.6.0 h1:E2Zarh5PSpFMksHR6af2ZOEUqp/kz55cxcNWPP1jjzI=
-github.com/Eyevinn/moqtransport v0.6.0/go.mod h1:xzseX5ZPFBxV0o+wZFqJNJCg3K+6qD+jFy0Qsch1K2M=
-github.com/Eyevinn/mp4ff v0.50.0 h1:vFlsvpQh5Jfz++cuaeTI90vbID5dAabebvvN/l9lom0=
-github.com/Eyevinn/mp4ff v0.50.0/go.mod h1:hJNUUqOBryLAzUW9wpCJyw2HaI+TCd2rUPhafoS5lgg=
+github.com/Eyevinn/moqtransport v0.6.1 h1:+Hwglg4D1xb5jgBSk118z7VeOTurj+LC0g6TSCeDj5o=
+github.com/Eyevinn/moqtransport v0.6.1/go.mod h1:xzseX5ZPFBxV0o+wZFqJNJCg3K+6qD+jFy0Qsch1K2M=
 github.com/Eyevinn/mp4ff v0.51.0 h1:ZYdHFXEcB3kJkCeCHMHl/tbCm64FJsD2XOU0Sj+ME2M=
 github.com/Eyevinn/mp4ff v0.51.0/go.mod h1:hJNUUqOBryLAzUW9wpCJyw2HaI+TCd2rUPhafoS5lgg=
 github.com/beevik/etree v1.5.0 h1:iaQZFSDS+3kYZiGoc9uKeOkUY3nYMXOKLl6KIJxiJWs=

--- a/internal/asset.go
+++ b/internal/asset.go
@@ -494,7 +494,6 @@ func (a *Asset) GenCMAFCatalogEntry(generatedAtMS int64) (*Catalog, error) {
 			switch ct.ContentType {
 			case "video":
 				track.Role = "video"
-				track.MimeType = "video/mp4"
 				track.Framerate = Ptr(frameRate)
 				switch sd := ct.SpecData.(type) {
 				case *AVCData:
@@ -514,7 +513,6 @@ func (a *Asset) GenCMAFCatalogEntry(generatedAtMS int64) (*Catalog, error) {
 				}
 			case "audio":
 				track.Role = "audio"
-				track.MimeType = "audio/mp4"
 				switch sd := ct.SpecData.(type) {
 				case *AACData:
 					if sd.sampleRate != 0 {
@@ -562,9 +560,6 @@ func (a *Asset) GenCMAFCatalogEntry(generatedAtMS int64) (*Catalog, error) {
 			initData = base64.StdEncoding.EncodeToString(data)
 		}
 
-		// Subtitles are encapsulated in MP4 (CMAF)
-		mimeType := "application/mp4"
-
 		// Determine altGroup based on format
 		altGroup := wvttAltGroup
 		if st.Format == SubtitleFormatSTPP {
@@ -581,7 +576,6 @@ func (a *Asset) GenCMAFCatalogEntry(generatedAtMS int64) (*Catalog, error) {
 			AltGroup:    &altGroup,
 			InitData:    initData,
 			Codec:       st.SpecData.Codec(),
-			MimeType:    mimeType,
 			Timescale:   Ptr(int(st.TimeScale)),
 			Language:    st.Language,
 		}

--- a/internal/catalog.go
+++ b/internal/catalog.go
@@ -147,10 +147,6 @@ type Track struct {
 	// Optional field at the track level.
 	Codec string `json:"codec,omitempty"`
 
-	// MimeType defines the mime type of the track.
-	// Optional field at the track level.
-	MimeType string `json:"mimeType,omitempty"`
-
 	// Framerate defines the video framerate of the track, expressed as frames per second.
 	// Optional field at the track level.
 	Framerate *float64 `json:"framerate,omitempty"`

--- a/internal/integration_test.go
+++ b/internal/integration_test.go
@@ -141,6 +141,35 @@ func TestCatalogExchange(t *testing.T) {
 	})
 }
 
+func TestFetchCatalog(t *testing.T) {
+	asset, catalog := loadTestAsset(t)
+
+	synctest.Test(t, func(t *testing.T) {
+		sConn, cConn := memConnPair()
+
+		ph := newPubHandler(asset, catalog)
+		go ph.Handle(t.Context(), sConn)
+
+		catalogBuf := newSyncBuffer()
+		sh := &sub.Handler{
+			Namespace: []string{internal.Namespace},
+			Outs:      map[string]io.Writer{"catalog": catalogBuf},
+			Logfh:     io.Discard,
+			VideoName: "NONE",
+			AudioName: "NONE",
+			UseFetch:  true,
+		}
+		go func() { _ = sh.RunWithConn(t.Context(), cConn) }()
+
+		catalogBuf.WaitForLen(1)
+
+		assert.Contains(t, catalogBuf.String(), "video_", "catalog should contain video tracks")
+		assert.Contains(t, catalogBuf.String(), "audio_", "catalog should contain audio tracks")
+
+		shutdown(sConn, cConn)
+	})
+}
+
 func TestVideoAudioReceive(t *testing.T) {
 	asset, catalog := loadTestAsset(t)
 

--- a/internal/pub/pub.go
+++ b/internal/pub/pub.go
@@ -32,6 +32,7 @@ func (h *Handler) Handle(ctx context.Context, conn moqtransport.Connection) {
 	session := &moqtransport.Session{
 		Handler:             h.getHandler(),
 		SubscribeHandler:    h.getSubscribeHandler(ctx),
+		FetchHandler:        h.getFetchHandler(),
 		InitialMaxRequestID: 100,
 		Qlogger:             qlog.NewQLOGHandler(h.Logfh, "MoQ QLOG", "MoQ QLOG", conn.Perspective().String(), moqt.Schema),
 	}
@@ -67,6 +68,55 @@ func (h *Handler) getHandler() moqtransport.Handler {
 			return
 		}
 	})
+}
+
+func (h *Handler) getFetchHandler() moqtransport.FetchHandler {
+	return moqtransport.FetchHandlerFunc(
+		func(w *moqtransport.FetchResponseWriter, m *moqtransport.FetchMessage) {
+			if !tupleEqual(m.Namespace, h.Namespace) {
+				slog.Warn("fetch: unexpected namespace",
+					"received", m.Namespace,
+					"expected", h.Namespace)
+				err := w.Reject(uint64(moqtransport.ErrorCodeFetchTrackDoesNotExist), "non-matching namespace")
+				if err != nil {
+					slog.Error("failed to reject fetch", "error", err)
+				}
+				return
+			}
+			if m.Track != "catalog" {
+				err := w.Reject(uint64(moqtransport.ErrorCodeFetchTrackDoesNotExist), "only catalog is fetchable")
+				if err != nil {
+					slog.Error("failed to reject fetch", "error", err)
+				}
+				return
+			}
+			err := w.Accept()
+			if err != nil {
+				slog.Error("failed to accept fetch", "error", err)
+				return
+			}
+			fs, err := w.FetchStream()
+			if err != nil {
+				slog.Error("failed to get fetch stream", "error", err)
+				return
+			}
+			catalogJSON, err := json.Marshal(h.Catalog)
+			if err != nil {
+				slog.Error("failed to marshal catalog", "error", err)
+				return
+			}
+			_, err = fs.WriteObject(0, 0, 0, 0, catalogJSON)
+			if err != nil {
+				slog.Error("failed to write catalog via fetch", "error", err)
+				return
+			}
+			err = fs.Close()
+			if err != nil {
+				slog.Error("failed to close fetch stream", "error", err)
+				return
+			}
+			slog.Info("served catalog via FETCH")
+		})
 }
 
 func (h *Handler) getSubscribeHandler(ctx context.Context) moqtransport.SubscribeHandler {

--- a/internal/sub/sub.go
+++ b/internal/sub/sub.go
@@ -128,7 +128,7 @@ func (h *Handler) handle(ctx context.Context, conn moqtransport.Connection) {
 			}
 		}
 		// Select video track
-		if strings.HasPrefix(track.MimeType, "video") {
+		if track.Role == "video" {
 			if h.VideoName != "" {
 				if videoTrack == "" && strings.Contains(track.Name, h.VideoName) {
 					videoTrack = track.Name
@@ -155,7 +155,7 @@ func (h *Handler) handle(ctx context.Context, conn moqtransport.Connection) {
 		}
 
 		// Select audio track
-		if strings.HasPrefix(track.MimeType, "audio") {
+		if track.Role == "audio" {
 			if h.AudioName != "" {
 				if audioTrack == "" && strings.Contains(track.Name, h.AudioName) {
 					audioTrack = track.Name
@@ -182,7 +182,7 @@ func (h *Handler) handle(ctx context.Context, conn moqtransport.Connection) {
 		}
 
 		// Select subtitle track (wvtt or stpp codec)
-		if track.MimeType == "application/mp4" {
+		if track.Role == "subtitle" {
 			if h.SubsName != "" {
 				if subsTrack == "" && strings.Contains(track.Name, h.SubsName) {
 					subsTrack = track.Name
@@ -400,12 +400,17 @@ func (h *Handler) subscribeAndRead(ctx context.Context, s *moqtransport.Session,
 				return
 			}
 			if o.ObjectID == 0 {
-				slog.Info("group start", "track", trackname, "groupID", o.GroupID, "payloadLength", len(o.Payload))
+				slog.Info("group start",
+					"track", trackname,
+					"groupID", o.GroupID,
+					"subGroupID", o.SubGroupID,
+					"payloadLength", len(o.Payload))
 			} else {
 				slog.Debug("object",
 					"track", trackname,
 					"objectID", o.ObjectID,
 					"groupID", o.GroupID,
+					"subGroupID", o.SubGroupID,
 					"payloadLength", len(o.Payload))
 			}
 			if h.cenc != nil {

--- a/internal/sub/sub.go
+++ b/internal/sub/sub.go
@@ -30,6 +30,7 @@ type Handler struct {
 	VideoName string
 	AudioName string
 	SubsName  string
+	UseFetch  bool
 
 	catalog *internal.Catalog
 	mux     *CmafMux
@@ -97,7 +98,11 @@ func (h *Handler) handle(ctx context.Context, conn moqtransport.Connection) {
 		}
 		return
 	}
-	err = h.subscribeToCatalog(ctx, session, h.Namespace)
+	if h.UseFetch {
+		err = h.fetchCatalog(ctx, session, h.Namespace)
+	} else {
+		err = h.subscribeToCatalog(ctx, session, h.Namespace)
+	}
 	if err != nil {
 		slog.Error("failed to subscribe to catalog", "error", err)
 		err = conn.CloseWithError(0, "internal error")
@@ -326,6 +331,51 @@ func (h *Handler) subscribeToCatalog(ctx context.Context, s *moqtransport.Sessio
 		}
 	}()
 
+	return nil
+}
+
+func (h *Handler) fetchCatalog(ctx context.Context, s *moqtransport.Session, namespace []string) error {
+	rt, err := s.Fetch(ctx, namespace, "catalog")
+	if err != nil {
+		return err
+	}
+	defer rt.Close()
+
+	o, err := rt.ReadObject(ctx)
+	if err != nil {
+		if err == io.EOF {
+			return nil
+		}
+		return err
+	}
+
+	err = json.Unmarshal(o.Payload, &h.catalog)
+	if err != nil {
+		return err
+	}
+	slog.Info("fetched catalog",
+		"groupID", o.GroupID,
+		"subGroupID", o.SubGroupID,
+		"payloadLength", len(o.Payload),
+	)
+	if slog.Default().Enabled(context.Background(), slog.LevelInfo) {
+		fmt.Fprintf(os.Stderr, "catalog: %s\n", h.catalog.String())
+	}
+	if h.Outs["catalog"] != nil {
+		indented, err := json.MarshalIndent(h.catalog, "", "  ")
+		if err != nil {
+			slog.Error("failed to marshal catalog", "error", err)
+		} else {
+			_, err = h.Outs["catalog"].Write(indented)
+			if err != nil {
+				slog.Error("failed to write catalog", "error", err)
+			}
+			_, err = h.Outs["catalog"].Write([]byte("\n"))
+			if err != nil {
+				slog.Error("failed to write catalog newline", "error", err)
+			}
+		}
+	}
 	return nil
 }
 


### PR DESCRIPTION
Add possibility to use FETCH to get the catalog (once).
Works both in mlmpub and mlmsub.
Can also specify namespace.
Mimetype removed from catalog.

Fixes #25.