### PR TITLE
feat: add namespace discovery and relay interop to mlmsub

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,16 +1,16 @@
-
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.3.0
+    rev: v5.0.0
     hooks:
       - id: trailing-whitespace
   - repo: https://github.com/dnephin/pre-commit-golang
-    rev: v0.5.0
+    rev: v0.5.1
     hooks:
       - id: go-fmt
       - id: golangci-lint
+      - id: go-unit-tests
   - repo: https://github.com/alessandrojcm/commitlint-pre-commit-hook
-    rev: v8.0.0
+    rev: v9.18.0
     hooks:
       - id: commitlint
         stages: [commit-msg]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `-discover` flag in mlmsub to list announced namespaces on a relay and exit
+- `-accept-any` flag in mlmsub to accept any announced namespace (for connecting to external relays)
+- `-catalog-track` flag in mlmsub to configure catalog track name (e.g. `catalog.json` for moq-dev hang format)
+- Multi-element namespace support in mlmsub `-namespace` flag (space-separated, e.g. `"demo bbb"`)
+- Raw catalog payload logging on parse failure for debugging non-CMSF catalog formats
+
 ## [0.7.0] - 2026-04-12
 
 MoQ Transport draft-16 support and [moq-interop-runner](https://github.com/englishm/moq-interop-runner) preparation.

--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,9 @@ pre-commit: venv/bin/pre-commit test
 
 venv/bin/pre-commit venv/bin/codespell:
 	python3 -m venv venv
-	venv/bin/pip install pre-commit codespell
+	venv/bin/pip install --upgrade pip
+	venv/bin/pip install pre-commit==4.2.0
+	venv/bin/pip install codespell
 
 codespell: venv/bin/codespell
 	venv/bin/codespell -S venv,references,coverage.html,'*.mp4' -L ue,trun,truns

--- a/cmd/mlmsub/main.go
+++ b/cmd/mlmsub/main.go
@@ -52,6 +52,9 @@ type options struct {
 	namespace    string
 	loglevel     string
 	fetchCatalog bool
+	acceptAny    bool
+	discover     bool
+	catalogTrack string
 	version      bool
 }
 
@@ -79,6 +82,9 @@ func parseOptions(fs *flag.FlagSet, args []string) (*options, error) {
 	fs.StringVar(&opts.namespace, "namespace", "cmsf/clear", "MoQ namespace to use")
 	fs.StringVar(&opts.loglevel, "loglevel", "info", "Log level: debug, info, warning, error")
 	fs.BoolVar(&opts.fetchCatalog, "fetchcatalog", false, "Use FETCH instead of SUBSCRIBE for catalog")
+	fs.BoolVar(&opts.acceptAny, "accept-any", false, "Accept any announced namespace")
+	fs.BoolVar(&opts.discover, "discover", false, "Discovery mode: list announced namespaces and exit")
+	fs.StringVar(&opts.catalogTrack, "catalog-track", "catalog", "Catalog track name (e.g. 'catalog' or 'catalog.json')")
 	fs.IntVar(&opts.draft, "draft", 14, "MoQ Transport draft version (14 or 16)")
 
 	err := fs.Parse(args[1:])
@@ -167,13 +173,21 @@ func runClient(ctx context.Context, opts *options) error {
 	// Automatically use WebTransport if address starts with https://
 	useWebTransport := strings.HasPrefix(opts.addr, "https://")
 
+	namespace := strings.Fields(opts.namespace)
+	if len(namespace) == 0 {
+		namespace = []string{opts.namespace}
+	}
+
 	h := &sub.Handler{
-		Namespace: []string{opts.namespace},
-		Logfh:     logfh,
-		VideoName: opts.videoname,
-		AudioName: opts.audioname,
-		SubsName:  opts.subsname,
-		UseFetch:  opts.fetchCatalog,
+		Namespace:    namespace,
+		Logfh:        logfh,
+		VideoName:    opts.videoname,
+		AudioName:    opts.audioname,
+		SubsName:     opts.subsname,
+		UseFetch:     opts.fetchCatalog,
+		AcceptAny:    opts.acceptAny,
+		Discover:     opts.discover,
+		CatalogTrack: opts.catalogTrack,
 	}
 
 	outs := make(map[string]io.Writer)

--- a/internal/sub/sub.go
+++ b/internal/sub/sub.go
@@ -24,13 +24,16 @@ const (
 // Handler handles MoQ subscriber sessions. It subscribes to a catalog,
 // selects tracks, and reads media data.
 type Handler struct {
-	Namespace []string
-	Outs      map[string]io.Writer
-	Logfh     io.Writer
-	VideoName string
-	AudioName string
-	SubsName  string
-	UseFetch  bool
+	Namespace    []string
+	Outs         map[string]io.Writer
+	Logfh        io.Writer
+	VideoName    string
+	AudioName    string
+	SubsName     string
+	UseFetch     bool
+	AcceptAny    bool   // Accept any announced namespace
+	Discover     bool   // Discovery mode: list namespaces and exit
+	CatalogTrack string // Catalog track name (default "catalog")
 
 	catalog *internal.Catalog
 	mux     *CmafMux
@@ -43,16 +46,46 @@ func (h *Handler) RunWithConn(ctx context.Context, conn moqtransport.Connection)
 	if h.Outs["mux"] != nil {
 		h.mux = NewCmafMux(h.Outs["mux"])
 	}
+	if h.CatalogTrack == "" {
+		h.CatalogTrack = "catalog"
+	}
+	if h.Discover {
+		return h.runDiscover(ctx, conn)
+	}
 	h.handle(ctx, conn)
 	<-ctx.Done()
 	slog.Info("end of RunWithConn")
 	return ctx.Err()
 }
 
+func (h *Handler) runDiscover(ctx context.Context, conn moqtransport.Connection) error {
+	session := &moqtransport.Session{
+		Handler:             h.getHandler(),
+		SubscribeHandler:    h.getSubscribeHandler(),
+		InitialMaxRequestID: initialMaxRequestID,
+		Qlogger:             qlog.NewQLOGHandler(h.Logfh, "MoQ QLOG", "MoQ QLOG", conn.Perspective().String(), moqt.Schema),
+	}
+	err := session.Run(conn)
+	if err != nil {
+		return fmt.Errorf("session init: %w", err)
+	}
+	slog.Info("connected, waiting for namespace announcements...")
+	<-ctx.Done()
+	return nil
+}
+
 func (h *Handler) getHandler() moqtransport.Handler {
 	return moqtransport.HandlerFunc(func(w moqtransport.ResponseWriter, r *moqtransport.Message) {
 		switch r.Method {
 		case moqtransport.MessageAnnounce:
+			if h.AcceptAny || h.Discover {
+				slog.Info("discovered namespace", "namespace", r.Namespace)
+				err := w.Accept()
+				if err != nil {
+					slog.Error("failed to accept announcement", "error", err)
+				}
+				return
+			}
 			if !tupleEqual(r.Namespace, h.Namespace) {
 				slog.Warn("got unexpected announcement namespace",
 					"received", r.Namespace,
@@ -98,6 +131,7 @@ func (h *Handler) handle(ctx context.Context, conn moqtransport.Connection) {
 		}
 		return
 	}
+
 	if h.UseFetch {
 		err = h.fetchCatalog(ctx, session, h.Namespace)
 	} else {
@@ -245,7 +279,7 @@ func (h *Handler) handle(ctx context.Context, conn moqtransport.Connection) {
 }
 
 func (h *Handler) subscribeToCatalog(ctx context.Context, s *moqtransport.Session, namespace []string) error {
-	rs, err := s.Subscribe(ctx, namespace, "catalog")
+	rs, err := s.Subscribe(ctx, namespace, h.CatalogTrack)
 	if err != nil {
 		return err
 	}
@@ -258,16 +292,23 @@ func (h *Handler) subscribeToCatalog(ctx context.Context, s *moqtransport.Sessio
 		return err
 	}
 
-	err = json.Unmarshal(o.Payload, &h.catalog)
-	if err != nil {
-		rs.Close()
-		return err
-	}
 	slog.Info("received catalog",
 		"groupID", o.GroupID,
 		"subGroupID", o.SubGroupID,
 		"payloadLength", len(o.Payload),
 	)
+	slog.Debug("raw catalog payload", "data", string(o.Payload))
+	err = json.Unmarshal(o.Payload, &h.catalog)
+	if err != nil {
+		slog.Warn("failed to parse catalog as CMSF, dumping raw", "error", err, "raw", string(o.Payload))
+		rs.Close()
+		// Still write raw catalog to output
+		if h.Outs["catalog"] != nil {
+			h.Outs["catalog"].Write(o.Payload)
+			h.Outs["catalog"].Write([]byte("\n"))
+		}
+		return err
+	}
 	if slog.Default().Enabled(context.Background(), slog.LevelInfo) {
 		fmt.Fprintf(os.Stderr, "catalog: %s\n", h.catalog.String())
 	}
@@ -335,7 +376,7 @@ func (h *Handler) subscribeToCatalog(ctx context.Context, s *moqtransport.Sessio
 }
 
 func (h *Handler) fetchCatalog(ctx context.Context, s *moqtransport.Session, namespace []string) error {
-	rt, err := s.Fetch(ctx, namespace, "catalog")
+	rt, err := s.Fetch(ctx, namespace, h.CatalogTrack)
 	if err != nil {
 		return err
 	}

--- a/internal/sub/sub.go
+++ b/internal/sub/sub.go
@@ -304,8 +304,8 @@ func (h *Handler) subscribeToCatalog(ctx context.Context, s *moqtransport.Sessio
 		rs.Close()
 		// Still write raw catalog to output
 		if h.Outs["catalog"] != nil {
-			h.Outs["catalog"].Write(o.Payload)
-			h.Outs["catalog"].Write([]byte("\n"))
+			_, _ = h.Outs["catalog"].Write(o.Payload)
+			_, _ = h.Outs["catalog"].Write([]byte("\n"))
 		}
 		return err
 	}


### PR DESCRIPTION
## Summary

- Add `-discover` flag to list announced namespaces on a relay and exit
- Add `-accept-any` flag to accept any announced namespace (needed for external relays)
- Add `-catalog-track` flag to configure catalog track name (e.g. `catalog.json` for moq-dev hang format)
- Support multi-element namespace tuples in `-namespace` flag (space-separated, e.g. `"demo bbb"`)
- Log raw catalog payload on parse failure for debugging non-CMSF formats

Tested against Luke Curley's moq-dev relay at `cdn.moq.dev:443`, successfully discovering namespaces, fetching MSF catalogs, and receiving live Big Buck Bunny media data.

## Test plan

- [ ] `mlmsub -addr cdn.moq.dev:443 -discover -duration 5` lists namespaces
- [ ] `mlmsub -addr cdn.moq.dev:443 -namespace "demo bbb" -accept-any -catalog-track catalog -catalogout - -duration 10` fetches catalog
- [ ] `mlmsub -addr cdn.moq.dev:443 -namespace "demo bbb" -accept-any -catalog-track catalog -videoname "0.hang" -audioname "1.hang" -videoout /tmp/v.bin -duration 10` receives video data
- [ ] Existing mlmsub usage against mlmpub (default flags) still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)