### PR TITLE
feat(loc): add HEVC support for LOC packaging

### DIFF
--- a/internal/asset.go
+++ b/internal/asset.go
@@ -653,9 +653,10 @@ func (a *Asset) GenCMAFCatalogEntry(namespace string, prot ProtectionType, gener
 // GenLOCCatalogEntry generates an MSF catalog with LOC packaging for this asset.
 // Conforms to draft-ietf-moq-msf-00 with packaging="loc" per draft-ietf-moq-loc-02.
 //
-// Only AVC video and AAC/Opus audio tracks with ProtectionNone are included.
+// Only AVC/HEVC video and AAC/Opus audio tracks with ProtectionNone are included.
 // No initData is set (LOC sends video config in-band with keyframes).
-// AVC tracks use "avc3" codec prefix since parameter sets are in the payload.
+// AVC tracks use "avc3" and HEVC tracks use "hev1" codec prefixes since
+// parameter sets travel in the payload (draft-ietf-moq-loc-02 §2.1.1).
 func (a *Asset) GenLOCCatalogEntry(generatedAtMS int64) (*Catalog, error) {
 	var tracks []Track
 	renderGroup := 1
@@ -665,24 +666,30 @@ func (a *Asset) GenLOCCatalogEntry(generatedAtMS int64) (*Catalog, error) {
 			if ct.Protection != ProtectionNone {
 				continue
 			}
-			// LOC only supports AVC video and AAC/Opus audio
+			// LOC supports AVC/HEVC video and AAC/Opus audio
 			switch ct.SpecData.(type) {
 			case *AVCData:
 				// OK - AVC video
+			case *HEVCData:
+				// OK - HEVC video
 			case *AACData:
 				// OK - AAC audio
 			case *OpusData:
 				// OK - Opus audio
 			default:
-				continue // Skip HEVC, AC-3, EC-3
+				continue // Skip AC-3, EC-3
 			}
 
 			frameRate := float64(ct.TimeScale) / float64(ct.SampleDur)
 
-			// For LOC, use avc3 codec string (param sets in payload, not init)
+			// For LOC, use codec strings that signal in-payload parameter sets
+			// (avc3 for AVC, hev1 for HEVC).
 			codec := ct.SpecData.Codec()
 			if _, ok := ct.SpecData.(*AVCData); ok {
 				codec = "avc3" + codec[4:] // Replace "avc1" prefix with "avc3"
+			}
+			if _, ok := ct.SpecData.(*HEVCData); ok {
+				codec = "hev1" + codec[4:] // Replace "hvc1" prefix with "hev1"
 			}
 			// MSF examples use lowercase "opus"
 			if _, ok := ct.SpecData.(*OpusData); ok {
@@ -704,7 +711,15 @@ func (a *Asset) GenLOCCatalogEntry(generatedAtMS int64) (*Catalog, error) {
 			case "video":
 				track.Role = "video"
 				track.Framerate = Ptr(frameRate)
-				if sd, ok := ct.SpecData.(*AVCData); ok {
+				switch sd := ct.SpecData.(type) {
+				case *AVCData:
+					if sd.width != 0 {
+						track.Width = Ptr(int(sd.width))
+					}
+					if sd.height != 0 {
+						track.Height = Ptr(int(sd.height))
+					}
+				case *HEVCData:
 					if sd.width != 0 {
 						track.Width = Ptr(int(sd.width))
 					}

--- a/internal/loc_test.go
+++ b/internal/loc_test.go
@@ -23,11 +23,11 @@ func TestGenLOCCatalogEntry(t *testing.T) {
 	assert.Equal(t, genAt, *cat.GeneratedAt)
 	require.NotEmpty(t, cat.Tracks)
 
-	// LOC only supports AVC video + AAC/Opus audio. HEVC, AC-3, EC-3 are excluded.
-	// test10s has 3 AVC, 3 HEVC, 2 AAC, 2 Opus, 2 AC-3 => 3+2+2 = 7 LOC tracks.
-	require.Len(t, cat.Tracks, 7, "LOC catalog should contain only AVC + AAC + Opus tracks")
+	// LOC supports AVC/HEVC video + AAC/Opus audio. AC-3, EC-3 are excluded.
+	// test10s has 3 AVC, 3 HEVC, 2 AAC, 2 Opus, 2 AC-3 => 3+3+2+2 = 10 LOC tracks.
+	require.Len(t, cat.Tracks, 10, "LOC catalog should contain AVC + HEVC + AAC + Opus tracks")
 
-	var sawAVC3, sawLowerOpus, sawLOCPackaging bool
+	var sawAVC3, sawHEV1, sawLowerOpus, sawLOCPackaging bool
 	for _, tr := range cat.Tracks {
 		assert.Equal(t, "loc", tr.Packaging)
 		assert.True(t, tr.IsLive)
@@ -36,10 +36,17 @@ func TestGenLOCCatalogEntry(t *testing.T) {
 		sawLOCPackaging = true
 
 		if tr.Role == "video" {
-			// AVC codec string must be rewritten to avc3.* for LOC.
-			assert.True(t, len(tr.Codec) >= 4 && tr.Codec[:4] == "avc3",
-				"video codec should start with avc3, got %q", tr.Codec)
-			sawAVC3 = true
+			// Video codec strings must be rewritten to in-payload variants for LOC.
+			require.GreaterOrEqual(t, len(tr.Codec), 4)
+			prefix := tr.Codec[:4]
+			assert.Contains(t, []string{"avc3", "hev1"}, prefix,
+				"video codec should start with avc3 or hev1, got %q", tr.Codec)
+			if prefix == "avc3" {
+				sawAVC3 = true
+			}
+			if prefix == "hev1" {
+				sawHEV1 = true
+			}
 			require.NotNil(t, tr.Framerate)
 			assert.Greater(t, *tr.Framerate, 0.0)
 		}
@@ -51,6 +58,7 @@ func TestGenLOCCatalogEntry(t *testing.T) {
 	}
 	assert.True(t, sawLOCPackaging)
 	assert.True(t, sawAVC3, "at least one avc3 track expected")
+	assert.True(t, sawHEV1, "at least one hev1 track expected")
 	assert.True(t, sawLowerOpus, "Opus codec string should be lowercase 'opus'")
 
 	// Protected tracks should not leak into the LOC catalog.
@@ -91,6 +99,46 @@ func TestAVCGenLOCVideoConfig(t *testing.T) {
 	}
 	for i, pps := range avcData.Ppss {
 		assert.Equal(t, pps, extracted[len(avcData.Spss)+i], "PPS[%d] mismatch", i)
+	}
+}
+
+func TestHEVCGenLOCVideoConfig(t *testing.T) {
+	asset, err := LoadAsset("../assets/test10s", 1, 1)
+	require.NoError(t, err)
+
+	vt := asset.GetTrackByName("video_400kbps_hevc")
+	require.NotNil(t, vt)
+	hevcData, ok := vt.SpecData.(*HEVCData)
+	require.True(t, ok)
+
+	cfg := hevcData.GenLOCVideoConfig()
+	require.NotEmpty(t, cfg)
+
+	// Parse the length-prefixed concatenation and verify it reproduces the
+	// original VPS+SPS+PPS NALUs in order.
+	var extracted [][]byte
+	data := cfg
+	for len(data) >= 4 {
+		n := binary.BigEndian.Uint32(data[:4])
+		data = data[4:]
+		require.LessOrEqual(t, int(n), len(data))
+		extracted = append(extracted, append([]byte{}, data[:n]...))
+		data = data[n:]
+	}
+	assert.Empty(t, data, "no trailing bytes")
+
+	require.Equal(t, len(hevcData.Vpss)+len(hevcData.Spss)+len(hevcData.Ppss), len(extracted))
+	off := 0
+	for i, vps := range hevcData.Vpss {
+		assert.Equal(t, vps, extracted[off+i], "VPS[%d] mismatch", i)
+	}
+	off += len(hevcData.Vpss)
+	for i, sps := range hevcData.Spss {
+		assert.Equal(t, sps, extracted[off+i], "SPS[%d] mismatch", i)
+	}
+	off += len(hevcData.Spss)
+	for i, pps := range hevcData.Ppss {
+		assert.Equal(t, pps, extracted[off+i], "PPS[%d] mismatch", i)
 	}
 }
 

--- a/internal/media.go
+++ b/internal/media.go
@@ -305,6 +305,30 @@ func (d *HEVCData) GetInit() *mp4.InitSegment {
 	return d.outInit
 }
 
+// GenLOCVideoConfig returns VPS, SPS, and PPS NALUs as length-prefixed data
+// suitable for prepending to IRAP frames in LOC payloads.
+// Format: [4-byte-len][VPS] [4-byte-len][SPS] [4-byte-len][PPS]
+func (d *HEVCData) GenLOCVideoConfig() []byte {
+	var buf []byte
+	work := make([]byte, 4)
+	for _, vps := range d.Vpss {
+		binary.BigEndian.PutUint32(work, uint32(len(vps)))
+		buf = append(buf, work...)
+		buf = append(buf, vps...)
+	}
+	for _, sps := range d.Spss {
+		binary.BigEndian.PutUint32(work, uint32(len(sps)))
+		buf = append(buf, work...)
+		buf = append(buf, sps...)
+	}
+	for _, pps := range d.Ppss {
+		binary.BigEndian.PutUint32(work, uint32(len(pps)))
+		buf = append(buf, work...)
+		buf = append(buf, pps...)
+	}
+	return buf
+}
+
 func (d *HEVCData) Clone() (CodecSpecificData, error) {
 	clonedInit, err := cloneInitSegment(d.outInit)
 	if err != nil {

--- a/internal/pub/pub.go
+++ b/internal/pub/pub.go
@@ -345,8 +345,11 @@ func PublishLOCTrack(ctx context.Context, publisher moqtransport.Publisher, asse
 	}
 
 	var videoConfig []byte
-	if avcData, ok := ct.SpecData.(*internal.AVCData); ok {
-		videoConfig = avcData.GenLOCVideoConfig()
+	switch sd := ct.SpecData.(type) {
+	case *internal.AVCData:
+		videoConfig = sd.GenLOCVideoConfig()
+	case *internal.HEVCData:
+		videoConfig = sd.GenLOCVideoConfig()
 	}
 
 	now := time.Now().UnixMilli()


### PR DESCRIPTION
## Summary

Extends MSF/LOC support to HEVC. Until now the `msf/clear` namespace only carried AVC video tracks — HEVC variants in the asset were silently dropped from the LOC catalog while continuing to feed the CMAF (`cmsf/clear`) namespace.

## What's new

- `HEVCData.GenLOCVideoConfig()` emits length-prefixed VPS+SPS+PPS to be prepended to IRAP frames in LOC payloads (mirror of the existing AVC path).
- `GenLOCCatalogEntry` accepts `*HEVCData` and rewrites the codec prefix `hvc1.*` → `hev1.*` (parameter sets in payload, per draft-ietf-moq-loc-02 §2.1.1) — the HEVC analog of `avc1` → `avc3`.
- `PublishLOCTrack` switches over both `*AVCData` and `*HEVCData` to source the in-band video config.
- LOC track count in `test10s` goes from 7 to 10 (3 AVC + **3 HEVC** + 2 AAC + 2 Opus).

## Test plan

- [x] `go test ./moqlivemock/...`, `golangci-lint run ./...` clean
- [x] New `TestHEVCGenLOCVideoConfig` round-trips length-prefixed VPS/SPS/PPS
- [x] Existing `TestGenLOCCatalogEntry` updated for the larger track set, asserts both `avc3` and `hev1` prefixes appear
- [x] End-to-end with [warp-player#117](https://github.com/Eyevinn/warp-player/pull/117): subscribed to `msf/clear/video_400kbps_hevc` from Chrome and Safari (26.4+); WebCodecs decoded `hvc1.1.6.L93.90` cleanly with stable buffers