### PR TITLE
feat: draft-16 support with dual-draft interop testing

### DIFF
--- a/.github/workflows/docker-mlmtest.yml
+++ b/.github/workflows/docker-mlmtest.yml
@@ -1,0 +1,47 @@
+name: Docker mlmtest
+
+on:
+  push:
+    branches: [main]
+    tags: ["v*"]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Log in to GHCR
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/eyevinn/mlmtest
+          tags: |
+            type=ref,event=branch
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=sha
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: Dockerfile.mlmtest
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,6 +24,7 @@ go mod vendor               # Vendor dependencies
 
 - `cmd/mlmpub/` - Publisher application serving media tracks (video, audio, subtitles)
 - `cmd/mlmsub/` - Subscriber application receiving media
+- `cmd/mlmtest/` - Interop test client for [moq-interop-runner](https://github.com/englishm/moq-interop-runner)
 - `internal/` - Shared internal packages:
   - `asset.go` - Asset loading and track management
   - `catalog.go` - MSF/CMSF catalog generation
@@ -107,6 +108,34 @@ Video tracks use `avc1` (H.264) and `hvc1` (HEVC) sample descriptors. These stor
 parameter sets (SPS/PPS for AVC, VPS/SPS/PPS for HEVC) in the init segment rather
 than inlining them in each sample. This is required for FairPlay DRM compatibility
 in Safari 26.4+.
+
+### Interop Testing (mlmtest)
+
+`mlmtest` is an interop test client for [moq-interop-runner](https://github.com/englishm/moq-interop-runner).
+It connects to a relay as a MoQ draft-16 client and runs protocol-level test cases, outputting TAP v14 results.
+
+**Test cases:**
+1. `setup-only` — connect, exchange SETUP, close
+2. `announce-only` — PUBLISH_NAMESPACE, wait for REQUEST_OK, close
+3. `publish-namespace-done` — PUBLISH_NAMESPACE, REQUEST_OK, PUBLISH_NAMESPACE_DONE, close
+4. `subscribe-error` — SUBSCRIBE to non-existent track, expect REQUEST_ERROR
+5. `announce-subscribe` — publisher announces, subscriber subscribes via relay
+6. `subscribe-before-announce` — subscriber subscribes first, publisher announces 500ms later
+
+**Usage:**
+```bash
+# Run all tests against a relay
+go run ./cmd/mlmtest -r moqt://relay:443 -tls-disable-verify
+
+# Run a specific test
+go run ./cmd/mlmtest -r moqt://relay:443 -t setup-only
+
+# List available tests
+go run ./cmd/mlmtest -l
+
+# Environment variables (used by moq-interop-runner)
+RELAY_URL=moqt://relay:443 TESTCASE=setup-only TLS_DISABLE_VERIFY=1 go run ./cmd/mlmtest
+```
 
 ## Testing
 

--- a/Dockerfile.mlmtest
+++ b/Dockerfile.mlmtest
@@ -1,0 +1,10 @@
+FROM golang:1.25 AS build
+WORKDIR /src
+COPY go.mod go.sum ./
+RUN go mod download
+COPY . .
+RUN CGO_ENABLED=0 go build -o /mlmtest ./cmd/mlmtest
+
+FROM gcr.io/distroless/static-debian12
+COPY --from=build /mlmtest /mlmtest
+ENTRYPOINT ["/mlmtest"]

--- a/cmd/mlmpub/handler.go
+++ b/cmd/mlmpub/handler.go
@@ -76,11 +76,15 @@ func (s *server) runServer(ctx context.Context) error {
 		if err != nil {
 			return err
 		}
-		if conn.ConnectionState().TLS.NegotiatedProtocol == "h3" {
+		alpn := conn.ConnectionState().TLS.NegotiatedProtocol
+		switch alpn {
+		case "h3":
 			go serveQUICConn(&wt, conn)
-		}
-		if conn.ConnectionState().TLS.NegotiatedProtocol == "moq-00" {
+		case "moq-00", "moqt-16":
 			go s.handler.Handle(ctx, quicmoq.NewServer(conn))
+		default:
+			slog.Warn("unknown ALPN, closing connection", "alpn", alpn)
+			conn.CloseWithError(0, "unsupported protocol")
 		}
 	}
 }

--- a/cmd/mlmpub/handler.go
+++ b/cmd/mlmpub/handler.go
@@ -61,6 +61,7 @@ func (s *server) runServer(ctx context.Context) error {
 		CheckOrigin: func(r *http.Request) bool {
 			return true
 		},
+		ApplicationProtocols: []string{"moqt-16", "moq-00"},
 	}
 	http.HandleFunc("/moq", func(w http.ResponseWriter, r *http.Request) {
 		session, err := wt.Upgrade(w, r)
@@ -84,7 +85,7 @@ func (s *server) runServer(ctx context.Context) error {
 			go s.handler.Handle(ctx, quicmoq.NewServer(conn))
 		default:
 			slog.Warn("unknown ALPN, closing connection", "alpn", alpn)
-			conn.CloseWithError(0, "unsupported protocol")
+			_ = conn.CloseWithError(0, "unsupported protocol")
 		}
 	}
 }

--- a/cmd/mlmpub/main.go
+++ b/cmd/mlmpub/main.go
@@ -275,7 +275,7 @@ func generateTLSConfigWithCertAndKey(certFile, keyFile string) (*tls.Config, err
 	}
 	return &tls.Config{
 		Certificates: []tls.Certificate{cert},
-		NextProtos:   []string{"moq-00", "h3"},
+		NextProtos:   []string{"moqt-16", "moq-00", "h3"},
 	}, nil
 }
 
@@ -346,6 +346,6 @@ func generateTLSConfig() (*tls.Config, error) {
 
 	return &tls.Config{
 		Certificates: []tls.Certificate{tlsCert},
-		NextProtos:   []string{"moq-00", "h3"},
+		NextProtos:   []string{"moqt-16", "moq-00", "h3"},
 	}, nil
 }

--- a/cmd/mlmsub/handler.go
+++ b/cmd/mlmsub/handler.go
@@ -21,7 +21,7 @@ func runClientWithDial(
 	var conn moqtransport.Connection
 	var err error
 	if useWebTransport {
-		conn, err = dialWebTransport(ctx, addr)
+		conn, err = dialWebTransport(ctx, addr, alpn)
 	} else {
 		conn, err = dialQUIC(ctx, addr, alpn)
 	}
@@ -66,7 +66,7 @@ func dialQUIC(ctx context.Context, addr string, alpn string) (moqtransport.Conne
 	return quicmoq.NewClient(conn), nil
 }
 
-func dialWebTransport(ctx context.Context, addr string) (moqtransport.Connection, error) {
+func dialWebTransport(ctx context.Context, addr string, alpn string) (moqtransport.Connection, error) {
 	dialer := webtransport.Dialer{
 		TLSClientConfig: &tls.Config{
 			InsecureSkipVerify: true,
@@ -75,6 +75,7 @@ func dialWebTransport(ctx context.Context, addr string) (moqtransport.Connection
 			EnableDatagrams:                  true,
 			EnableStreamResetPartialDelivery: true,
 		},
+		ApplicationProtocols: []string{alpn},
 	}
 	_, session, err := dialer.Dial(ctx, ensureURLPort(addr, "443"), nil)
 	if err != nil {

--- a/cmd/mlmsub/handler.go
+++ b/cmd/mlmsub/handler.go
@@ -16,14 +16,14 @@ import (
 )
 
 func runClientWithDial(
-	ctx context.Context, addr string, useWebTransport bool, h *sub.Handler, outs map[string]io.Writer,
+	ctx context.Context, addr string, useWebTransport bool, alpn string, h *sub.Handler, outs map[string]io.Writer,
 ) error {
 	var conn moqtransport.Connection
 	var err error
 	if useWebTransport {
 		conn, err = dialWebTransport(ctx, addr)
 	} else {
-		conn, err = dialQUIC(ctx, addr)
+		conn, err = dialQUIC(ctx, addr, alpn)
 	}
 	if err != nil {
 		return err
@@ -51,11 +51,11 @@ func ensureURLPort(rawURL, defaultPort string) string {
 	return rawURL
 }
 
-func dialQUIC(ctx context.Context, addr string) (moqtransport.Connection, error) {
+func dialQUIC(ctx context.Context, addr string, alpn string) (moqtransport.Connection, error) {
 	addr = ensurePort(addr, "443")
 	conn, err := quic.DialAddr(ctx, addr, &tls.Config{
 		InsecureSkipVerify: true,
-		NextProtos:         []string{"moq-00"},
+		NextProtos:         []string{alpn},
 	}, &quic.Config{
 		EnableDatagrams:                  true,
 		EnableStreamResetPartialDelivery: true,

--- a/cmd/mlmsub/main.go
+++ b/cmd/mlmsub/main.go
@@ -39,6 +39,7 @@ type options struct {
 	addr         string
 	trackname    string
 	duration     int
+	draft        int
 	muxout       string
 	videoOut     string
 	audioOut     string
@@ -78,6 +79,7 @@ func parseOptions(fs *flag.FlagSet, args []string) (*options, error) {
 	fs.StringVar(&opts.namespace, "namespace", "cmsf/clear", "MoQ namespace to use")
 	fs.StringVar(&opts.loglevel, "loglevel", "info", "Log level: debug, info, warning, error")
 	fs.BoolVar(&opts.fetchCatalog, "fetchcatalog", false, "Use FETCH instead of SUBSCRIBE for catalog")
+	fs.IntVar(&opts.draft, "draft", 14, "MoQ Transport draft version (14 or 16)")
 
 	err := fs.Parse(args[1:])
 	return &opts, err
@@ -200,5 +202,13 @@ func runClient(ctx context.Context, opts *options) error {
 		}
 	}
 
-	return runClientWithDial(ctx, opts.addr, useWebTransport, h, outs)
+	var alpn string
+	switch opts.draft {
+	case 16:
+		alpn = "moqt-16"
+	default:
+		alpn = "moq-00"
+	}
+
+	return runClientWithDial(ctx, opts.addr, useWebTransport, alpn, h, outs)
 }

--- a/cmd/mlmtest/main.go
+++ b/cmd/mlmtest/main.go
@@ -1,0 +1,225 @@
+// mlmtest is an interop test client for the MoQ interop runner.
+// It implements the 6 test cases defined in moq-interop-runner and
+// outputs TAP v14 results on stdout.
+package main
+
+import (
+	"context"
+	"crypto/tls"
+	"flag"
+	"fmt"
+	"net"
+	"net/url"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/Eyevinn/moqlivemock/internal"
+	"github.com/Eyevinn/moqtransport"
+	"github.com/Eyevinn/moqtransport/quicmoq"
+	"github.com/quic-go/quic-go"
+)
+
+const defaultTimeout = 5 * time.Second
+
+type testCase struct {
+	name string
+	fn   func(ctx context.Context, relay string, tlsSkipVerify bool) error
+}
+
+var testCases = []testCase{
+	{"setup-only", testSetupOnly},
+	{"announce-only", testAnnounceOnly},
+	{"publish-namespace-done", testPublishNamespaceDone},
+	{"subscribe-error", testSubscribeError},
+}
+
+func main() {
+	relay := flag.String("r", "", "Relay URL (moqt:// for QUIC)")
+	test := flag.String("t", "", "Specific test to run (default: all)")
+	list := flag.Bool("l", false, "List available tests")
+	tlsSkipVerify := flag.Bool("tls-disable-verify", false, "Skip TLS verification")
+	flag.Parse()
+
+	// Environment variable overrides
+	if env := os.Getenv("RELAY_URL"); env != "" && *relay == "" {
+		*relay = env
+	}
+	if env := os.Getenv("TESTCASE"); env != "" && *test == "" {
+		*test = env
+	}
+	if os.Getenv("TLS_DISABLE_VERIFY") == "1" {
+		*tlsSkipVerify = true
+	}
+
+	if *list {
+		for _, tc := range testCases {
+			fmt.Println(tc.name)
+		}
+		os.Exit(0)
+	}
+
+	if *relay == "" {
+		fmt.Fprintf(os.Stderr, "Error: relay URL required (-r or RELAY_URL env)\n")
+		os.Exit(1)
+	}
+
+	// Select tests to run
+	cases := testCases
+	if *test != "" {
+		cases = nil
+		for _, tc := range testCases {
+			if tc.name == *test {
+				cases = append(cases, tc)
+				break
+			}
+		}
+		if len(cases) == 0 {
+			fmt.Fprintf(os.Stderr, "Unknown test case: %s\n", *test)
+			os.Exit(127)
+		}
+	}
+
+	// TAP v14 output
+	fmt.Println("TAP version 14")
+	fmt.Printf("# moqlivemock %s\n", internal.GetVersion())
+	fmt.Printf("# Relay: %s\n", *relay)
+	fmt.Printf("1..%d\n", len(cases))
+
+	failed := 0
+	for i, tc := range cases {
+		ctx, cancel := context.WithTimeout(context.Background(), defaultTimeout)
+		err := tc.fn(ctx, *relay, *tlsSkipVerify)
+		cancel()
+
+		num := i + 1
+		if err != nil {
+			fmt.Printf("not ok %d - %s\n", num, tc.name)
+			fmt.Printf("  ---\n  error: %v\n  ...\n", err)
+			failed++
+		} else {
+			fmt.Printf("ok %d - %s\n", num, tc.name)
+		}
+	}
+
+	if failed > 0 {
+		os.Exit(1)
+	}
+}
+
+// dial connects to the relay using raw QUIC with moqt-16 ALPN.
+func dial(ctx context.Context, relay string, tlsSkipVerify bool) (moqtransport.Connection, error) {
+	u, err := url.Parse(relay)
+	if err != nil {
+		return nil, fmt.Errorf("parse relay URL: %w", err)
+	}
+
+	addr := u.Host
+	if u.Port() == "" {
+		addr = net.JoinHostPort(u.Hostname(), "443")
+	}
+
+	conn, err := quic.DialAddr(ctx, addr, &tls.Config{
+		InsecureSkipVerify: tlsSkipVerify,
+		NextProtos:         []string{"moqt-16"},
+	}, &quic.Config{
+		EnableDatagrams:                  true,
+		EnableStreamResetPartialDelivery: true,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("QUIC dial: %w", err)
+	}
+	return quicmoq.NewClient(conn), nil
+}
+
+// runSession creates a session with a no-op handler, runs it, and returns it.
+func runSession(ctx context.Context, conn moqtransport.Connection) (*moqtransport.Session, error) {
+	s := &moqtransport.Session{
+		InitialMaxRequestID: 64,
+		Handler: moqtransport.HandlerFunc(func(w moqtransport.ResponseWriter, r *moqtransport.Message) {
+			// Accept announcements from relay
+			if r.Method == moqtransport.MessageAnnounce {
+				_ = w.Accept()
+			}
+		}),
+	}
+	if err := s.Run(conn); err != nil {
+		return nil, fmt.Errorf("session setup: %w", err)
+	}
+	return s, nil
+}
+
+// testSetupOnly: connect, exchange SETUP, close.
+func testSetupOnly(ctx context.Context, relay string, tlsSkipVerify bool) error {
+	conn, err := dial(ctx, relay, tlsSkipVerify)
+	if err != nil {
+		return err
+	}
+	s, err := runSession(ctx, conn)
+	if err != nil {
+		return err
+	}
+	s.Close()
+	return nil
+}
+
+// testAnnounceOnly: setup, PUBLISH_NAMESPACE, wait for REQUEST_OK, close.
+func testAnnounceOnly(ctx context.Context, relay string, tlsSkipVerify bool) error {
+	conn, err := dial(ctx, relay, tlsSkipVerify)
+	if err != nil {
+		return err
+	}
+	s, err := runSession(ctx, conn)
+	if err != nil {
+		return err
+	}
+	if err := s.Announce(ctx, []string{"moq-test", "interop"}); err != nil {
+		return fmt.Errorf("PUBLISH_NAMESPACE: %w", err)
+	}
+	s.Close()
+	return nil
+}
+
+// testPublishNamespaceDone: setup, PUBLISH_NAMESPACE, REQUEST_OK, PUBLISH_NAMESPACE_DONE, close.
+func testPublishNamespaceDone(ctx context.Context, relay string, tlsSkipVerify bool) error {
+	conn, err := dial(ctx, relay, tlsSkipVerify)
+	if err != nil {
+		return err
+	}
+	s, err := runSession(ctx, conn)
+	if err != nil {
+		return err
+	}
+	if err := s.Announce(ctx, []string{"moq-test", "interop"}); err != nil {
+		return fmt.Errorf("PUBLISH_NAMESPACE: %w", err)
+	}
+	if err := s.Unannounce(ctx, []string{"moq-test", "interop"}); err != nil {
+		return fmt.Errorf("PUBLISH_NAMESPACE_DONE: %w", err)
+	}
+	s.Close()
+	return nil
+}
+
+// testSubscribeError: setup, SUBSCRIBE non-existent track, expect REQUEST_ERROR.
+func testSubscribeError(ctx context.Context, relay string, tlsSkipVerify bool) error {
+	conn, err := dial(ctx, relay, tlsSkipVerify)
+	if err != nil {
+		return err
+	}
+	s, err := runSession(ctx, conn)
+	if err != nil {
+		return err
+	}
+	_, subErr := s.Subscribe(ctx, []string{"nonexistent", "namespace"}, "test-track")
+	if subErr == nil {
+		_ = s.Close()
+		return fmt.Errorf("expected REQUEST_ERROR but got SUBSCRIBE_OK")
+	}
+	// Any error (subscribe error, timeout) is acceptable — the relay rejected the subscribe
+	if strings.Contains(subErr.Error(), "context deadline exceeded") {
+		_ = s.Close()
+		return fmt.Errorf("timed out waiting for REQUEST_ERROR")
+	}
+	_ = s.Close()
+	return nil
+}

--- a/cmd/mlmtest/main.go
+++ b/cmd/mlmtest/main.go
@@ -11,6 +11,7 @@ import (
 	"net"
 	"net/url"
 	"os"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -25,7 +26,7 @@ const defaultTimeout = 5 * time.Second
 
 type testCase struct {
 	name string
-	fn   func(ctx context.Context, relay string, tlsSkipVerify bool) error
+	fn   func(ctx context.Context, relay string, tlsSkipVerify bool, draft int) error
 }
 
 var testCases = []testCase{
@@ -42,6 +43,7 @@ func main() {
 	test := flag.String("t", "", "Specific test to run (default: all)")
 	list := flag.Bool("l", false, "List available tests")
 	tlsSkipVerify := flag.Bool("tls-disable-verify", false, "Skip TLS verification")
+	draft := flag.Int("draft", 16, "MoQ Transport draft version (14 or 16)")
 	flag.Parse()
 
 	// Environment variable overrides
@@ -53,6 +55,15 @@ func main() {
 	}
 	if os.Getenv("TLS_DISABLE_VERIFY") == "1" {
 		*tlsSkipVerify = true
+	}
+	if env := os.Getenv("DRAFT"); env != "" {
+		if d, err := strconv.Atoi(env); err == nil {
+			*draft = d
+		}
+	}
+	if *draft != 14 && *draft != 16 {
+		fmt.Fprintf(os.Stderr, "Error: draft must be 14 or 16, got %d\n", *draft)
+		os.Exit(1)
 	}
 
 	if *list {
@@ -83,16 +94,26 @@ func main() {
 		}
 	}
 
+	// Select ALPN based on draft
+	var alpn string
+	switch *draft {
+	case 14:
+		alpn = "moq-00"
+	default:
+		alpn = "moqt-16"
+	}
+
 	// TAP v14 output
 	fmt.Println("TAP version 14")
 	fmt.Printf("# moqlivemock %s\n", internal.GetVersion())
 	fmt.Printf("# Relay: %s\n", *relay)
+	fmt.Printf("# Draft: %d (ALPN: %s)\n", *draft, alpn)
 	fmt.Printf("1..%d\n", len(cases))
 
 	failed := 0
 	for i, tc := range cases {
 		ctx, cancel := context.WithTimeout(context.Background(), defaultTimeout)
-		err := tc.fn(ctx, *relay, *tlsSkipVerify)
+		err := tc.fn(ctx, *relay, *tlsSkipVerify, *draft)
 		cancel()
 
 		num := i + 1
@@ -110,8 +131,8 @@ func main() {
 	}
 }
 
-// dial connects to the relay using raw QUIC with moqt-16 ALPN.
-func dial(ctx context.Context, relay string, tlsSkipVerify bool) (moqtransport.Connection, error) {
+// dial connects to the relay using raw QUIC with the appropriate ALPN for the draft.
+func dial(ctx context.Context, relay string, tlsSkipVerify bool, draft int) (moqtransport.Connection, error) {
 	u, err := url.Parse(relay)
 	if err != nil {
 		return nil, fmt.Errorf("parse relay URL: %w", err)
@@ -122,9 +143,17 @@ func dial(ctx context.Context, relay string, tlsSkipVerify bool) (moqtransport.C
 		addr = net.JoinHostPort(u.Hostname(), "443")
 	}
 
+	var alpn string
+	switch draft {
+	case 14:
+		alpn = "moq-00"
+	default:
+		alpn = "moqt-16"
+	}
+
 	conn, err := quic.DialAddr(ctx, addr, &tls.Config{
 		InsecureSkipVerify: tlsSkipVerify,
-		NextProtos:         []string{"moqt-16"},
+		NextProtos:         []string{alpn},
 	}, &quic.Config{
 		EnableDatagrams:                  true,
 		EnableStreamResetPartialDelivery: true,
@@ -136,9 +165,10 @@ func dial(ctx context.Context, relay string, tlsSkipVerify bool) (moqtransport.C
 }
 
 // runSession creates a session with a no-op handler, runs it, and returns it.
-func runSession(ctx context.Context, conn moqtransport.Connection) (*moqtransport.Session, error) {
+func runSession(ctx context.Context, conn moqtransport.Connection, draft int) (*moqtransport.Session, error) {
 	s := &moqtransport.Session{
 		InitialMaxRequestID: 64,
+
 		Handler: moqtransport.HandlerFunc(func(w moqtransport.ResponseWriter, r *moqtransport.Message) {
 			// Accept announcements from relay
 			if r.Method == moqtransport.MessageAnnounce {
@@ -153,12 +183,12 @@ func runSession(ctx context.Context, conn moqtransport.Connection) (*moqtranspor
 }
 
 // testSetupOnly: connect, exchange SETUP, close.
-func testSetupOnly(ctx context.Context, relay string, tlsSkipVerify bool) error {
-	conn, err := dial(ctx, relay, tlsSkipVerify)
+func testSetupOnly(ctx context.Context, relay string, tlsSkipVerify bool, draft int) error {
+	conn, err := dial(ctx, relay, tlsSkipVerify, draft)
 	if err != nil {
 		return err
 	}
-	s, err := runSession(ctx, conn)
+	s, err := runSession(ctx, conn, draft)
 	if err != nil {
 		return err
 	}
@@ -167,12 +197,12 @@ func testSetupOnly(ctx context.Context, relay string, tlsSkipVerify bool) error 
 }
 
 // testAnnounceOnly: setup, PUBLISH_NAMESPACE, wait for REQUEST_OK, close.
-func testAnnounceOnly(ctx context.Context, relay string, tlsSkipVerify bool) error {
-	conn, err := dial(ctx, relay, tlsSkipVerify)
+func testAnnounceOnly(ctx context.Context, relay string, tlsSkipVerify bool, draft int) error {
+	conn, err := dial(ctx, relay, tlsSkipVerify, draft)
 	if err != nil {
 		return err
 	}
-	s, err := runSession(ctx, conn)
+	s, err := runSession(ctx, conn, draft)
 	if err != nil {
 		return err
 	}
@@ -184,12 +214,12 @@ func testAnnounceOnly(ctx context.Context, relay string, tlsSkipVerify bool) err
 }
 
 // testPublishNamespaceDone: setup, PUBLISH_NAMESPACE, REQUEST_OK, PUBLISH_NAMESPACE_DONE, close.
-func testPublishNamespaceDone(ctx context.Context, relay string, tlsSkipVerify bool) error {
-	conn, err := dial(ctx, relay, tlsSkipVerify)
+func testPublishNamespaceDone(ctx context.Context, relay string, tlsSkipVerify bool, draft int) error {
+	conn, err := dial(ctx, relay, tlsSkipVerify, draft)
 	if err != nil {
 		return err
 	}
-	s, err := runSession(ctx, conn)
+	s, err := runSession(ctx, conn, draft)
 	if err != nil {
 		return err
 	}
@@ -204,12 +234,12 @@ func testPublishNamespaceDone(ctx context.Context, relay string, tlsSkipVerify b
 }
 
 // testSubscribeError: setup, SUBSCRIBE non-existent track, expect REQUEST_ERROR.
-func testSubscribeError(ctx context.Context, relay string, tlsSkipVerify bool) error {
-	conn, err := dial(ctx, relay, tlsSkipVerify)
+func testSubscribeError(ctx context.Context, relay string, tlsSkipVerify bool, draft int) error {
+	conn, err := dial(ctx, relay, tlsSkipVerify, draft)
 	if err != nil {
 		return err
 	}
-	s, err := runSession(ctx, conn)
+	s, err := runSession(ctx, conn, draft)
 	if err != nil {
 		return err
 	}
@@ -228,19 +258,23 @@ func testSubscribeError(ctx context.Context, relay string, tlsSkipVerify bool) e
 }
 
 // runPublisherSession creates a session that announces a namespace and accepts subscriptions.
-func runPublisherSession(ctx context.Context, relay string, tlsSkipVerify bool, namespace []string) (*moqtransport.Session, error) {
-	conn, err := dial(ctx, relay, tlsSkipVerify)
+func runPublisherSession(
+	ctx context.Context, relay string, tlsSkipVerify bool, draft int, namespace []string,
+) (*moqtransport.Session, error) {
+	conn, err := dial(ctx, relay, tlsSkipVerify, draft)
 	if err != nil {
 		return nil, err
 	}
 	s := &moqtransport.Session{
 		InitialMaxRequestID: 64,
+
 		Handler: moqtransport.HandlerFunc(func(w moqtransport.ResponseWriter, r *moqtransport.Message) {
 			if r.Method == moqtransport.MessageAnnounce {
 				_ = w.Accept()
 			}
 		}),
-		SubscribeHandler: moqtransport.SubscribeHandlerFunc(func(w *moqtransport.SubscribeResponseWriter, m *moqtransport.SubscribeMessage) {
+		SubscribeHandler: moqtransport.SubscribeHandlerFunc(
+			func(w *moqtransport.SubscribeResponseWriter, m *moqtransport.SubscribeMessage) {
 			_ = w.Accept()
 		}),
 	}
@@ -255,22 +289,22 @@ func runPublisherSession(ctx context.Context, relay string, tlsSkipVerify bool, 
 }
 
 // testAnnounceSubscribe: publisher announces, subscriber subscribes, both succeed.
-func testAnnounceSubscribe(ctx context.Context, relay string, tlsSkipVerify bool) error {
+func testAnnounceSubscribe(ctx context.Context, relay string, tlsSkipVerify bool, draft int) error {
 	ns := []string{"moq-test", "interop"}
 
 	// Publisher: connect, setup, announce
-	pub, err := runPublisherSession(ctx, relay, tlsSkipVerify, ns)
+	pub, err := runPublisherSession(ctx, relay, tlsSkipVerify, draft, ns)
 	if err != nil {
 		return fmt.Errorf("publisher: %w", err)
 	}
 	defer pub.Close()
 
 	// Subscriber: connect, setup, subscribe
-	conn, err := dial(ctx, relay, tlsSkipVerify)
+	conn, err := dial(ctx, relay, tlsSkipVerify, draft)
 	if err != nil {
 		return fmt.Errorf("subscriber dial: %w", err)
 	}
-	sub, err := runSession(ctx, conn)
+	sub, err := runSession(ctx, conn, draft)
 	if err != nil {
 		return fmt.Errorf("subscriber session: %w", err)
 	}
@@ -285,15 +319,15 @@ func testAnnounceSubscribe(ctx context.Context, relay string, tlsSkipVerify bool
 
 // testSubscribeBeforeAnnounce: subscriber subscribes first, publisher 500ms later.
 // Either SUBSCRIBE_OK or REQUEST_ERROR is valid.
-func testSubscribeBeforeAnnounce(ctx context.Context, relay string, tlsSkipVerify bool) error {
+func testSubscribeBeforeAnnounce(ctx context.Context, relay string, tlsSkipVerify bool, draft int) error {
 	ns := []string{"moq-test", "interop"}
 
 	// Subscriber: connect first
-	subConn, err := dial(ctx, relay, tlsSkipVerify)
+	subConn, err := dial(ctx, relay, tlsSkipVerify, draft)
 	if err != nil {
 		return fmt.Errorf("subscriber dial: %w", err)
 	}
-	sub, err := runSession(ctx, subConn)
+	sub, err := runSession(ctx, subConn, draft)
 	if err != nil {
 		return fmt.Errorf("subscriber session: %w", err)
 	}
@@ -311,7 +345,7 @@ func testSubscribeBeforeAnnounce(ctx context.Context, relay string, tlsSkipVerif
 	// Wait 500ms, then publisher connects and announces
 	time.Sleep(500 * time.Millisecond)
 
-	pub, pubErr := runPublisherSession(ctx, relay, tlsSkipVerify, ns)
+	pub, pubErr := runPublisherSession(ctx, relay, tlsSkipVerify, draft, ns)
 	if pubErr != nil {
 		return fmt.Errorf("publisher: %w", pubErr)
 	}

--- a/cmd/mlmtest/main.go
+++ b/cmd/mlmtest/main.go
@@ -12,6 +12,7 @@ import (
 	"net/url"
 	"os"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/Eyevinn/moqlivemock/internal"
@@ -32,6 +33,8 @@ var testCases = []testCase{
 	{"announce-only", testAnnounceOnly},
 	{"publish-namespace-done", testPublishNamespaceDone},
 	{"subscribe-error", testSubscribeError},
+	{"announce-subscribe", testAnnounceSubscribe},
+	{"subscribe-before-announce", testSubscribeBeforeAnnounce},
 }
 
 func main() {
@@ -221,5 +224,106 @@ func testSubscribeError(ctx context.Context, relay string, tlsSkipVerify bool) e
 		return fmt.Errorf("timed out waiting for REQUEST_ERROR")
 	}
 	_ = s.Close()
+	return nil
+}
+
+// runPublisherSession creates a session that announces a namespace and accepts subscriptions.
+func runPublisherSession(ctx context.Context, relay string, tlsSkipVerify bool, namespace []string) (*moqtransport.Session, error) {
+	conn, err := dial(ctx, relay, tlsSkipVerify)
+	if err != nil {
+		return nil, err
+	}
+	s := &moqtransport.Session{
+		InitialMaxRequestID: 64,
+		Handler: moqtransport.HandlerFunc(func(w moqtransport.ResponseWriter, r *moqtransport.Message) {
+			if r.Method == moqtransport.MessageAnnounce {
+				_ = w.Accept()
+			}
+		}),
+		SubscribeHandler: moqtransport.SubscribeHandlerFunc(func(w *moqtransport.SubscribeResponseWriter, m *moqtransport.SubscribeMessage) {
+			_ = w.Accept()
+		}),
+	}
+	if err := s.Run(conn); err != nil {
+		return nil, fmt.Errorf("publisher session setup: %w", err)
+	}
+	if err := s.Announce(ctx, namespace); err != nil {
+		s.Close()
+		return nil, fmt.Errorf("PUBLISH_NAMESPACE: %w", err)
+	}
+	return s, nil
+}
+
+// testAnnounceSubscribe: publisher announces, subscriber subscribes, both succeed.
+func testAnnounceSubscribe(ctx context.Context, relay string, tlsSkipVerify bool) error {
+	ns := []string{"moq-test", "interop"}
+
+	// Publisher: connect, setup, announce
+	pub, err := runPublisherSession(ctx, relay, tlsSkipVerify, ns)
+	if err != nil {
+		return fmt.Errorf("publisher: %w", err)
+	}
+	defer pub.Close()
+
+	// Subscriber: connect, setup, subscribe
+	conn, err := dial(ctx, relay, tlsSkipVerify)
+	if err != nil {
+		return fmt.Errorf("subscriber dial: %w", err)
+	}
+	sub, err := runSession(ctx, conn)
+	if err != nil {
+		return fmt.Errorf("subscriber session: %w", err)
+	}
+	defer sub.Close()
+
+	_, subErr := sub.Subscribe(ctx, ns, "test-track")
+	if subErr != nil {
+		return fmt.Errorf("SUBSCRIBE: %w", subErr)
+	}
+	return nil
+}
+
+// testSubscribeBeforeAnnounce: subscriber subscribes first, publisher 500ms later.
+// Either SUBSCRIBE_OK or REQUEST_ERROR is valid.
+func testSubscribeBeforeAnnounce(ctx context.Context, relay string, tlsSkipVerify bool) error {
+	ns := []string{"moq-test", "interop"}
+
+	// Subscriber: connect first
+	subConn, err := dial(ctx, relay, tlsSkipVerify)
+	if err != nil {
+		return fmt.Errorf("subscriber dial: %w", err)
+	}
+	sub, err := runSession(ctx, subConn)
+	if err != nil {
+		return fmt.Errorf("subscriber session: %w", err)
+	}
+	defer sub.Close()
+
+	// Subscribe in background (may block waiting for publisher)
+	var subErr error
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		_, subErr = sub.Subscribe(ctx, ns, "test-track")
+	}()
+
+	// Wait 500ms, then publisher connects and announces
+	time.Sleep(500 * time.Millisecond)
+
+	pub, pubErr := runPublisherSession(ctx, relay, tlsSkipVerify, ns)
+	if pubErr != nil {
+		return fmt.Errorf("publisher: %w", pubErr)
+	}
+	defer pub.Close()
+
+	// Wait for subscriber result
+	wg.Wait()
+
+	// Either SUBSCRIBE_OK or REQUEST_ERROR is acceptable
+	if subErr != nil && strings.Contains(subErr.Error(), "context deadline exceeded") {
+		return fmt.Errorf("subscriber timed out (neither OK nor ERROR received)")
+	}
+	// subErr == nil means SUBSCRIBE_OK, non-nil means REQUEST_ERROR — both valid
 	return nil
 }

--- a/cmd/mlmtest/main_test.go
+++ b/cmd/mlmtest/main_test.go
@@ -1,0 +1,117 @@
+package main
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/pem"
+	"fmt"
+	"math/big"
+	"net"
+	"testing"
+
+	"github.com/Eyevinn/moqtransport"
+	"github.com/Eyevinn/moqtransport/quicmoq"
+	"github.com/quic-go/quic-go"
+)
+
+// startInteropServer starts a QUIC-based MoQ server that accepts
+// interop test operations (announce, subscribe) on both draft-14 and draft-16 ALPNs.
+// It returns the listener address and a cancel function.
+func startInteropServer(t *testing.T) (addr string, cancel func()) {
+	t.Helper()
+	tlsConfig, err := generateTLSConfig()
+	if err != nil {
+		t.Fatal(err)
+	}
+	listener, err := quic.ListenAddr("localhost:0", tlsConfig, &quic.Config{
+		EnableDatagrams: true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ctx, ctxCancel := context.WithCancel(context.Background())
+
+	go func() {
+		for {
+			conn, err := listener.Accept(ctx)
+			if err != nil {
+				return
+			}
+			go serveInteropConn(ctx, conn)
+		}
+	}()
+
+	port := listener.Addr().(*net.UDPAddr).Port
+	return fmt.Sprintf("moqt://localhost:%d", port), func() {
+		ctxCancel()
+		_ = listener.Close()
+	}
+}
+
+func serveInteropConn(ctx context.Context, conn *quic.Conn) {
+	s := &moqtransport.Session{
+		InitialMaxRequestID: 64,
+		Handler: moqtransport.HandlerFunc(func(w moqtransport.ResponseWriter, r *moqtransport.Message) {
+			if r.Method == moqtransport.MessageAnnounce {
+				_ = w.Accept()
+			}
+		}),
+		SubscribeHandler: moqtransport.SubscribeHandlerFunc(
+			func(w *moqtransport.SubscribeResponseWriter, m *moqtransport.SubscribeMessage) {
+				// Accept interop namespace, reject everything else
+				if len(m.Namespace) == 2 && m.Namespace[0] == "moq-test" && m.Namespace[1] == "interop" {
+					_ = w.Accept()
+					return
+				}
+				_ = w.Reject(0, "unknown namespace")
+			}),
+	}
+	if err := s.Run(quicmoq.NewServer(conn)); err != nil {
+		return
+	}
+	<-ctx.Done()
+	s.Close()
+}
+
+func generateTLSConfig() (*tls.Config, error) {
+	key, err := rsa.GenerateKey(rand.Reader, 1024)
+	if err != nil {
+		return nil, err
+	}
+	template := x509.Certificate{SerialNumber: big.NewInt(1)}
+	certDER, err := x509.CreateCertificate(rand.Reader, &template, &template, &key.PublicKey, key)
+	if err != nil {
+		return nil, err
+	}
+	keyPEM := pem.EncodeToMemory(&pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(key)})
+	certPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: certDER})
+	tlsCert, err := tls.X509KeyPair(certPEM, keyPEM)
+	if err != nil {
+		return nil, err
+	}
+	return &tls.Config{
+		Certificates: []tls.Certificate{tlsCert},
+		NextProtos:   []string{"moqt-16", "moq-00"},
+	}, nil
+}
+
+func TestInteropTestCases(t *testing.T) {
+	addr, cancel := startInteropServer(t)
+	defer cancel()
+
+	for _, draft := range []int{14, 16} {
+		for _, tc := range testCases {
+			t.Run(fmt.Sprintf("draft%d/%s", draft, tc.name), func(t *testing.T) {
+				ctx, ctxCancel := context.WithTimeout(context.Background(), defaultTimeout)
+				defer ctxCancel()
+				if err := tc.fn(ctx, addr, true, draft); err != nil {
+					t.Fatalf("%s (draft-%d): %v", tc.name, draft, err)
+				}
+			})
+		}
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.25.0
 
 require (
 	github.com/Dash-Industry-Forum/livesim2 v1.9.0
-	github.com/Eyevinn/moqtransport v0.6.3
+	github.com/Eyevinn/moqtransport v0.7.0
 	github.com/Eyevinn/mp4ff v0.51.0
 	github.com/mengelbart/qlog v0.1.0
 	github.com/quic-go/quic-go v0.59.0

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
 github.com/Dash-Industry-Forum/livesim2 v1.9.0 h1:7NTv3f+9gszh9mX7p6ltaTJmLlR400S+R4pjWrzpLKQ=
 github.com/Dash-Industry-Forum/livesim2 v1.9.0/go.mod h1:AtqFe2WBX6TSoHlpHw7Hh/IWttqDRnoN+VnysQyssiA=
-github.com/Eyevinn/moqtransport v0.6.3 h1:P5BjpZ5oKjpCbQuzjcnhC2ZkIZYCG1JAukwMee/I1Pk=
-github.com/Eyevinn/moqtransport v0.6.3/go.mod h1:xzseX5ZPFBxV0o+wZFqJNJCg3K+6qD+jFy0Qsch1K2M=
+github.com/Eyevinn/moqtransport v0.7.0 h1:jPfyLnyDZOaKzjx6XqCGfv7qTfnZj07exY1FmjTWxn0=
+github.com/Eyevinn/moqtransport v0.7.0/go.mod h1:xzseX5ZPFBxV0o+wZFqJNJCg3K+6qD+jFy0Qsch1K2M=
 github.com/Eyevinn/mp4ff v0.51.0 h1:ZYdHFXEcB3kJkCeCHMHl/tbCm64FJsD2XOU0Sj+ME2M=
 github.com/Eyevinn/mp4ff v0.51.0/go.mod h1:hJNUUqOBryLAzUW9wpCJyw2HaI+TCd2rUPhafoS5lgg=
 github.com/beevik/etree v1.5.0 h1:iaQZFSDS+3kYZiGoc9uKeOkUY3nYMXOKLl6KIJxiJWs=

--- a/internal/memconn_test.go
+++ b/internal/memconn_test.go
@@ -282,6 +282,10 @@ func (c *memConn) Perspective() moqtransport.Perspective {
 	return c.perspective
 }
 
+func (c *memConn) NegotiatedALPN() string {
+	return "moq-00" // in-memory connections use draft-14 negotiation
+}
+
 // memStream implements moqtransport.Stream (bidirectional).
 type memStream struct {
 	id uint64

--- a/internal/pub/pub.go
+++ b/internal/pub/pub.go
@@ -63,10 +63,24 @@ func (h *Handler) Handle(ctx context.Context, conn moqtransport.Connection) {
 	<-ctx.Done()
 }
 
+// interopNamespace is the namespace used by the moq-interop-runner test cases.
+var interopNamespace = []string{"moq-test", "interop"}
+
+func isInteropNamespace(ns []string) bool {
+	return tupleEqual(ns, interopNamespace)
+}
+
 func (h *Handler) getHandler() moqtransport.Handler {
 	return moqtransport.HandlerFunc(func(w moqtransport.ResponseWriter, r *moqtransport.Message) {
 		switch r.Method {
 		case moqtransport.MessageAnnounce:
+			if isInteropNamespace(r.Namespace) {
+				slog.Info("accepting interop announcement", "namespace", r.Namespace)
+				if err := w.Accept(); err != nil {
+					slog.Error("failed to accept interop announcement", "error", err)
+				}
+				return
+			}
 			slog.Warn("got unexpected announcement", "namespace", r.Namespace)
 			err := w.Reject(0, "publisher doesn't take announcements")
 			if err != nil {
@@ -138,6 +152,14 @@ func (h *Handler) getFetchHandler() moqtransport.FetchHandler {
 func (h *Handler) getSubscribeHandler(ctx context.Context) moqtransport.SubscribeHandler {
 	return moqtransport.SubscribeHandlerFunc(
 		func(w *moqtransport.SubscribeResponseWriter, m *moqtransport.SubscribeMessage) {
+			// Accept interop test subscriptions (control-plane only, no media)
+			if isInteropNamespace(m.Namespace) {
+				slog.Info("accepting interop subscription", "namespace", m.Namespace, "track", m.Track)
+				if err := w.Accept(); err != nil {
+					slog.Error("failed to accept interop subscription", "error", err)
+				}
+				return
+			}
 			nsEntry := h.findNamespace(m.Namespace)
 			if nsEntry == nil {
 				slog.Warn("got unexpected subscription namespace", "received", m.Namespace)

--- a/internal/pub/pub.go
+++ b/internal/pub/pub.go
@@ -59,6 +59,11 @@ func (h *Handler) Handle(ctx context.Context, conn moqtransport.Connection) {
 		}
 		slog.Info("namespace announced successfully", "namespace", ns.Namespace)
 	}
+	// Announce interop test namespace for moq-interop-runner compatibility
+	slog.Info("announcing interop namespace", "namespace", interopNamespace)
+	if err := session.Announce(ctx, interopNamespace); err != nil {
+		slog.Warn("failed to announce interop namespace", "error", err)
+	}
 	// Block until context is cancelled to keep the session alive
 	<-ctx.Done()
 }

--- a/internal/pub/pub_test.go
+++ b/internal/pub/pub_test.go
@@ -1,0 +1,83 @@
+package pub
+
+import (
+	"testing"
+
+	"github.com/Eyevinn/moqlivemock/internal"
+)
+
+func TestTupleEqual(t *testing.T) {
+	tests := []struct {
+		name string
+		a, b []string
+		want bool
+	}{
+		{"both empty", nil, nil, true},
+		{"equal", []string{"a", "b"}, []string{"a", "b"}, true},
+		{"different length", []string{"a"}, []string{"a", "b"}, false},
+		{"different values", []string{"a", "b"}, []string{"a", "c"}, false},
+		{"single equal", []string{"x"}, []string{"x"}, true},
+		{"one nil", nil, []string{"a"}, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tupleEqual(tt.a, tt.b); got != tt.want {
+				t.Errorf("tupleEqual(%v, %v) = %v, want %v", tt.a, tt.b, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestIsInteropNamespace(t *testing.T) {
+	tests := []struct {
+		name string
+		ns   []string
+		want bool
+	}{
+		{"interop namespace", []string{"moq-test", "interop"}, true},
+		{"wrong prefix", []string{"other", "interop"}, false},
+		{"wrong suffix", []string{"moq-test", "other"}, false},
+		{"too short", []string{"moq-test"}, false},
+		{"too long", []string{"moq-test", "interop", "extra"}, false},
+		{"empty", nil, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isInteropNamespace(tt.ns); got != tt.want {
+				t.Errorf("isInteropNamespace(%v) = %v, want %v", tt.ns, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestFindNamespace(t *testing.T) {
+	catalog := &internal.Catalog{}
+	h := &Handler{
+		Namespaces: []NamespaceEntry{
+			{Namespace: []string{"cmsf", "clear"}, Catalog: catalog},
+			{Namespace: []string{"cmsf", "drm-cenc"}, Catalog: catalog},
+		},
+	}
+
+	tests := []struct {
+		name  string
+		ns    []string
+		found bool
+	}{
+		{"found first", []string{"cmsf", "clear"}, true},
+		{"found second", []string{"cmsf", "drm-cenc"}, true},
+		{"not found", []string{"cmsf", "other"}, false},
+		{"empty", nil, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := h.findNamespace(tt.ns)
+			if tt.found && result == nil {
+				t.Errorf("findNamespace(%v) = nil, want non-nil", tt.ns)
+			}
+			if !tt.found && result != nil {
+				t.Errorf("findNamespace(%v) = %v, want nil", tt.ns, result)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Adds draft-16 wire format support (via moqtransport v0.7.0) and prepares moqlivemock for the [moq-interop-runner](https://github.com/englishm/moq-interop-runner) automatic interop testing matrix.

### Draft-16 support
- Upgrade moqtransport to v0.7.0 with full draft-16 wire format (ALPN negotiation, delta-encoded parameters, version-aware messages)
- Add `-draft` flag to mlmsub for draft-14/16 selection (ALPN: `moq-00` / `moqt-16`)
- mlmpub advertises both `moqt-16` and `moq-00` ALPNs for raw QUIC
- WebTransport protocol negotiation via `WT-Available-Protocols` / `WT-Protocol` headers (per draft-16 Section 3.1)

### Interop runner preparation
- Add `mlmtest` interop test client with 6 test cases outputting TAP v14
- Add `-draft` flag and `DRAFT` env var for dual draft-14/16 testing
- mlmpub accepts ANNOUNCE and SUBSCRIBE for interop namespace `["moq-test", "interop"]` (control-plane only, no media)
- Add `Dockerfile.mlmtest` for containerized test client
- Environment variables: `RELAY_URL`, `TESTCASE`, `TLS_DISABLE_VERIFY`, `DRAFT`

### Test cases
1. `setup-only` — connect, exchange SETUP, close
2. `announce-only` — PUBLISH_NAMESPACE, wait for REQUEST_OK, close
3. `publish-namespace-done` — PUBLISH_NAMESPACE, REQUEST_OK, PUBLISH_NAMESPACE_DONE, close
4. `subscribe-error` — SUBSCRIBE non-existent track, expect REQUEST_ERROR
5. `announce-subscribe` — publisher announces, subscriber subscribes, both succeed
6. `subscribe-before-announce` — subscriber first, publisher 500ms later

## Test plan

- [x] All unit tests pass
- [x] golangci-lint clean (0 new issues)
- [x] mlmtest 6/6 tests pass against local mlmpub with draft-16
- [x] mlmtest 6/6 tests pass against local mlmpub with draft-14
- [x] Docker image builds and runs successfully
- [x] Docker container 6/6 tests pass with both `DRAFT=14` and `DRAFT=16`