### PR TITLE
chore: bump version to 0.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.0] - 2026-04-12
+
+MoQ Transport draft-16 support and [moq-interop-runner](https://github.com/englishm/moq-interop-runner) preparation.
+
+### Added
+
+- MoQ Transport draft-16 support via moqtransport v0.7.0
+  - ALPN-based version negotiation (`moqt-16` for draft-16, `moq-00` for draft-14)
+  - Delta-encoded parameters and version-aware message formats
+  - WebTransport protocol negotiation via `WT-Available-Protocols` / `WT-Protocol` headers (per draft-16 Section 3.1)
+- `mlmtest` interop test client for [moq-interop-runner][interop-runner]
+  - 6 test cases: setup-only, announce-only, publish-namespace-done, subscribe-error, announce-subscribe, subscribe-before-announce
+  - TAP v14 output, dual draft-14/16 support via `-draft` flag and `DRAFT` env var
+  - `Dockerfile.mlmtest` and GitHub Actions workflow for GHCR publishing
+- `-draft` flag in mlmsub for draft-14/16 selection
+- Interop namespace `["moq-test", "interop"]` in mlmpub: accepts ANNOUNCE and SUBSCRIBE from clients, and announces it to subscribers
+- Integration tests for mlmtest (all 6 test cases with both draft-14 and draft-16)
+- Unit tests for pub package (interop namespace helpers)
+
+### Changed
+
+- Bumped moqtransport to v0.7.0 (draft-16 wire format)
+- mlmpub advertises both `moqt-16` and `moq-00` ALPNs for raw QUIC
+- mlmpub WebTransport server advertises `ApplicationProtocols: ["moqt-16", "moq-00"]`
+- mlmsub WebTransport dialer passes ALPN based on `-draft` flag
+
 ## [0.6.1] - 2026-04-11
 
 ### Added
@@ -147,7 +173,8 @@ Full [MOQ Transport draft-14][moqt-d14] compliance release.
 
 - initial version of the repo
 
-[Unreleased]: https://github.com/Eyevinn/moqlivemock/releases/tag/v0.6.1...HEAD
+[Unreleased]: https://github.com/Eyevinn/moqlivemock/releases/tag/v0.7.0...HEAD
+[0.7.0]: https://github.com/Eyevinn/moqlivemock/releases/tag/v0.6.1...v0.7.0
 [0.6.1]: https://github.com/Eyevinn/moqlivemock/releases/tag/v0.6.0...v0.6.1
 [0.6.0]: https://github.com/Eyevinn/moqlivemock/releases/tag/v0.5.0...v0.6.0
 [0.5.0]: https://github.com/Eyevinn/moqlivemock/releases/tag/v0.4.0...v0.5.0
@@ -162,4 +189,5 @@ Full [MOQ Transport draft-14][moqt-d14] compliance release.
 [moqt-d14]: https://datatracker.ietf.org/doc/draft-ietf-moq-transport/14/
 [moqtransport]: https://github.com/Eyevinn/moqtransport
 [moqtransport-eyevinn]: https://github.com/Eyevinn/moqtransport
+[interop-runner]: https://github.com/englishm/moq-interop-runner
 [wp]: https://github.com/Eyevinn/warp-player

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,7 +33,8 @@ go mod vendor               # Vendor dependencies
 
 ### MoQ Transport Dependency
 
-Uses `github.com/Eyevinn/moqtransport` (forked from mengelbart/moqtransport) with draft-14 support.
+Uses `github.com/Eyevinn/moqtransport` (forked from mengelbart/moqtransport) with draft-14 and draft-16 support.
+Version negotiation uses ALPN (`moqt-16` for draft-16, `moq-00` for draft-14) and `WT-Available-Protocols` for WebTransport.
 - Session creation: `&moqtransport.Session{Handler: ..., SubscribeHandler: ...}`
 - Call `session.Run(conn)` to start
 - Subscriptions use separate `SubscribeHandler` interface
@@ -112,7 +113,7 @@ in Safari 26.4+.
 ### Interop Testing (mlmtest)
 
 `mlmtest` is an interop test client for [moq-interop-runner](https://github.com/englishm/moq-interop-runner).
-It connects to a relay as a MoQ draft-16 client and runs protocol-level test cases, outputting TAP v14 results.
+It connects to a server/relay and runs protocol-level test cases with both draft-14 and draft-16, outputting TAP v14 results.
 
 **Test cases:**
 1. `setup-only` — connect, exchange SETUP, close
@@ -148,6 +149,7 @@ go test ./internal/...
 
 IETF draft specifications are stored in `references/` for offline reference:
 
-- `draft-ietf-moq-transport-14.txt` - MoQ Transport protocol (draft-14), the wire protocol used by this project
+- `draft-ietf-moq-transport-14.txt` - MoQ Transport protocol (draft-14)
+- `draft-ietf-moq-transport-16.txt` - MoQ Transport protocol (draft-16), the primary wire protocol used by this project
 - `draft-ietf-moq-msf-00.txt` - MoQ Streaming Format (MSF), defines how media is mapped to MoQ tracks/groups/objects
 - `draft-ietf-moq-cmsf-00.txt` - CMAF MoQ Streaming Format (CMSF), defines CMAF-based media packaging for MoQ

--- a/README.md
+++ b/README.md
@@ -40,9 +40,10 @@ All streams are aligned to UTC wall-clock time at two levels:
 LOC is currently not supported, but one possible scenario is to send LOC over the wire and
 then reassamble CMAF on the receiving side again.
 
-This project uses [moqtransport][moqtransport] for the MoQ transport layer.
-As the MoQ transport layer is still work in progress, this project is also
-work in progress. Currently a fork is used to align to [draft-14 of MOQT][moqt-14].
+This project uses [moqtransport][moqtransport] for the MoQ transport layer,
+supporting both draft-14 and draft-16 of MOQT. Draft-16 uses ALPN-based version
+negotiation (`moqt-16`) and `WT-Available-Protocols` for WebTransport. Draft-14
+(`moq-00`) is supported for backward compatibility.
 
 ## Namespaces
 
@@ -107,7 +108,7 @@ To receive subtitles with the mlmsub subscriber:
 
 ## Requirements
 
-* Go 1.24 or later
+* Go 1.25 or later
 
 ## Installation and Usage
 
@@ -119,10 +120,11 @@ go mod tidy
 
 to get up and running.
 
-There are two commands
+There are three commands
 
 * `mlmpub` is the server and publisher
 * `mlmsub` is the client and subscriber
+* `mlmtest` is an interop test client for the [moq-interop-runner][interop-runner]
 
 The content used is in the `assets/test10s` directory, and was
 generated using the tools in `utils/contentgen`.
@@ -308,7 +310,7 @@ Example QUIC config:
 
 ## Development
 
-Use plain Go environment, with go 1.24 or later.
+Use plain Go environment, with go 1.25 or later.
 The Makefile helps out with some tasks.
 
 ## Contributing
@@ -342,3 +344,4 @@ Want to know more about Eyevinn and how it is to work here. Contact us at work@e
 [CMSF]: https://datatracker.ietf.org/doc/html/draft-ietf-moq-cmsf-00
 [moqtransport]: https://github.com/Eyevinn/moqtransport
 [warp-player]: https://github.com/Eyevinn/warp-player
+[interop-runner]: https://github.com/englishm/moq-interop-runner

--- a/internal/version.go
+++ b/internal/version.go
@@ -8,8 +8,8 @@ import (
 )
 
 var (
-	commitVersion string = "0.6.1"      // Should be updated during build
-	commitDate    string = "1744401600" // commitDate in Epoch seconds (can be filled/updated in during build)
+	commitVersion string = "0.7.0"      // Should be updated during build
+	commitDate    string = "1775994426" // commitDate in Epoch seconds (can be filled/updated in during build)
 )
 
 // GetVersion - get version, commitHash and  commitDate depending on what is inserted


### PR DESCRIPTION
MoQ Transport draft-16 support and [moq-interop-runner](https://github.com/englishm/moq-interop-runner) preparation.

### Added

- MoQ Transport draft-16 support via moqtransport v0.7.0
  - ALPN-based version negotiation (`moqt-16` for draft-16, `moq-00` for draft-14)
  - Delta-encoded parameters and version-aware message formats
  - WebTransport protocol negotiation via `WT-Available-Protocols` / `WT-Protocol` headers (per draft-16 Section 3.1)
- `mlmtest` interop test client for [moq-interop-runner](https://github.com/englishm/moq-interop-runner)
  - 6 test cases: setup-only, announce-only, publish-namespace-done, subscribe-error, announce-subscribe, subscribe-before-announce
  - TAP v14 output, dual draft-14/16 support via `-draft` flag and `DRAFT` env var
  - `Dockerfile.mlmtest` and GitHub Actions workflow for GHCR publishing
- `-draft` flag in mlmsub for draft-14/16 selection
- Interop namespace `["moq-test", "interop"]` in mlmpub: accepts ANNOUNCE and SUBSCRIBE from clients, and announces it to subscribers
- Integration tests for mlmtest (all 6 test cases with both draft-14 and draft-16)
- Unit tests for pub package (interop namespace helpers)

### Changed

- Bumped moqtransport to v0.7.0 (draft-16 wire format)
- mlmpub advertises both `moqt-16` and `moq-00` ALPNs for raw QUIC
- mlmpub WebTransport server advertises `ApplicationProtocols: ["moqt-16", "moq-00"]`
- mlmsub WebTransport dialer passes ALPN based on `-draft` flag