### PR TITLE
feat: multi-namespace support with separate DRM and ECCP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.0] - 2026-04-11
+
+Full [MOQ Transport draft-14][moqt-d14] compliance release.
+
 ### Added
 
 - FETCH support for catalog retrieval as an alternative to SUBSCRIBE (`-fetchcatalog` flag in mlmsub)
@@ -23,6 +27,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Object ID delta encoding in subgroup streams per draft-14 spec (moqtransport v0.6.2)
+- Inverted Unannounce condition that returned error for known namespaces (moqtransport v0.6.3)
 - Safari 26.4 WebTransport support by adding newer SETTINGS codepoints
   ([warp-player#88](https://github.com/Eyevinn/warp-player/issues/88))
 
@@ -31,14 +37,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Use `role` instead of `mimeType` in catalog per CMSF/MSF spec
 - Refactored `cmd/mlmpub` and `cmd/mlmsub` into thin wrappers over `internal/pub` and `internal/sub`
 - Bumped Go version to 1.25
+- Bumped moqtransport to v0.6.3
 - Publisher goroutines now use proper context propagation instead of `context.TODO()`
 - Switched video sample descriptors from `avc3`/`hev1` to `avc1`/`hvc1` to support
   FairPlay streaming in Safari 26.4+. With `avc1`/`hvc1`, parameter sets (SPS/PPS
   for AVC, VPS/SPS/PPS for HEVC) are stored in the init segment rather than
   inlined in each sample
-
-### Changed
-
 - CI: added coverage workflow, updated Go to 1.25, aligned workflows with hi264
 
 ## [0.5.0] - 2026-01-27
@@ -126,7 +130,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - initial version of the repo
 
-[Unreleased]: https://github.com/Eyevinn/moqlivemock/releases/tag/v0.5.0...HEAD
+[Unreleased]: https://github.com/Eyevinn/moqlivemock/releases/tag/v0.6.0...HEAD
+[0.6.0]: https://github.com/Eyevinn/moqlivemock/releases/tag/v0.5.0...v0.6.0
 [0.5.0]: https://github.com/Eyevinn/moqlivemock/releases/tag/v0.4.0...v0.5.0
 [0.4.0]: https://github.com/Eyevinn/moqlivemock/releases/tag/v0.3.0...v0.4.0
 [0.3.0]: https://github.com/Eyevinn/moqlivemock/releases/tag/v0.2.0...v0.3.0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,11 +37,31 @@ Uses `github.com/Eyevinn/moqtransport` (forked from mengelbart/moqtransport) wit
 - Call `session.Run(conn)` to start
 - Subscriptions use separate `SubscribeHandler` interface
 
+### Multi-Namespace Architecture
+
+mlmpub announces one or more namespaces, each with its own catalog:
+- `cmsf/clear` — always present, clear (unencrypted) tracks
+- `cmsf/drm-{scheme}` — when `-drmpath` is set, commercial DRM tracks (`_drm` suffix)
+- `cmsf/eccp-{scheme}` — when `-kid`/`-iv` are set, ClearKey/ECCP tracks (`_eccp` suffix)
+
+Key types in `internal/pub/pub.go`:
+- `NamespaceEntry` — pairs a namespace tuple with its catalog
+- `Handler.Namespaces []NamespaceEntry` — all announced namespaces
+
+Key types in `internal/asset.go`:
+- `ProtectionType` — enum: `ProtectionNone`, `ProtectionDRM`, `ProtectionECCP`
+- `ContentTrack.Protection` — identifies how a track is encrypted
+- `Asset.Drm` / `Asset.Eccp` — independent DRM configs
+
+`GenCMAFCatalogEntry(namespace, protectionType, timestamp)` generates a catalog
+filtered to the specified protection type.
+
 ### Handler Pattern
 
 Publishers implement:
 - `Handler` - for ANNOUNCE messages
 - `SubscribeHandler` - for SUBSCRIBE messages (returns `*SubscribeResponseWriter`)
+- `FetchHandler` - for FETCH messages (returns `*FetchResponseWriter`)
 
 Subscribers implement:
 - `Handler` - for ANNOUNCE messages (accept/reject)
@@ -63,6 +83,23 @@ Configuration via mlmpub flags:
 - `-subsstpp "en,sv"` - comma-separated STPP languages (default: "en")
 
 Track naming: `subs_wvtt_{lang}`, `subs_stpp_{lang}`
+
+### Content Protection
+
+Two independent encryption modes, both optional and can be active simultaneously:
+
+**ClearKey/ECCP** (explicit key flags):
+- `-kid` — key ID (32 hex chars)
+- `-iv` — initialization vector (16 or 32 hex chars)
+- `-cenckey` — encryption key (32 hex chars, defaults to kid if omitted)
+- `-scheme` — `cenc` or `cbcs`
+- `-laurl` — external license URL for the catalog (falls back to `http://localhost:{sideport}/clearkey`)
+- `-sideport` — HTTP port serving `/fingerprint` and `/clearkey` endpoints
+
+**Commercial DRM** (CPIX config file):
+- `-drmpath` — path to config JSON (format: `assets/testdrm/drm_config_test.json`)
+
+Track naming: clear tracks have no suffix, DRM tracks get `_drm`, ECCP tracks get `_eccp`.
 
 ### Video Codecs
 

--- a/README.md
+++ b/README.md
@@ -44,16 +44,32 @@ This project uses [moqtransport][moqtransport] for the MoQ transport layer.
 As the MoQ transport layer is still work in progress, this project is also
 work in progress. Currently a fork is used to align to [draft-14 of MOQT][moqt-14].
 
+## Namespaces
+
+mlmpub announces one or more namespaces depending on the configured protection modes.
+Each namespace has its own MSF catalog containing only the relevant tracks:
+
+| Namespace | Condition | Track suffix | Description |
+|-----------|-----------|--------------|-------------|
+| `cmsf/clear` | Always | *(none)* | Unencrypted tracks |
+| `cmsf/drm-{scheme}` | `-drmpath` set | `_drm` | Commercial DRM (Widevine/PlayReady/FairPlay via CPIX) |
+| `cmsf/eccp-{scheme}` | `-kid`/`-iv` set | `_eccp` | ClearKey/ECCP (explicit key over HTTP) |
+
+Both DRM and ECCP can be active simultaneously — they use independent encryption keys
+and produce separate sets of protected tracks.
+
+Subtitle tracks are included in all namespaces since they are not encrypted.
+
 ## Session setup
 
-The first things that happens after the session establishment is that the namespace is
-announced by the server. The client next subscribes to the MSF catalog.
-Once it has the catalog, it can subscribe to media.
+After session establishment, the server announces all configured namespaces.
+The client subscribes to the MSF catalog in the desired namespace.
+Once it has the catalog, it can subscribe to media tracks listed in that catalog.
 
-The bundled `mlmsub` client subscribes to the first video and audio track from the catalog
-or tracks that match the `-videoname`, `-audioname`. For subtitles, see below.
-It should later be possible to switch bitrate by unsubscribing to one
-track and subscribing to another, with no repeated or lost frames.
+The bundled `mlmsub` client connects to a single namespace (default: `cmsf/clear`,
+configurable via `-namespace`). It subscribes to the first video and audio track
+from the catalog or tracks that match `-videoname`, `-audioname`.
+For subtitles, see below.
 
 ## Subtitle Tracks
 
@@ -181,7 +197,7 @@ useful when running the server locally.
 
 **Run mlmpub with fingerprint support**:
 ```sh
-> go run . -fingerprintport 8081
+> go run . -sideport 8081
 ```
 
 This will automatically generate a WebTransport-compatible certificate with:
@@ -193,12 +209,12 @@ Alternatively, you can use your own certificate (e.g., generated with the includ
 ```sh
 cd cmd/mlmpub
 ./generate-webtransport-cert.sh
-go run . -cert cert-fp.pem -key key-fp.pem -fingerprintport 8081
+go run . -cert cert-fp.pem -key key-fp.pem -sideport 8081
 ```
 
 This will:
 - Start the MoQ server on port 4443 (default address is `0.0.0.0:4443`, listening on all interfaces)
-- Start an HTTP server on port 8081 that serves the certificate's SHA-256 fingerprint
+- Start an HTTP side server on port 8081 serving `/fingerprint` and `/clearkey`
 - Validate that the certificate meets WebTransport requirements
 
 The warp-player can then connect using:
@@ -206,33 +222,69 @@ The warp-player can then connect using:
 - Fingerprint URL: `http://localhost:8081/fingerprint` or `http://127.0.0.1:8081/fingerprint`
 
 **Notes**:
-- The fingerprint server is disabled by default (`-fingerprintport 0`).
-  Only enable it when using certificates that meet WebTransport's strict requirements.
+- The side server is disabled by default (`-sideport 0`).
+  Enable it when using certificate fingerprints or ClearKey/ECCP encryption.
 - If no certificate files are provided, mlmpub will generate WebTransport-compatible certificates automatically.
 
 ### Using DRM
-moqlivemock supports the use of DRM. Supported DRM systems are Widevine, PlayReady, FairPlay (untested) and ClearKey. To use ClearKey you need to add the `-kid`, `-iv`, and `-cenckey` flags with relevant values to the publisher. If no cenc key is provided the key-id will be used as the cenc key. The ClearKey license server is hosted on the fingerprint server on the path `/clearkey` so you also need to enable the fingerprint server with the  `-fingerprintport` flag.
 
-To use any of the other DRM systems you need to add a CPIX file and a config JSON file (preferably in the gitignored directory `assets/drm/`) and add the flag `-drmpath` which points to the config JSON file. The config JSON file needs to be of the same format as the example file `assets/testdrm/drm_config_test.json`.
+moqlivemock supports two independent content protection modes that can run simultaneously:
 
-Example ClearKey publisher:
+#### ClearKey / ECCP (explicit key)
+
+Use `-kid`, `-iv`, and optionally `-cenckey` flags. If no cenc key is provided, the
+key-id is used as the key. The ClearKey license endpoint is served at `/clearkey` on
+the side server, so `-sideport` must be set. For production behind a reverse proxy,
+use `-laurl` to specify the external license URL announced in the catalog.
+
 ```sh
-cd cmd/mlmpub
-go run . -kid 39112233445566778899aabbccddeeff -iv 41112233445566778899aabbccddeeff -fingerprintport 8081
+# Local development
+go run . -kid 39112233445566778899aabbccddeeff -iv 41112233445566778899aabbccddeeff -scheme cbcs -sideport 8081
+
+# Behind a reverse proxy (e.g. Caddy forwarding /clearkey → localhost:8081/clearkey)
+go run . -kid 39112233445566778899aabbccddeeff -iv 41112233445566778899aabbccddeeff -scheme cbcs \
+         -sideport 8081 -laurl https://moqlivemock.demo.osaas.io/clearkey
 ```
 
-Example commercial DRM publisher:
+This announces namespace `cmsf/eccp-cbcs` with tracks like `video_400kbps_avc_eccp`.
+
+#### Commercial DRM (CPIX)
+
+Use `-drmpath` pointing to a config JSON file in the same format as `assets/testdrm/drm_config_test.json`.
+Supported systems: Widevine, PlayReady, FairPlay.
+
 ```sh
-cd cmd/mlmpub
-go run . -drmpath ../../assets/testdrm/drm_config_test.json #Test DRM. Does not contain a real DRM key.
+go run . -drmpath ../../assets/testdrm/drm_config_test.json
 ```
 
-The subscriber uses information from the catalog to make a ClearKey request so no extra flags need to be provided except for choosing the protected tracks.
+This announces namespace `cmsf/drm-{scheme}` with tracks like `video_400kbps_avc_drm`.
 
-Example subscriber:
+#### Both simultaneously
+
+Both modes can be active at the same time, each with independent encryption keys:
+
 ```sh
-cd cmd/mlmsub
-go run . -videoname video_400kbps_avc_protected -audioname audio_monotonic_128kbps_aac_protected -muxout - | ffplay -
+go run . -drmpath ../../assets/drm/drm_config.json \
+         -kid 39112233445566778899aabbccddeeff -iv 41112233445566778899aabbccddeeff -scheme cbcs \
+         -sideport 8081 -laurl https://moqlivemock.demo.osaas.io/clearkey
+```
+
+This announces three namespaces: `cmsf/clear`, `cmsf/drm-cbcs`, and `cmsf/eccp-cbcs`.
+
+#### Subscriber examples
+
+The subscriber uses information from the catalog to make license requests,
+so no extra flags are needed except choosing the right namespace and track names:
+
+```sh
+# Clear content (default namespace)
+go run . -muxout - | ffplay -
+
+# ECCP-protected content
+go run . -namespace cmsf/eccp-cbcs -videoname _eccp -audioname _eccp -muxout - | ffplay -
+
+# DRM-protected content
+go run . -namespace cmsf/drm-cbcs -videoname _drm -audioname _drm -muxout - | ffplay -
 ```
 
 ## QUIC / WebTransport Configuration

--- a/cmd/mlmpub/handler.go
+++ b/cmd/mlmpub/handler.go
@@ -24,13 +24,13 @@ type server struct {
 	addr            string
 	tlsConfig       *tls.Config
 	handler         *pub.Handler
-	fingerprintPort int
+	sidePort int
 }
 
 func (s *server) runServer(ctx context.Context) error {
-	// Start HTTP server for fingerprint if port is specified
-	if s.fingerprintPort > 0 {
-		go s.startFingerprintServer()
+	// Start HTTP side server for /fingerprint and /clearkey
+	if s.sidePort > 0 {
+		go s.startSideServer()
 	}
 
 	slog.Info("Starting MoQ server", "addr", s.addr)
@@ -85,7 +85,7 @@ func (s *server) runServer(ctx context.Context) error {
 	}
 }
 
-func (s *server) startFingerprintServer() {
+func (s *server) startSideServer() {
 	// Validate certificate for WebTransport requirements
 	if err := s.validateCertificateForWebTransport(); err != nil {
 		slog.Warn("Certificate does not meet WebTransport fingerprint requirements", "error", err)
@@ -172,10 +172,10 @@ func (s *server) startFingerprintServer() {
 		slog.Info("Served ClearKey license")
 	}))
 
-	addr := fmt.Sprintf(":%d", s.fingerprintPort)
-	slog.Info("Starting fingerprint HTTP server", "addr", addr)
+	addr := fmt.Sprintf(":%d", s.sidePort)
+	slog.Info("Starting HTTP side server", "addr", addr)
 	if err := http.ListenAndServe(addr, mux); err != nil {
-		slog.Error("fingerprint server failed", "error", err)
+		slog.Error("side server failed", "error", err)
 	}
 }
 

--- a/cmd/mlmpub/handler.go
+++ b/cmd/mlmpub/handler.go
@@ -21,10 +21,10 @@ import (
 )
 
 type server struct {
-	addr            string
-	tlsConfig       *tls.Config
-	handler         *pub.Handler
-	sidePort int
+	addr      string
+	tlsConfig *tls.Config
+	handler   *pub.Handler
+	sidePort  int
 }
 
 func (s *server) runServer(ctx context.Context) error {

--- a/cmd/mlmpub/main.go
+++ b/cmd/mlmpub/main.go
@@ -60,6 +60,7 @@ type options struct {
 	iv               string
 	kid              string
 	scheme           string
+	laURL            string
 	drmConfigPath    string
 	version          bool
 }
@@ -88,6 +89,8 @@ func parseOptions(fs *flag.FlagSet, args []string) (*options, error) {
 		"if no key is specified the key id will be used as the key.")
 	fs.StringVar(&opts.scheme, "scheme", "cenc", "Scheme for CENC encryption,"+
 		"either \"cenc\" or \"cbcs\"")
+	fs.StringVar(&opts.laURL, "laurl", "", "ClearKey/ECCP license acquisition URL announced in catalog."+
+		" Falls back to http://localhost:{fingerprintport}/clearkey if not set.")
 	fs.StringVar(&opts.drmConfigPath, "drmpath", "", "path to a drm config file")
 	fs.BoolVar(&opts.version, "version", false, fmt.Sprintf("Get %s version", appName))
 	err := fs.Parse(args[1:])
@@ -153,8 +156,12 @@ func runServer(opts *options) error {
 	}
 
 	// Parse ClearKey/ECCP config (explicit key flags)
+	laURL := opts.laURL
+	if laURL == "" && opts.fingerprintPort > 0 {
+		laURL = fmt.Sprintf("http://localhost:%d/clearkey", opts.fingerprintPort)
+	}
 	var eccp *internal.DRMInfo
-	eccp, err = internal.ParseCENCflags(opts.scheme, opts.kid, opts.cencKey, opts.iv, opts.fingerprintPort)
+	eccp, err = internal.ParseCENCflags(opts.scheme, opts.kid, opts.cencKey, opts.iv, laURL)
 	if err != nil {
 		return err
 	}

--- a/cmd/mlmpub/main.go
+++ b/cmd/mlmpub/main.go
@@ -241,10 +241,10 @@ func runServer(opts *options) error {
 	}
 
 	s := &server{
-		addr:            opts.addr,
-		tlsConfig:       tlsConfig,
-		handler:         h,
-		sidePort: opts.sidePort,
+		addr:      opts.addr,
+		tlsConfig: tlsConfig,
+		handler:   h,
+		sidePort:  opts.sidePort,
 	}
 
 	return s.runServer(ctx)

--- a/cmd/mlmpub/main.go
+++ b/cmd/mlmpub/main.go
@@ -53,7 +53,7 @@ type options struct {
 	qlogfile         string
 	audioSampleBatch int
 	videoSampleBatch int
-	fingerprintPort  int
+	sidePort         int
 	subsWvttLangs    string
 	subsStppLangs    string
 	cencKey          string
@@ -80,7 +80,7 @@ func parseOptions(fs *flag.FlagSet, args []string) (*options, error) {
 	fs.StringVar(&opts.qlogfile, "qlog", defaultQlogFileName, "qlog file to write to. Use '-' for stderr")
 	fs.IntVar(&opts.audioSampleBatch, "audiobatch", 2, "Nr audio samples per MoQ object/CMAF chunk")
 	fs.IntVar(&opts.videoSampleBatch, "videobatch", 1, "Nr video samples per MoQ object/CMAF chunk")
-	fs.IntVar(&opts.fingerprintPort, "fingerprintport", 0, "Port for HTTP fingerprint server (0 to disable)")
+	fs.IntVar(&opts.sidePort, "sideport", 0, "Port for HTTP side server serving /fingerprint and /clearkey (0 to disable)")
 	fs.StringVar(&opts.subsWvttLangs, "subswvtt", "sv", "Comma-separated WVTT subtitle languages (e.g. 'en,sv')")
 	fs.StringVar(&opts.subsStppLangs, "subsstpp", "en", "Comma-separated STPP subtitle languages (e.g. 'en,sv')")
 	fs.StringVar(&opts.kid, "kid", "", "key id for CENC encryption (32 hex or 24 base64 chars)")
@@ -90,7 +90,7 @@ func parseOptions(fs *flag.FlagSet, args []string) (*options, error) {
 	fs.StringVar(&opts.scheme, "scheme", "cenc", "Scheme for CENC encryption,"+
 		"either \"cenc\" or \"cbcs\"")
 	fs.StringVar(&opts.laURL, "laurl", "", "ClearKey/ECCP license acquisition URL announced in catalog."+
-		" Falls back to http://localhost:{fingerprintport}/clearkey if not set.")
+		" Falls back to http://localhost:{sideport}/clearkey if not set.")
 	fs.StringVar(&opts.drmConfigPath, "drmpath", "", "path to a drm config file")
 	fs.BoolVar(&opts.version, "version", false, fmt.Sprintf("Get %s version", appName))
 	err := fs.Parse(args[1:])
@@ -157,8 +157,8 @@ func runServer(opts *options) error {
 
 	// Parse ClearKey/ECCP config (explicit key flags)
 	laURL := opts.laURL
-	if laURL == "" && opts.fingerprintPort > 0 {
-		laURL = fmt.Sprintf("http://localhost:%d/clearkey", opts.fingerprintPort)
+	if laURL == "" && opts.sidePort > 0 {
+		laURL = fmt.Sprintf("http://localhost:%d/clearkey", opts.sidePort)
 	}
 	var eccp *internal.DRMInfo
 	eccp, err = internal.ParseCENCflags(opts.scheme, opts.kid, opts.cencKey, opts.iv, laURL)
@@ -244,7 +244,7 @@ func runServer(opts *options) error {
 		addr:            opts.addr,
 		tlsConfig:       tlsConfig,
 		handler:         h,
-		fingerprintPort: opts.fingerprintPort,
+		sidePort: opts.sidePort,
 	}
 
 	return s.runServer(ctx)

--- a/cmd/mlmpub/main.go
+++ b/cmd/mlmpub/main.go
@@ -143,16 +143,23 @@ func runServer(opts *options) error {
 			return err
 		}
 	}
+	// Parse commercial DRM config (CPIX)
 	var drm *internal.DRMInfo
 	if opts.drmConfigPath != "" {
 		drm, err = internal.ConfigureDRMFromFile(opts.drmConfigPath)
-	} else {
-		drm, err = internal.ParseCENCflags(opts.scheme, opts.kid, opts.cencKey, opts.iv, opts.fingerprintPort)
+		if err != nil {
+			return err
+		}
 	}
+
+	// Parse ClearKey/ECCP config (explicit key flags)
+	var eccp *internal.DRMInfo
+	eccp, err = internal.ParseCENCflags(opts.scheme, opts.kid, opts.cencKey, opts.iv, opts.fingerprintPort)
 	if err != nil {
 		return err
 	}
-	asset, err := internal.LoadAssetWithDRM(opts.asset, opts.audioSampleBatch, opts.videoSampleBatch, drm)
+
+	asset, err := internal.LoadAssetWithProtection(opts.asset, opts.audioSampleBatch, opts.videoSampleBatch, drm, eccp)
 	if err != nil {
 		return err
 	}
@@ -169,9 +176,44 @@ func runServer(opts *options) error {
 	}
 	slog.Info("added subtitle tracks", "wvtt", wvttLangs, "stpp", stppLangs)
 
-	catalog, err := asset.GenCMAFCatalogEntry(time.Now().UnixMilli())
+	now := time.Now().UnixMilli()
+
+	// Always create the clear namespace
+	clearCatalog, err := asset.GenCMAFCatalogEntry("cmsf/clear", internal.ProtectionNone, now)
 	if err != nil {
 		return err
+	}
+	namespaces := []pub.NamespaceEntry{
+		{Namespace: []string{"cmsf/clear"}, Catalog: clearCatalog},
+	}
+
+	// Add commercial DRM namespace if configured
+	if drm != nil {
+		drmCatalog, err := asset.GenCMAFCatalogEntry("cmsf/drm-"+opts.scheme, internal.ProtectionDRM, now)
+		if err != nil {
+			return err
+		}
+		namespaces = append(namespaces, pub.NamespaceEntry{
+			Namespace: []string{"cmsf/drm-" + opts.scheme},
+			Catalog:   drmCatalog,
+		})
+	}
+
+	// Add ClearKey/ECCP namespace if configured
+	if eccp != nil {
+		eccpCatalog, err := asset.GenCMAFCatalogEntry("cmsf/eccp-"+opts.scheme, internal.ProtectionECCP, now)
+		if err != nil {
+			return err
+		}
+		namespaces = append(namespaces, pub.NamespaceEntry{
+			Namespace: []string{"cmsf/eccp-" + opts.scheme},
+			Catalog:   eccpCatalog,
+		})
+	}
+
+	for _, ns := range namespaces {
+		slog.Info("configured namespace", "namespace", ns.Namespace,
+			"tracks", len(ns.Catalog.Tracks))
 	}
 
 	var logfh io.Writer
@@ -186,10 +228,9 @@ func runServer(opts *options) error {
 		defer fh.Close()
 	}
 	h := &pub.Handler{
-		Namespace: []string{internal.Namespace},
-		Asset:     asset,
-		Catalog:   catalog,
-		Logfh:     logfh,
+		Namespaces: namespaces,
+		Asset:      asset,
+		Logfh:      logfh,
 	}
 
 	s := &server{

--- a/cmd/mlmsub/main.go
+++ b/cmd/mlmsub/main.go
@@ -75,7 +75,7 @@ func parseOptions(fs *flag.FlagSet, args []string) (*options, error) {
 	fs.StringVar(&opts.videoname, "videoname", "_avc", "Substring to match for video track (default AVC)")
 	fs.StringVar(&opts.audioname, "audioname", "_aac", "Substring to match for audio track (default AAC)")
 	fs.StringVar(&opts.subsname, "subsname", "", "Substring to match for selecting subtitle track (e.g. 'wvtt' or 'stpp')")
-	fs.StringVar(&opts.namespace, "namespace", internal.Namespace, "MoQ namespace to use")
+	fs.StringVar(&opts.namespace, "namespace", "cmsf/clear", "MoQ namespace to use")
 	fs.StringVar(&opts.loglevel, "loglevel", "info", "Log level: debug, info, warning, error")
 	fs.BoolVar(&opts.fetchCatalog, "fetchcatalog", false, "Use FETCH instead of SUBSCRIBE for catalog")
 

--- a/cmd/mlmsub/main.go
+++ b/cmd/mlmsub/main.go
@@ -36,18 +36,18 @@ Usage of %s:
 `
 
 type options struct {
-	addr       string
-	trackname  string
-	duration   int
-	muxout     string
-	videoOut   string
-	audioOut   string
-	subsOut    string
-	catalogOut string
-	qlogfile   string
-	videoname  string
-	audioname  string
-	subsname   string
+	addr         string
+	trackname    string
+	duration     int
+	muxout       string
+	videoOut     string
+	audioOut     string
+	subsOut      string
+	catalogOut   string
+	qlogfile     string
+	videoname    string
+	audioname    string
+	subsname     string
 	namespace    string
 	loglevel     string
 	fetchCatalog bool

--- a/internal/asset.go
+++ b/internal/asset.go
@@ -18,6 +18,15 @@ const (
 	cmafOverheadBytes = 112 // moof + mdat header size for one sample
 )
 
+// ProtectionType identifies how a track is encrypted.
+type ProtectionType int
+
+const (
+	ProtectionNone ProtectionType = iota
+	ProtectionDRM  // Commercial DRM (Widevine/PlayReady/FairPlay via CPIX)
+	ProtectionECCP // ClearKey / ECCP (explicit key over HTTP)
+)
+
 type ContentTrack struct {
 	Name                    string
 	ContentType             string
@@ -32,6 +41,7 @@ type ContentTrack struct {
 	SampleBatch             int
 	Samples                 []mp4.FullSample
 	SpecData                CodecSpecificData
+	Protection              ProtectionType
 	contentProtectionRefIDs []string
 	cenc                    *CENCInfo
 	ipd                     *mp4.InitProtectData
@@ -43,6 +53,7 @@ type Asset struct {
 	LoopDurMS      uint32
 	SubtitleTracks []*SubtitleTrack
 	Drm            *DRMInfo
+	Eccp           *DRMInfo
 }
 
 type CodecSpecificData interface {
@@ -267,21 +278,33 @@ func InitContentTrack(r io.Reader, name string, audioSampleBatch, videoSampleBat
 // LoadAsset opens a directory, reads all *.mp4 files, creates ContentTrack from each,
 // groups them by contentType, and returns a pointer to an Asset.
 func LoadAsset(dirPath string, audioSampleBatch, videoSampleBatch int) (*Asset, error) {
-	return LoadAssetWithDRM(dirPath, audioSampleBatch, videoSampleBatch, nil)
+	return LoadAssetWithProtection(dirPath, audioSampleBatch, videoSampleBatch, nil, nil)
 }
 
-// LoadAssetWithDRM creates an asset from the *.mp4 files in the specified dirPath.
-// If CENCInfo is not nil, a separate track with content protection applied is created
-// for all existing video and audio tracks.
+// LoadAssetWithDRM creates an asset with a single DRM config (backward compatibility).
 func LoadAssetWithDRM(dirPath string, audioSampleBatch, videoSampleBatch int, drm *DRMInfo) (*Asset, error) {
+	return LoadAssetWithProtection(dirPath, audioSampleBatch, videoSampleBatch, drm, nil)
+}
+
+// LoadAssetWithProtection creates an asset from the *.mp4 files in the specified dirPath.
+// If drm is not nil, protected tracks with "_drm" suffix are created (commercial DRM via CPIX).
+// If eccp is not nil, protected tracks with "_eccp" suffix are created (ClearKey/ECCP).
+// Both can be provided simultaneously to create two independent sets of encrypted tracks.
+func LoadAssetWithProtection(dirPath string, audioSampleBatch, videoSampleBatch int, drm, eccp *DRMInfo) (*Asset, error) {
 	tracksByType, err := parseTracks(dirPath, audioSampleBatch, videoSampleBatch)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse tracks: %w", err)
 	}
 	if drm != nil {
-		err = createProtectedTracks(tracksByType, drm)
+		err = createProtectedTracks(tracksByType, drm, "_drm", ProtectionDRM)
 		if err != nil {
-			return nil, fmt.Errorf("failed to create protected tracks: %w", err)
+			return nil, fmt.Errorf("failed to create DRM protected tracks: %w", err)
+		}
+	}
+	if eccp != nil {
+		err = createProtectedTracks(tracksByType, eccp, "_eccp", ProtectionECCP)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create ECCP protected tracks: %w", err)
 		}
 	}
 	trackGroups, err := generateTrackGroups(tracksByType)
@@ -292,6 +315,7 @@ func LoadAssetWithDRM(dirPath string, audioSampleBatch, videoSampleBatch int, dr
 		Name:   filepath.Base(dirPath),
 		Groups: trackGroups,
 		Drm:    drm,
+		Eccp:   eccp,
 	}
 	if err := asset.setLoopDuration(); err != nil {
 		return nil, fmt.Errorf("could not set loop duration: %w", err)
@@ -328,8 +352,10 @@ func parseTracks(dirPath string, audioSampleBatch, videoSampleBatch int) (map[st
 	return tracksByType, nil
 }
 
-// createProtectedTracks creates duplicate protected versions of all existing tracks and adds them to the map.
-func createProtectedTracks(tracksByType map[string][]ContentTrack, drm *DRMInfo) error {
+// createProtectedTracks creates duplicate protected versions of all existing clear tracks
+// and adds them to the map. The suffix (e.g. "_drm", "_eccp") and protectionType distinguish
+// different protection schemes.
+func createProtectedTracks(tracksByType map[string][]ContentTrack, drm *DRMInfo, suffix string, prot ProtectionType) error {
 	types := []string{"video", "audio"}
 	for _, typ := range types {
 		orig, ok := tracksByType[typ]
@@ -338,7 +364,11 @@ func createProtectedTracks(tracksByType map[string][]ContentTrack, drm *DRMInfo)
 		}
 		var added []ContentTrack
 		for _, ct := range orig {
-			protectedCt, err := addProtectionInfoToTrack(ct, drm)
+			// Only create protected versions of clear tracks
+			if ct.Protection != ProtectionNone {
+				continue
+			}
+			protectedCt, err := addProtectionInfoToTrack(ct, drm, suffix, prot)
 			if err != nil {
 				return err
 			}
@@ -349,20 +379,21 @@ func createProtectedTracks(tracksByType map[string][]ContentTrack, drm *DRMInfo)
 	return nil
 }
 
-// addProtectionInfoToTrack adds protection information to a track.
-func addProtectionInfoToTrack(ct ContentTrack, drm *DRMInfo) (ContentTrack, error) {
+// addProtectionInfoToTrack adds protection information to a track with the given suffix and type.
+func addProtectionInfoToTrack(ct ContentTrack, drm *DRMInfo, suffix string, prot ProtectionType) (ContentTrack, error) {
 	protectedCt := ct
 	protectedSpecData, err := cloneCodecSpecificData(ct.SpecData)
-	protectedCt.Name = ct.Name + "_protected"
+	if err != nil {
+		return ContentTrack{}, err
+	}
+	protectedCt.Name = ct.Name + suffix
+	protectedCt.Protection = prot
 	protectedCt.cenc = drm.cenc
 	refIDs := make([]string, 0, len(drm.ContentProtections))
 	for _, cp := range drm.ContentProtections {
 		refIDs = append(refIDs, cp.RefID)
 	}
 	protectedCt.contentProtectionRefIDs = refIDs
-	if err != nil {
-		return ContentTrack{}, err
-	}
 	protectedCt.SpecData = protectedSpecData
 	kid, err := mp4.NewUUIDFromString(drm.ContentProtections[0].DefaultKIDs[0])
 	if err != nil {
@@ -457,14 +488,23 @@ func (a *Asset) setLoopDuration() error {
 
 // GenCMAFCatalogEntry generates an MSF/CMSF catalog entry for this asset, populating all available fields.
 // Conforms to draft-ietf-moq-msf-00 and draft-ietf-moq-cmsf-00, except for the extra contentProtection field.
+//
+// The namespace parameter sets the Track.Namespace field in each catalog track entry.
+// The prot parameter selects which tracks to include: ProtectionNone for clear tracks,
+// ProtectionDRM for commercial DRM tracks, ProtectionECCP for ClearKey/ECCP tracks.
+// Subtitle tracks are always included regardless of the filter.
 // The generatedAtMS parameter is the wallclock time in milliseconds since the Unix epoch
 // to be set as the catalog's generatedAt value.
-func (a *Asset) GenCMAFCatalogEntry(generatedAtMS int64) (*Catalog, error) {
+func (a *Asset) GenCMAFCatalogEntry(namespace string, prot ProtectionType, generatedAtMS int64) (*Catalog, error) {
 	var tracks []Track
 	renderGroup := 1
 	for _, group := range a.Groups {
 		altGroup := int(group.AltGroupID)
 		for _, ct := range group.Tracks {
+			if ct.Protection != prot {
+				continue
+			}
+
 			initData := ""
 			if ct.SpecData != nil {
 				data, err := ct.SpecData.GenCMAFInitData()
@@ -479,6 +519,7 @@ func (a *Asset) GenCMAFCatalogEntry(generatedAtMS int64) (*Catalog, error) {
 
 			track := Track{
 				Name:        ct.Name,
+				Namespace:   namespace,
 				Packaging:   "cmaf",
 				IsLive:      true,
 				RenderGroup: &renderGroup,
@@ -540,7 +581,6 @@ func (a *Asset) GenCMAFCatalogEntry(generatedAtMS int64) (*Catalog, error) {
 			if len(ct.contentProtectionRefIDs) > 0 {
 				track.ContentProtectionRefIDs = ct.contentProtectionRefIDs
 			}
-			track.Namespace = Namespace
 			tracks = append(tracks, track)
 		}
 	}
@@ -568,7 +608,7 @@ func (a *Asset) GenCMAFCatalogEntry(generatedAtMS int64) (*Catalog, error) {
 
 		track := Track{
 			Name:        st.Name,
-			Namespace:   Namespace,
+			Namespace:   namespace,
 			Packaging:   "cmaf",
 			IsLive:      true,
 			Role:        "subtitle",
@@ -587,8 +627,15 @@ func (a *Asset) GenCMAFCatalogEntry(generatedAtMS int64) (*Catalog, error) {
 		GeneratedAt: &generatedAtMS,
 		Tracks:      tracks,
 	}
-	if a.Drm != nil {
-		cat.ContentProtections = a.Drm.ContentProtections
+	switch prot {
+	case ProtectionDRM:
+		if a.Drm != nil {
+			cat.ContentProtections = a.Drm.ContentProtections
+		}
+	case ProtectionECCP:
+		if a.Eccp != nil {
+			cat.ContentProtections = a.Eccp.ContentProtections
+		}
 	}
 	return cat, nil
 }

--- a/internal/asset.go
+++ b/internal/asset.go
@@ -23,8 +23,8 @@ type ProtectionType int
 
 const (
 	ProtectionNone ProtectionType = iota
-	ProtectionDRM  // Commercial DRM (Widevine/PlayReady/FairPlay via CPIX)
-	ProtectionECCP // ClearKey / ECCP (explicit key over HTTP)
+	ProtectionDRM                 // Commercial DRM (Widevine/PlayReady/FairPlay via CPIX)
+	ProtectionECCP                // ClearKey / ECCP (explicit key over HTTP)
 )
 
 type ContentTrack struct {
@@ -290,7 +290,8 @@ func LoadAssetWithDRM(dirPath string, audioSampleBatch, videoSampleBatch int, dr
 // If drm is not nil, protected tracks with "_drm" suffix are created (commercial DRM via CPIX).
 // If eccp is not nil, protected tracks with "_eccp" suffix are created (ClearKey/ECCP).
 // Both can be provided simultaneously to create two independent sets of encrypted tracks.
-func LoadAssetWithProtection(dirPath string, audioSampleBatch, videoSampleBatch int, drm, eccp *DRMInfo) (*Asset, error) {
+func LoadAssetWithProtection(dirPath string, audioSampleBatch, videoSampleBatch int,
+	drm, eccp *DRMInfo) (*Asset, error) {
 	tracksByType, err := parseTracks(dirPath, audioSampleBatch, videoSampleBatch)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse tracks: %w", err)
@@ -355,7 +356,8 @@ func parseTracks(dirPath string, audioSampleBatch, videoSampleBatch int) (map[st
 // createProtectedTracks creates duplicate protected versions of all existing clear tracks
 // and adds them to the map. The suffix (e.g. "_drm", "_eccp") and protectionType distinguish
 // different protection schemes.
-func createProtectedTracks(tracksByType map[string][]ContentTrack, drm *DRMInfo, suffix string, prot ProtectionType) error {
+func createProtectedTracks(tracksByType map[string][]ContentTrack, drm *DRMInfo, suffix string,
+	prot ProtectionType) error {
 	types := []string{"video", "audio"}
 	for _, typ := range types {
 		orig, ok := tracksByType[typ]

--- a/internal/asset.go
+++ b/internal/asset.go
@@ -423,8 +423,16 @@ func generateTrackGroups(tracksByType map[string][]ContentTrack) ([]TrackGroup, 
 	var groups []TrackGroup
 	groupID := uint32(1)
 	// Add video group(s) first
+	// Sort by codec (avc before hvc) then by bitrate ascending.
+	// This ensures AVC tracks appear first, which matters because
+	// HEVC with CENC is not fully supported in Widevine/Chrome.
 	if videoTracks, ok := tracksByType["video"]; ok {
 		sort.Slice(videoTracks, func(i, j int) bool {
+			ci := videoTracks[i].SpecData.Codec()
+			cj := videoTracks[j].SpecData.Codec()
+			if ci != cj {
+				return ci < cj
+			}
 			return videoTracks[i].SampleBitrate < videoTracks[j].SampleBitrate
 		})
 		for i := 0; i < len(videoTracks); i++ {

--- a/internal/asset_test.go
+++ b/internal/asset_test.go
@@ -146,13 +146,13 @@ func TestLoadAsset(t *testing.T) {
 				"loop duration should be 10s in timescale")
 		}
 	}
-	cat, err := asset.GenCMAFCatalogEntry(1234567890000)
+	cat, err := asset.GenCMAFCatalogEntry("cmsf/clear", ProtectionNone,1234567890000)
 	require.NoError(t, err)
 	require.NotNil(t, cat)
 	require.Equal(t, 12, len(cat.Tracks))
 	// Check that all tracks have the namespace set
 	for _, track := range cat.Tracks {
-		require.Equal(t, Namespace, track.Namespace)
+		require.Equal(t, "cmsf/clear", track.Namespace)
 	}
 }
 
@@ -170,7 +170,7 @@ func TestCreateProtectedTracksDoesNotMutateOriginalTrackInit(t *testing.T) {
 	drm, err := ParseCENCflags("cenc", kidStr, keyStr, ivStr, 8081)
 	require.NoError(t, err)
 
-	err = createProtectedTracks(tracksByType, drm)
+	err = createProtectedTracks(tracksByType, drm, "_drm", ProtectionDRM)
 	require.NoError(t, err)
 
 	origVideoAfter := tracksByType["video"][0]
@@ -249,16 +249,16 @@ func TestClearKeyDecryptionMatchExcatly(t *testing.T) {
 	ivStr := "41112233445566778899aabbccddeeff"
 	schemes := []string{"cbcs", "cenc"}
 	for _, scheme := range schemes {
-		drm, err := ParseCENCflags(scheme, kidStr, keyStr, ivStr, 8081)
+		eccp, err := ParseCENCflags(scheme, kidStr, keyStr, ivStr, 8081)
 		require.NoError(t, err)
-		checkDecryptedTracksMatchExactly(t, drm)
+		checkDecryptedTracksMatchExactly(t, eccp, "_eccp")
 	}
 }
 
 func TestCommercialDRMDecryptionMatchExactly(t *testing.T) {
 	drm, err := ConfigureDRMFromFile("../assets/testdrm/drm_config_test.json")
 	require.NoError(t, err)
-	checkDecryptedTracksMatchExactly(t, drm)
+	checkDecryptedTracksMatchExactly(t, drm, "_drm")
 }
 
 func TestGetSubtitleTrackByName(t *testing.T) {
@@ -306,8 +306,14 @@ func TestAddSubtitleTracksEmpty(t *testing.T) {
 	assert.Equal(t, 0, len(asset.SubtitleTracks))
 }
 
-func checkDecryptedTracksMatchExactly(t *testing.T, drm *DRMInfo) {
-	drmAsset, err := LoadAssetWithDRM("../assets/test10s", 1, 1, drm)
+func checkDecryptedTracksMatchExactly(t *testing.T, drm *DRMInfo, suffix string) {
+	var drmAsset *Asset
+	var err error
+	if suffix == "_eccp" {
+		drmAsset, err = LoadAssetWithProtection("../assets/test10s", 1, 1, nil, drm)
+	} else {
+		drmAsset, err = LoadAssetWithProtection("../assets/test10s", 1, 1, drm, nil)
+	}
 	require.NoError(t, err)
 	require.NotNil(t, drmAsset)
 
@@ -338,7 +344,7 @@ func checkDecryptedTracksMatchExactly(t *testing.T, drm *DRMInfo) {
 				case "original":
 					tr = originalTrack
 				case "encrypted":
-					protectedName := originalTrack.Name + "_protected"
+					protectedName := originalTrack.Name + suffix
 					found := false
 					for _, cand := range drmAsset.Groups[tc.groupIdx].Tracks {
 						if cand.Name == protectedName {

--- a/internal/asset_test.go
+++ b/internal/asset_test.go
@@ -107,20 +107,27 @@ func TestLoadAsset(t *testing.T) {
 		}
 	}
 
-	// Check that video tracks are in bitrate order (ascending)
+	// Check that video tracks are sorted by codec (avc before hvc) then by bitrate ascending
+	var videoCodecs []string
 	var videoBitrates []int
 	var videoNames []string
 	for _, group := range asset.Groups {
 		if len(group.Tracks) > 0 && group.Tracks[0].ContentType == "video" {
 			for _, track := range group.Tracks {
+				videoCodecs = append(videoCodecs, track.SpecData.Codec())
 				videoBitrates = append(videoBitrates, int(track.SampleBitrate))
 				videoNames = append(videoNames, track.Name)
 			}
 		}
 	}
 	for i := 1; i < len(videoBitrates); i++ {
-		require.LessOrEqual(t, videoBitrates[i-1], videoBitrates[i],
-			"video tracks not in bitrate order: got %v (%v)", videoBitrates, videoNames)
+		if videoCodecs[i-1] == videoCodecs[i] {
+			require.LessOrEqual(t, videoBitrates[i-1], videoBitrates[i],
+				"video tracks not in bitrate order within codec: got %v (%v)", videoBitrates, videoNames)
+		} else {
+			require.LessOrEqual(t, videoCodecs[i-1], videoCodecs[i],
+				"video tracks not in codec order: got %v (%v)", videoCodecs, videoNames)
+		}
 	}
 
 	// Check that video group has a lower altGroupID than audio group

--- a/internal/asset_test.go
+++ b/internal/asset_test.go
@@ -167,7 +167,7 @@ func TestCreateProtectedTracksDoesNotMutateOriginalTrackInit(t *testing.T) {
 	kidStr := "39112233445566778899aabbccddeeff"
 	keyStr := "40112233445566778899aabbccddeeff"
 	ivStr := "41112233445566778899aabbccddeeff"
-	drm, err := ParseCENCflags("cenc", kidStr, keyStr, ivStr, 8081)
+	drm, err := ParseCENCflags("cenc", kidStr, keyStr, ivStr, "http://localhost:8081/clearkey")
 	require.NoError(t, err)
 
 	err = createProtectedTracks(tracksByType, drm, "_drm", ProtectionDRM)
@@ -249,7 +249,7 @@ func TestClearKeyDecryptionMatchExcatly(t *testing.T) {
 	ivStr := "41112233445566778899aabbccddeeff"
 	schemes := []string{"cbcs", "cenc"}
 	for _, scheme := range schemes {
-		eccp, err := ParseCENCflags(scheme, kidStr, keyStr, ivStr, 8081)
+		eccp, err := ParseCENCflags(scheme, kidStr, keyStr, ivStr, "http://localhost:8081/clearkey")
 		require.NoError(t, err)
 		checkDecryptedTracksMatchExactly(t, eccp, "_eccp")
 	}

--- a/internal/asset_test.go
+++ b/internal/asset_test.go
@@ -153,7 +153,7 @@ func TestLoadAsset(t *testing.T) {
 				"loop duration should be 10s in timescale")
 		}
 	}
-	cat, err := asset.GenCMAFCatalogEntry("cmsf/clear", ProtectionNone,1234567890000)
+	cat, err := asset.GenCMAFCatalogEntry("cmsf/clear", ProtectionNone, 1234567890000)
 	require.NoError(t, err)
 	require.NotNil(t, cat)
 	require.Equal(t, 12, len(cat.Tracks))

--- a/internal/batch_test.go
+++ b/internal/batch_test.go
@@ -148,7 +148,7 @@ func TestLoadAssetWithBatch(t *testing.T) {
 			}
 
 			// Test that the catalog bitrates are calculated correctly based on batch size
-			catalog, err := asset.GenCMAFCatalogEntry("cmsf/clear", ProtectionNone,1234567890000)
+			catalog, err := asset.GenCMAFCatalogEntry("cmsf/clear", ProtectionNone, 1234567890000)
 			require.NoError(t, err)
 			require.NotNil(t, catalog)
 

--- a/internal/batch_test.go
+++ b/internal/batch_test.go
@@ -148,7 +148,7 @@ func TestLoadAssetWithBatch(t *testing.T) {
 			}
 
 			// Test that the catalog bitrates are calculated correctly based on batch size
-			catalog, err := asset.GenCMAFCatalogEntry(1234567890000)
+			catalog, err := asset.GenCMAFCatalogEntry("cmsf/clear", ProtectionNone,1234567890000)
 			require.NoError(t, err)
 			require.NotNil(t, catalog)
 

--- a/internal/const.go
+++ b/internal/const.go
@@ -1,6 +1,5 @@
 package internal
 
 const (
-	Namespace     = "moqlivemock"
 	MoqGroupDurMS = 1000
 )

--- a/internal/drm.go
+++ b/internal/drm.go
@@ -102,12 +102,13 @@ func ConfigureDRMFromFile(configpath string) (*DRMInfo, error) {
 
 // ParseCENCflags converts the string CENC-related parameters into a ClearKey-compliant *DRMInfo struct.
 // If all flags are empty (except scheme) nil is returned.
-func ParseCENCflags(scheme, kidStr, keyStr, ivStr string, fingerprintPort int) (*DRMInfo, error) {
+// The laURL parameter is the license acquisition URL announced in the catalog.
+func ParseCENCflags(scheme, kidStr, keyStr, ivStr, laURL string) (*DRMInfo, error) {
 	if kidStr == "" && keyStr == "" && ivStr == "" {
 		return nil, nil
 	}
-	if fingerprintPort <= 0 {
-		return nil, fmt.Errorf("invalid or non-configured fingerprintport: %d", fingerprintPort)
+	if laURL == "" {
+		return nil, fmt.Errorf("laurl must be configured for ClearKey/ECCP encryption")
 	}
 
 	kid, err := mp4.UnpackKey(kidStr)
@@ -156,7 +157,7 @@ func ParseCENCflags(scheme, kidStr, keyStr, ivStr string, fingerprintPort int) (
 		iv:  iv,
 	}
 	license := &DRMService{
-		URL:  fmt.Sprintf("http://localhost:%d/clearkey", fingerprintPort),
+		URL:  laURL,
 		Type: "EME-1.0",
 	}
 	sw := bits.NewFixedSliceWriter(int(psshBox.Size()))

--- a/internal/integration_test.go
+++ b/internal/integration_test.go
@@ -87,7 +87,7 @@ func loadTestAsset(t *testing.T) (*internal.Asset, *internal.Catalog) {
 	err = asset.AddSubtitleTracks([]string{"en"}, nil)
 	require.NoError(t, err)
 
-	catalog, err := asset.GenCMAFCatalogEntry("cmsf/clear", internal.ProtectionNone,time.Now().UnixMilli())
+	catalog, err := asset.GenCMAFCatalogEntry("cmsf/clear", internal.ProtectionNone, time.Now().UnixMilli())
 	require.NoError(t, err)
 
 	return asset, catalog

--- a/internal/integration_test.go
+++ b/internal/integration_test.go
@@ -87,24 +87,27 @@ func loadTestAsset(t *testing.T) (*internal.Asset, *internal.Catalog) {
 	err = asset.AddSubtitleTracks([]string{"en"}, nil)
 	require.NoError(t, err)
 
-	catalog, err := asset.GenCMAFCatalogEntry(time.Now().UnixMilli())
+	catalog, err := asset.GenCMAFCatalogEntry("cmsf/clear", internal.ProtectionNone,time.Now().UnixMilli())
 	require.NoError(t, err)
 
 	return asset, catalog
 }
 
+const testNamespace = "cmsf/clear"
+
 func newPubHandler(asset *internal.Asset, catalog *internal.Catalog) *pub.Handler {
 	return &pub.Handler{
-		Namespace: []string{internal.Namespace},
-		Asset:     asset,
-		Catalog:   catalog,
-		Logfh:     io.Discard,
+		Namespaces: []pub.NamespaceEntry{
+			{Namespace: []string{testNamespace}, Catalog: catalog},
+		},
+		Asset: asset,
+		Logfh: io.Discard,
 	}
 }
 
 func newSubHandler(outs map[string]io.Writer) *sub.Handler {
 	return &sub.Handler{
-		Namespace: []string{internal.Namespace},
+		Namespace: []string{testNamespace},
 		Outs:      outs,
 		Logfh:     io.Discard,
 		VideoName: "_avc",
@@ -152,7 +155,7 @@ func TestFetchCatalog(t *testing.T) {
 
 		catalogBuf := newSyncBuffer()
 		sh := &sub.Handler{
-			Namespace: []string{internal.Namespace},
+			Namespace: []string{testNamespace},
 			Outs:      map[string]io.Writer{"catalog": catalogBuf},
 			Logfh:     io.Discard,
 			VideoName: "NONE",
@@ -205,7 +208,7 @@ func TestSubtitleReceive(t *testing.T) {
 
 		subsBuf := newSyncBuffer()
 		sh := &sub.Handler{
-			Namespace: []string{internal.Namespace},
+			Namespace: []string{testNamespace},
 			Outs:      map[string]io.Writer{"subs": subsBuf},
 			Logfh:     io.Discard,
 			VideoName: "NONE",

--- a/internal/memconn_test.go
+++ b/internal/memconn_test.go
@@ -149,7 +149,7 @@ type memConn struct {
 	cancel      context.CancelFunc
 	cancelPeer  context.CancelFunc
 	peer        *memConn
-	biAccept    chan moqtransport.Stream       // peer-opened bidirectional streams
+	biAccept    chan moqtransport.Stream        // peer-opened bidirectional streams
 	uniAccept   chan moqtransport.ReceiveStream // peer-opened unidirectional streams
 	streamID    atomic.Uint64
 
@@ -292,9 +292,9 @@ type memStream struct {
 func (s *memStream) Read(p []byte) (int, error)  { return s.r.Read(p) }
 func (s *memStream) Write(p []byte) (int, error) { return s.w.Write(p) }
 func (s *memStream) Close() error                { return s.w.Close() }
-func (s *memStream) Stop(uint32)                  { _ = s.r.CloseWithError(io.EOF) }
-func (s *memStream) Reset(uint32)                 { _ = s.w.CloseWithError(io.ErrClosedPipe) }
-func (s *memStream) StreamID() uint64             { return s.id }
+func (s *memStream) Stop(uint32)                 { _ = s.r.CloseWithError(io.EOF) }
+func (s *memStream) Reset(uint32)                { _ = s.w.CloseWithError(io.ErrClosedPipe) }
+func (s *memStream) StreamID() uint64            { return s.id }
 
 // memSendStream implements moqtransport.SendStream (write-only).
 type memSendStream struct {
@@ -304,8 +304,8 @@ type memSendStream struct {
 
 func (s *memSendStream) Write(p []byte) (int, error) { return s.w.Write(p) }
 func (s *memSendStream) Close() error                { return s.w.Close() }
-func (s *memSendStream) Reset(uint32)                 { _ = s.w.CloseWithError(io.ErrClosedPipe) }
-func (s *memSendStream) StreamID() uint64             { return s.id }
+func (s *memSendStream) Reset(uint32)                { _ = s.w.CloseWithError(io.ErrClosedPipe) }
+func (s *memSendStream) StreamID() uint64            { return s.id }
 
 // memReceiveStream implements moqtransport.ReceiveStream (read-only).
 type memReceiveStream struct {
@@ -314,5 +314,5 @@ type memReceiveStream struct {
 }
 
 func (s *memReceiveStream) Read(p []byte) (int, error) { return s.r.Read(p) }
-func (s *memReceiveStream) Stop(uint32)                 { _ = s.r.CloseWithError(io.EOF) }
-func (s *memReceiveStream) StreamID() uint64            { return s.id }
+func (s *memReceiveStream) Stop(uint32)                { _ = s.r.CloseWithError(io.EOF) }
+func (s *memReceiveStream) StreamID() uint64           { return s.id }

--- a/internal/pub/pub.go
+++ b/internal/pub/pub.go
@@ -17,16 +17,21 @@ const (
 	MediaPriority = 128
 )
 
-// Handler handles MoQ publisher sessions. It serves a catalog and publishes
-// media tracks (video, audio, subtitles) to subscribers.
-type Handler struct {
+// NamespaceEntry pairs an announcement namespace with its catalog.
+type NamespaceEntry struct {
 	Namespace []string
-	Asset     *internal.Asset
 	Catalog   *internal.Catalog
-	Logfh     io.Writer
 }
 
-// Handle runs a MoQ session on the given connection, announces the namespace,
+// Handler handles MoQ publisher sessions. It serves catalogs and publishes
+// media tracks (video, audio, subtitles) to subscribers across multiple namespaces.
+type Handler struct {
+	Namespaces []NamespaceEntry
+	Asset      *internal.Asset
+	Logfh      io.Writer
+}
+
+// Handle runs a MoQ session on the given connection, announces all namespaces,
 // and serves subscriptions. The context controls the lifetime of publishing goroutines.
 func (h *Handler) Handle(ctx context.Context, conn moqtransport.Connection) {
 	session := &moqtransport.Session{
@@ -46,12 +51,14 @@ func (h *Handler) Handle(ctx context.Context, conn moqtransport.Connection) {
 		}
 		return
 	}
-	slog.Info("MoQ session established, announcing namespace", "namespace", h.Namespace)
-	if err := session.Announce(ctx, h.Namespace); err != nil {
-		slog.Error("failed to announce namespace", "namespace", h.Namespace, "error", err)
-		return
+	for _, ns := range h.Namespaces {
+		slog.Info("announcing namespace", "namespace", ns.Namespace)
+		if err := session.Announce(ctx, ns.Namespace); err != nil {
+			slog.Error("failed to announce namespace", "namespace", ns.Namespace, "error", err)
+			return
+		}
+		slog.Info("namespace announced successfully", "namespace", ns.Namespace)
 	}
-	slog.Info("namespace announced successfully", "namespace", h.Namespace)
 	// Block until context is cancelled to keep the session alive
 	<-ctx.Done()
 }
@@ -70,13 +77,22 @@ func (h *Handler) getHandler() moqtransport.Handler {
 	})
 }
 
+// findNamespace returns the NamespaceEntry matching the given namespace tuple, or nil.
+func (h *Handler) findNamespace(ns []string) *NamespaceEntry {
+	for i := range h.Namespaces {
+		if tupleEqual(ns, h.Namespaces[i].Namespace) {
+			return &h.Namespaces[i]
+		}
+	}
+	return nil
+}
+
 func (h *Handler) getFetchHandler() moqtransport.FetchHandler {
 	return moqtransport.FetchHandlerFunc(
 		func(w *moqtransport.FetchResponseWriter, m *moqtransport.FetchMessage) {
-			if !tupleEqual(m.Namespace, h.Namespace) {
-				slog.Warn("fetch: unexpected namespace",
-					"received", m.Namespace,
-					"expected", h.Namespace)
+			nsEntry := h.findNamespace(m.Namespace)
+			if nsEntry == nil {
+				slog.Warn("fetch: unknown namespace", "received", m.Namespace)
 				err := w.Reject(uint64(moqtransport.ErrorCodeFetchTrackDoesNotExist), "non-matching namespace")
 				if err != nil {
 					slog.Error("failed to reject fetch", "error", err)
@@ -100,7 +116,7 @@ func (h *Handler) getFetchHandler() moqtransport.FetchHandler {
 				slog.Error("failed to get fetch stream", "error", err)
 				return
 			}
-			catalogJSON, err := json.Marshal(h.Catalog)
+			catalogJSON, err := json.Marshal(nsEntry.Catalog)
 			if err != nil {
 				slog.Error("failed to marshal catalog", "error", err)
 				return
@@ -115,17 +131,16 @@ func (h *Handler) getFetchHandler() moqtransport.FetchHandler {
 				slog.Error("failed to close fetch stream", "error", err)
 				return
 			}
-			slog.Info("served catalog via FETCH")
+			slog.Info("served catalog via FETCH", "namespace", m.Namespace)
 		})
 }
 
 func (h *Handler) getSubscribeHandler(ctx context.Context) moqtransport.SubscribeHandler {
 	return moqtransport.SubscribeHandlerFunc(
 		func(w *moqtransport.SubscribeResponseWriter, m *moqtransport.SubscribeMessage) {
-			if !tupleEqual(m.Namespace, h.Namespace) {
-				slog.Warn("got unexpected subscription namespace",
-					"received", m.Namespace,
-					"expected", h.Namespace)
+			nsEntry := h.findNamespace(m.Namespace)
+			if nsEntry == nil {
+				slog.Warn("got unexpected subscription namespace", "received", m.Namespace)
 				err := w.Reject(0, "non-matching namespace")
 				if err != nil {
 					slog.Error("failed to reject subscription", "error", err)
@@ -143,7 +158,7 @@ func (h *Handler) getSubscribeHandler(ctx context.Context) moqtransport.Subscrib
 					slog.Error("failed to open subgroup", "error", err)
 					return
 				}
-				json, err := json.Marshal(h.Catalog)
+				json, err := json.Marshal(nsEntry.Catalog)
 				if err != nil {
 					slog.Error("failed to marshal catalog", "error", err)
 					return
@@ -167,20 +182,20 @@ func (h *Handler) getSubscribeHandler(ctx context.Context) moqtransport.Subscrib
 					slog.Error("failed to accept subscription", "error", err)
 					return
 				}
-				slog.Info("got subtitle subscription", "track", st.Name)
+				slog.Info("got subtitle subscription", "track", st.Name, "namespace", m.Namespace)
 				go PublishSubtitleTrack(ctx, w, st)
 				return
 			}
 
-			// Check for video/audio tracks
-			for _, track := range h.Catalog.Tracks {
+			// Check for video/audio tracks in this namespace's catalog
+			for _, track := range nsEntry.Catalog.Tracks {
 				if m.Track == track.Name {
 					err := w.Accept()
 					if err != nil {
 						slog.Error("failed to accept subscription", "error", err)
 						return
 					}
-					slog.Info("got subscription", "track", track.Name)
+					slog.Info("got subscription", "track", track.Name, "namespace", m.Namespace)
 					go PublishTrack(ctx, w, h.Asset, track.Name)
 					return
 				}

--- a/internal/version.go
+++ b/internal/version.go
@@ -8,8 +8,8 @@ import (
 )
 
 var (
-	commitVersion string = "0.5.0"      // Should be updated during build
-	commitDate    string = "1737936000" // commitDate in Epoch seconds (can be filled/updated in during build)
+	commitVersion string = "0.6.0"      // Should be updated during build
+	commitDate    string = "1744329600" // commitDate in Epoch seconds (can be filled/updated in during build)
 )
 
 // GetVersion - get version, commitHash and  commitDate depending on what is inserted


### PR DESCRIPTION
## Summary
- Announce multiple namespaces: `cmsf/clear` (always), `cmsf/drm-{scheme}` (CPIX), `cmsf/eccp-{scheme}` (ClearKey)
- Independent encryption keys for DRM and ECCP tracks (`_drm` and `_eccp` suffixes)
- Add `-laurl` flag for external ClearKey license URL (for reverse proxy deployments)
- Rename `-fingerprintport` to `-sideport` (serves `/fingerprint` and `/clearkey`)
- Sort video tracks AVC before HEVC for Widevine compatibility
- Update README and CLAUDE.md with new configuration

## Test plan
- [x] All existing tests pass
- [x] Run with ECCP only: `-kid ... -iv ... -scheme cbcs -sideport 8081`
- [x] Run with DRM only: `-drmpath config.json`
- [x] Run with both: `-drmpath config.json -kid ... -iv ... -scheme cbcs -sideport 8081 -laurl https://example.com/clearkey`
- [x] Verify three namespaces announced and each catalog contains correct tracks