### PR TITLE
fix(cenc): chain IV across CMAF fragments to avoid reuse

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- CENC IV reuse across CMAF fragments: track per-`ContentTrack` running IV
+  and chain it through successive `GenCMAFChunk` calls using mp4ff's new
+  `EncryptFragment` return value (mp4ff #499)
+
+### Changed
+
+- Bumped mp4ff to v0.52.0 (new `EncryptFragment` signature returning the
+  next IV so callers can avoid IV reuse on cenc)
+
 ## [0.8.0] - 2026-05-05
 
 ### Added

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.25.0
 require (
 	github.com/Dash-Industry-Forum/livesim2 v1.9.0
 	github.com/Eyevinn/moqtransport v0.8.1
-	github.com/Eyevinn/mp4ff v0.51.0
+	github.com/Eyevinn/mp4ff v0.52.0
 	github.com/mengelbart/qlog v0.1.0
 	github.com/quic-go/quic-go v0.59.0
 	github.com/quic-go/webtransport-go v0.10.0

--- a/go.sum
+++ b/go.sum
@@ -2,8 +2,8 @@ github.com/Dash-Industry-Forum/livesim2 v1.9.0 h1:7NTv3f+9gszh9mX7p6ltaTJmLlR400
 github.com/Dash-Industry-Forum/livesim2 v1.9.0/go.mod h1:AtqFe2WBX6TSoHlpHw7Hh/IWttqDRnoN+VnysQyssiA=
 github.com/Eyevinn/moqtransport v0.8.1 h1:FMzlHMEh/5Sy2Vfvy7ntvbMPmDB2eGYYBIWHfiN+moo=
 github.com/Eyevinn/moqtransport v0.8.1/go.mod h1:xzseX5ZPFBxV0o+wZFqJNJCg3K+6qD+jFy0Qsch1K2M=
-github.com/Eyevinn/mp4ff v0.51.0 h1:ZYdHFXEcB3kJkCeCHMHl/tbCm64FJsD2XOU0Sj+ME2M=
-github.com/Eyevinn/mp4ff v0.51.0/go.mod h1:hJNUUqOBryLAzUW9wpCJyw2HaI+TCd2rUPhafoS5lgg=
+github.com/Eyevinn/mp4ff v0.52.0 h1:QJUi2PtROeZGkcumbX7f4/91Jz6dlhjeKzpwSdCoYG8=
+github.com/Eyevinn/mp4ff v0.52.0/go.mod h1:LKZAf3K+OtWYdzlvte8uafD/e3g2aK2WcsgVohvjccU=
 github.com/Eyevinn/webtransport-go v0.0.0-20260428203517-12aa0d7199e5 h1:vzaoTakGI3gADG+mrYqjBdZGJc899JJQFQrsU+1WCfY=
 github.com/Eyevinn/webtransport-go v0.0.0-20260428203517-12aa0d7199e5/go.mod h1:ocpwcCqYQbWRGNaCYlToTUVgjsbh0yEjLAyXl8yAIdA=
 github.com/beevik/etree v1.5.0 h1:iaQZFSDS+3kYZiGoc9uKeOkUY3nYMXOKLl6KIJxiJWs=

--- a/internal/asset.go
+++ b/internal/asset.go
@@ -59,6 +59,10 @@ type ContentTrack struct {
 	contentProtectionRefIDs []string
 	cenc                    *CENCInfo
 	ipd                     *mp4.InitProtectData
+	// currentIV is the per-track running IV used for encrypting the next fragment.
+	// mp4.EncryptFragment chains IVs across fragments (incremented by the number of
+	// encrypted AES blocks) so that callers using the same key avoid IV reuse.
+	currentIV []byte
 }
 
 type Asset struct {
@@ -405,6 +409,10 @@ func addProtectionInfoToTrack(ct ContentTrack, drm *DRMInfo, suffix string, prot
 	protectedCt.Name = ct.Name + suffix
 	protectedCt.Protection = prot
 	protectedCt.cenc = drm.cenc
+	// Each ContentTrack instance owns its IV state. Tracks copied from this one
+	// (e.g., via Asset.GetTrackByName for a new subscription) share the initial
+	// slice header until the first EncryptFragment call replaces it.
+	protectedCt.currentIV = append([]byte(nil), drm.cenc.iv...)
 	refIDs := make([]string, 0, len(drm.ContentProtections))
 	for _, cp := range drm.ContentProtections {
 		refIDs = append(refIDs, cp.RefID)
@@ -908,6 +916,8 @@ func (t *ContentTrack) CalcSample(nr uint64) (startTime, origNr uint64) {
 
 // encryptFragment encrypts an encoded fragment and returns the encrypted bytes.
 // For mp4ff.EncryptFragment to work the fragment is first decoded, then encrypted, then finally encoded.
+// mp4.EncryptFragment returns the next IV to use; we store it on the track so consecutive
+// fragments chain without IV reuse (cenc) or carry the constant IV forward (cbcs).
 func (t *ContentTrack) encryptFragment(fragmentBytes []byte) ([]byte, error) {
 	bytesReader := bytes.NewReader(fragmentBytes)
 	var pos uint64 = 0
@@ -933,10 +943,14 @@ func (t *ContentTrack) encryptFragment(fragmentBytes []byte) ([]byte, error) {
 	decodedFrag.AddChild(moof)
 	decodedFrag.AddChild(mdat)
 
-	err = mp4.EncryptFragment(decodedFrag, t.cenc.key, t.cenc.iv, t.ipd)
+	if t.currentIV == nil {
+		t.currentIV = append([]byte(nil), t.cenc.iv...)
+	}
+	nextIV, err := mp4.EncryptFragment(decodedFrag, t.cenc.key, t.currentIV, t.ipd)
 	if err != nil {
 		return nil, fmt.Errorf("unable to encrypt fragment: %w", err)
 	}
+	t.currentIV = nextIV
 	sw := bits.NewFixedSliceWriter(int(decodedFrag.Size()))
 	err = decodedFrag.EncodeSW(sw)
 	if err != nil {


### PR DESCRIPTION
## Summary

- Adopt the new `mp4ff.EncryptFragment` signature (returns the next IV) so consecutive CMAF fragments do not reuse the same cenc IV under the same key — addresses mp4ff #499
- Track a per-`ContentTrack` running IV (initialized from a copy of `drm.cenc.iv` in `addProtectionInfoToTrack`) and feed it back into each `mp4.EncryptFragment` call from `encryptFragment`; cbcs is unaffected (constant IV preserved)
- Bump `github.com/Eyevinn/mp4ff` to `v0.52.0`

## Test plan

- [x] `go build ./...`
- [x] `go test ./...` (includes `TestClearKeyDecryptionMatchExcatly` and `TestCommercialDRMDecryptionMatchExactly` for AVC/HEVC video and AAC/Opus audio, both cenc and cbcs)
- [x] `golangci-lint run` clean