### PR TITLE
LOCMAF: encoder/decoder fixes, roundtrip CLI, and design doc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,39 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- LOCMAF (Low Overhead CMAF) packaging: a LOC-inspired variant of CMAF that
+  encodes only the non-derivable `moof`/`moov` fields as MoQT key-value pairs
+  using QUIC varints. The first object of every group is a LOCMAF *full* moof
+  (carries every required field); subsequent objects in the group are LOCMAF
+  *delta* moofs that only carry the fields that changed since the previous
+  moof. Signed fields (composition time offsets, delta differences) use
+  zigzag-encoded varints. The catalog `initData` field is the LOCMAF-encoded
+  `moov`, so subscribers reconstruct a valid CMAF init segment by decoding
+  the LOCMAF fields and merging them into an empty CMAF template
+- LOCMAF namespaces in mlmpub: `locmaf/clear` (always), `locmaf/drm-{scheme}`
+  (when `-drmpath` is set) and `locmaf/eccp-{scheme}` (when `-kid`/`-iv` are
+  set). LOCMAF carries all information needed to reconstruct a valid CMAF
+  file and therefore supports both commercial DRM (CPIX) and ClearKey/ECCP
+- LOCMAF subscriber support in mlmsub: decodes full and delta moofs against
+  the LOCMAF-encoded `moov` from the catalog and rewrites a standard CMAF
+  fragment for the mux/video/audio outputs
+- `cmd/locmaf` test asset generator: writes a CMAF init segment, the
+  matching LOCMAF init, and two LOCMAF objects (full moof + delta moof) so
+  other LOCMAF implementations can test against a reference asset. Output is
+  encrypted (cbcs) to exercise the encrypted-field path. Input and output
+  paths are configurable via `-input` / `-out`
+- `cmd/locmaf roundtrip` subcommand: encodes a fragmented MP4 through the
+  LOCMAF encoder/decoder, verifies sample-level fidelity (mdat byte-equal
+  and matching size / duration / effective flags / composition-time offset
+  / decode time per ISO 14496-12 §8.8.8.2), and prints wire-overhead
+  statistics for the init segment and per-moof. Useful for validating
+  LOCMAF compression and fidelity against arbitrary fMP4 inputs
+- `MoofDeltaCompressor` / `MoofDeltaDecompressor` types in `internal` that
+  maintain the per-track previous-moof state used to encode and decode
+  LOCMAF delta moofs
+
 ### Fixed
 
 - CENC IV reuse across CMAF fragments: track per-`ContentTrack` running IV

--- a/README.md
+++ b/README.md
@@ -38,8 +38,9 @@ All streams are aligned to UTC wall-clock time at two levels:
    displacement is applied without accumulated drift over time.
 
 In addition to CMSF, mlmpub also announces an [LOC][LOC] (Low Overhead
-Container) namespace and a [moq-mi][moq-mi] (MoQ Media Interop) namespace.
-See the [Namespaces](#namespaces) section below for details.
+Container) namespace, a [moq-mi][moq-mi] (MoQ Media Interop) namespace, and
+one or more LOCMAF (Low Overhead CMAF) namespaces. See the
+[Namespaces](#namespaces) section below for details.
 
 This project uses [moqtransport][moqtransport] for the MoQ transport layer,
 supporting both draft-14 and draft-16 of MOQT. Draft-16 uses ALPN-based version
@@ -60,7 +61,7 @@ convention.
 | `cmsf/eccp-{scheme}` | CMSF (CMAF chunks) | `-kid`/`-iv` set | `_eccp` | ClearKey/ECCP (explicit key over HTTP) |
 | `msf/clear` | LOC ([draft-mzanaty-moq-loc][LOC]) | Always | *(none)* | AVC video + AAC/Opus audio, clear only |
 | `moq-mi/clear` | moq-mi ([draft-cenzano-moq-media-interop][moq-mi]) | When asset has AVC + AAC-LC/Opus | *(none)* | Catalogless, fixed track names `video0` / `audio0` |
-| `locmaf/clear` | LOCMAF | Always | (none) | Unencrypted Tracks
+| `locmaf/clear` | LOCMAF | Always | *(none)* | Unencrypted tracks |
 | `locmaf/drm-{scheme}` | LOCMAF | `-drmpath` set | `_drm` | Commercial DRM (Widevine/PlayReady/FairPlay via CPIX) |
 | `locmaf/eccp-{scheme}` | LOCMAF | `-kid`/`-iv` set | `_eccp` | ClearKey/ECCP (explicit key over HTTP) |
 
@@ -92,12 +93,40 @@ the codec bitstream as defined by moqmi (AVCC length-prefixed NALUs for
 video, raw frames for AAC/Opus) and are written through unchanged by `mlmsub`
 — this namespace is intended for interop testing, not direct ffplay playback.
 
-### LOCMAF
-This locmaf namespace implements Low Overhead CMAF (LOCMAF), a LOC-inspired variant of CMAF which uses MoQT key-value pairs to extract only the required information from CMAF headers in order to create a low overhead. If this option is used the packaging will be `locmaf` and both the catalog `initData` field and object payloads will use key-value pairs for storing CMAF headers. Each object starts with a LOCMAF full moof or a LOCMAF delta moof. The first moof header in a group is always sent as a LOCMAF full moof which contains all required moof field. The following moof headers in a group will be sent as a LOCMAF delta moof which only store the difference between two consecutive moof headers and ignores fields with no difference.
+### LOCMAF (`locmaf/clear`, `locmaf/drm-{scheme}`, `locmaf/eccp-{scheme}`)
 
-LOCMAF carries all information needed to reconstruct a valid CMAF file and therefore supports DRM. Only fields necessary for playback are sent in LOCMAF so to reconstruct a valid CMAF header an empty header needs to be created and the fields signaled via LOCMAF need to replace the fields in the created header.
+LOCMAF (Low Overhead CMAF) is a LOC-inspired variant of CMAF in which only
+the non-derivable `moof`/`moov` fields are sent, encoded as MoQT key-value
+pairs over QUIC varints. The packaging value in the catalog is `locmaf`, and
+the catalog `initData` field is the LOCMAF-encoded `moov`. Object payloads
+each start with either:
 
-QUIC varints are used but since composition time offset requires signed integers and since the LOCMAF delta moofs store the differences as signed integers (except for the deltedFields field), zigzag-scanning is used to encode signed varints.
+- a **LOCMAF full moof** — carries every required moof field; always used
+  for the first object of a group, and
+- a **LOCMAF delta moof** — carries only the fields that changed since the
+  previous moof; used for all subsequent objects in a group.
+
+Subscribers reconstruct a valid CMAF init segment and CMAF media fragments
+by decoding the LOCMAF fields and merging them into empty CMAF templates.
+Because all fields needed for playback (including encryption metadata) are
+carried, LOCMAF supports both commercial DRM (CPIX) and ClearKey/ECCP, with
+the same namespace layout as CMSF: `locmaf/clear`, `locmaf/drm-{scheme}`,
+and `locmaf/eccp-{scheme}`.
+
+LOCMAF deltas store signed differences and the composition time offset is
+itself signed, so signed values use zigzag-encoded varints (`0 → 0`,
+`-1 → 1`, `1 → 2`, `-2 → 3`, …) on top of the QUIC varint wire format.
+
+See [`docs/LOCMAF.md`](docs/LOCMAF.md) for the design rationale — how
+LOCMAF maps to LL-HLS Parts / DASH Chunked CMAF, where its compression
+wins come from in the sample-level low-latency regime, and how the wire
+format is positioned to add future object types like `prft` without a
+version bump.
+
+See [Generating LOCMAF test assets](#generating-locmaf-test-assets) below
+for a small standalone tool that emits a CMAF init segment, the matching
+LOCMAF init segment, and a few LOCMAF objects so other LOCMAF
+implementations can be tested against a reference asset.
 
 ## Session setup
 
@@ -287,7 +316,7 @@ go run . -kid 39112233445566778899aabbccddeeff -iv 41112233445566778899aabbccdde
          -sideport 8081 -laurl https://moqlivemock.demo.osaas.io/clearkey
 ```
 
-This announces namespace `cmsf/eccp-cbcs` and `locmaf/eccp-cbcs with tracks like `video_400kbps_avc_eccp`.
+This announces namespaces `cmsf/eccp-cbcs` and `locmaf/eccp-cbcs` with tracks like `video_400kbps_avc_eccp`.
 
 #### Commercial DRM (CPIX)
 
@@ -298,7 +327,7 @@ Supported systems: Widevine, PlayReady, FairPlay.
 go run . -drmpath ../../assets/testdrm/drm_config_test.json
 ```
 
-This announces namespace `cmsf/drm-{scheme}` and `locmaf/drm-{scheme}` with tracks like `video_400kbps_avc_drm`.
+This announces namespaces `cmsf/drm-{scheme}` and `locmaf/drm-{scheme}` with tracks like `video_400kbps_avc_drm`.
 
 #### Both simultaneously
 
@@ -310,7 +339,7 @@ go run . -drmpath ../../assets/drm/drm_config.json \
          -sideport 8081 -laurl https://moqlivemock.demo.osaas.io/clearkey
 ```
 
-This announces three namespaces per DRM-capable packaging. For CMSF these are: `cmaf/clear`, `cmaf/drm-cbcs`, and `cmaf/eccp-cbcs`.
+This announces three namespaces per DRM-capable packaging. For CMSF these are: `cmsf/clear`, `cmsf/drm-cbcs`, and `cmsf/eccp-cbcs`; for LOCMAF: `locmaf/clear`, `locmaf/drm-cbcs`, and `locmaf/eccp-cbcs`.
 
 #### Subscriber examples
 
@@ -322,10 +351,10 @@ so no extra flags are needed except choosing the right namespace and track names
 go run . -muxout - | ffplay -
 
 # ECCP-protected content
-go run . -namespace cmaf/eccp-cbcs -videoname _eccp -audioname _eccp -muxout - | ffplay -
+go run . -namespace cmsf/eccp-cbcs -videoname _eccp -audioname _eccp -muxout - | ffplay -
 
 # DRM-protected content
-go run . -namespace cmaf/drm-cbcs -videoname _drm -audioname _drm -muxout - | ffplay -
+go run . -namespace cmsf/drm-cbcs -videoname _drm -audioname _drm -muxout - | ffplay -
 
 # LOC packaging — AVC reframed to AnnexB, AAC reframed to ADTS
 go run . -namespace msf/clear -videoout video.h264 -audioout audio.aac
@@ -340,18 +369,48 @@ go run . -namespace locmaf/clear -videoname _avc -audioname _aac -muxout - | ffp
 ```
 
 ### Generating LOCMAF test assets
-For testing purposes in non-moqlivemock applications, a command for generating test assets is provided. 
-It writes to file, a CMAF init segment, a LOCMAF init segment, and 2 objects of LOCMAF full moof + payload, 
-and LOCMAF delta moof + payload. 
 
-To run this file use
+To help other LOCMAF implementations validate against a reference, the
+`cmd/locmaf` tool emits a fixed set of files for a single fragmented MP4
+input: a plain CMAF init segment, the matching LOCMAF-encoded init, one
+LOCMAF full moof object (header + payload), and one LOCMAF delta moof
+object (header + payload). The asset is cbcs-encrypted so the encrypted
+LOCMAF fields are exercised.
+
 ```sh
 cd cmd/locmaf
 go run . testgen
 ```
 
-It is possible to change the input and output file via the flags ```-input``` and ```-out```.
-The asset is encrypted cbcs to test that encrypted LOCMAF fields work.
+Use `-input` to point at a different fragmented MP4 and `-out` to choose
+the output directory.
+
+### Round-tripping fMP4 through LOCMAF
+
+The `roundtrip` subcommand encodes a fragmented MP4 through the LOCMAF
+encoder, decodes it back, verifies fidelity (mdat byte-equal plus matching
+sample size / duration / flags / composition-time offset / decode time per
+ISO 14496-12 §8.8.8.2 effective-flag semantics), and prints wire-overhead
+statistics.
+
+```sh
+cd cmd/locmaf
+go run . roundtrip                                          # default video_400kbps_avc.mp4
+go run . roundtrip -input ../../assets/test10s/video_900kbps_hevc.mp4
+go run . roundtrip -verbose                                  # per-fragment table
+```
+
+Sample output:
+
+```
+Init segment (ftyp+moov vs LOCMAF init object):
+  cmaf   =    828 B
+  locmaf =     75 B  (9.1% of cmaf)
+
+Moofs (250 fragments: 1 full + 249 delta):
+  cmaf   total =   26040 B  (avg 104.2 B/moof)
+  locmaf total =     592 B  (avg   2.4 B/moof, 2.3% of cmaf)
+```
 
 ## QUIC / WebTransport Configuration
 

--- a/cmd/locmaf/main.go
+++ b/cmd/locmaf/main.go
@@ -10,7 +10,7 @@ func main() {
 	command := "experiments"
 	if len(args) > 0 {
 		switch args[0] {
-		case "testgen":
+		case "testgen", "roundtrip":
 			command = args[0]
 			args = args[1:]
 		case "help", "-h", "--help":
@@ -23,6 +23,8 @@ func main() {
 	switch command {
 	case "testgen":
 		err = runTestFileGeneratorCommand(args)
+	case "roundtrip":
+		err = runRoundtripCommand(args)
 	default:
 		err = fmt.Errorf("unknown command %q", command)
 	}
@@ -33,8 +35,9 @@ func main() {
 }
 
 func printUsage() {
-	fmt.Fprintf(os.Stderr, "usage: locmaf [experiments|testgen] [flags]\n")
+	fmt.Fprintf(os.Stderr, "usage: locmaf [experiments|testgen|roundtrip] [flags]\n")
 	fmt.Fprintf(os.Stderr, "\n")
 	fmt.Fprintf(os.Stderr, "commands:\n")
 	fmt.Fprintf(os.Stderr, "  testgen      generate LOCMAF test files\n")
+	fmt.Fprintf(os.Stderr, "  roundtrip    encode an fMP4 through LOCMAF and verify fidelity\n")
 }

--- a/cmd/locmaf/roundtrip.go
+++ b/cmd/locmaf/roundtrip.go
@@ -1,0 +1,537 @@
+package main
+
+import (
+	"bytes"
+	"compress/gzip"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/Eyevinn/moqlivemock/internal"
+	"github.com/Eyevinn/mp4ff/mp4"
+)
+
+const defaultRoundtripInput = "../../assets/test10s/video_400kbps_avc.mp4"
+
+// segmentPaths collects repeated -segment flag values.
+type segmentPaths []string
+
+func (s *segmentPaths) String() string     { return strings.Join(*s, ",") }
+func (s *segmentPaths) Set(v string) error { *s = append(*s, v); return nil }
+
+func runRoundtripCommand(args []string) error {
+	flags := flag.NewFlagSet("roundtrip", flag.ContinueOnError)
+	inputPath := flags.String("input", "", "single fragmented MP4 to round-trip (mutually exclusive with -init)")
+	initPath := flags.String("init", "", "CMAF init segment (used with one or more -segment)")
+	var segments segmentPaths
+	flags.Var(&segments, "segment", "CMAF media segment (.m4s); repeat for multiple")
+	trackInfoPath := flags.String("track-info", "",
+		"optional CMSF Track JSON (overrides metadata otherwise synthesised from the moov)")
+	verbose := flags.Bool("verbose", false, "print per-fragment stats")
+	if err := flags.Parse(args); err != nil {
+		return err
+	}
+	if flags.NArg() > 0 {
+		return fmt.Errorf("unexpected positional arguments: %v", flags.Args())
+	}
+
+	if *inputPath == "" && *initPath == "" {
+		*inputPath = defaultRoundtripInput
+	}
+	if *inputPath != "" && *initPath != "" {
+		return fmt.Errorf("-input and -init are mutually exclusive")
+	}
+	if *initPath != "" && len(segments) == 0 {
+		return fmt.Errorf("-init requires at least one -segment")
+	}
+
+	return runRoundtrip(*inputPath, *initPath, segments, *trackInfoPath, *verbose)
+}
+
+func runRoundtrip(inputPath, initPath string, segmentPaths []string, trackInfoPath string, verbose bool) error {
+	moov, initBytes, fragments, sourceLabel, err := loadMoovAndFragments(inputPath, initPath, segmentPaths)
+	if err != nil {
+		return err
+	}
+
+	track, trackSource, err := resolveTrack(moov, trackInfoPath)
+	if err != nil {
+		return err
+	}
+
+	initStats, err := roundtripMoov(moov, initBytes, track)
+	if err != nil {
+		return fmt.Errorf("moov round-trip: %w", err)
+	}
+
+	moofStats, err := roundtripFragments(fragments, moov, initStats.decodedMoov, verbose)
+	if err != nil {
+		return fmt.Errorf("moof round-trip: %w", err)
+	}
+
+	printRoundtripReport(sourceLabel, trackSource, track, initStats, moofStats)
+	return nil
+}
+
+// loadMoovAndFragments parses either a single concatenated fMP4 (inputPath)
+// or a separate init+segments pair, and returns the moov, the raw wire-form
+// init bytes (the on-disk init.mp4 in separate mode, or a fresh serialisation
+// of ftyp+moov in single-input mode), and the list of fragments in order.
+func loadMoovAndFragments(inputPath, initPath string, segmentPaths []string) (
+	moov *mp4.MoovBox, initBytes []byte, fragments []*mp4.Fragment, sourceLabel string, err error) {
+
+	if inputPath != "" {
+		file, ferr := decodeFile(inputPath)
+		if ferr != nil {
+			return nil, nil, nil, "", ferr
+		}
+		if !file.IsFragmented() {
+			return nil, nil, nil, "", fmt.Errorf("%s is not a fragmented MP4", inputPath)
+		}
+		if len(file.Moov.Traks) != 1 {
+			return nil, nil, nil, "", fmt.Errorf("expected one track in moov, got %d", len(file.Moov.Traks))
+		}
+		var buf bytes.Buffer
+		if file.Ftyp != nil {
+			if err := file.Ftyp.Encode(&buf); err != nil {
+				return nil, nil, nil, "", fmt.Errorf("re-serialise ftyp: %w", err)
+			}
+		}
+		if err := file.Moov.Encode(&buf); err != nil {
+			return nil, nil, nil, "", fmt.Errorf("re-serialise moov: %w", err)
+		}
+		var frags []*mp4.Fragment
+		for _, seg := range file.Segments {
+			frags = append(frags, seg.Fragments...)
+		}
+		return file.Moov, buf.Bytes(), frags, inputPath, nil
+	}
+
+	rawInit, readErr := os.ReadFile(initPath)
+	if readErr != nil {
+		return nil, nil, nil, "", fmt.Errorf("read init %s: %w", initPath, readErr)
+	}
+	initFile, ferr := mp4.DecodeFile(bytes.NewReader(rawInit))
+	if ferr != nil {
+		return nil, nil, nil, "", fmt.Errorf("decode %s: %w", initPath, ferr)
+	}
+	if initFile.Moov == nil {
+		return nil, nil, nil, "", fmt.Errorf("%s has no moov", initPath)
+	}
+	if len(initFile.Moov.Traks) != 1 {
+		return nil, nil, nil, "", fmt.Errorf("expected one track in moov, got %d", len(initFile.Moov.Traks))
+	}
+
+	var allFrags []*mp4.Fragment
+	for _, segPath := range segmentPaths {
+		segFile, ferr := decodeFile(segPath)
+		if ferr != nil {
+			return nil, nil, nil, "", ferr
+		}
+		if len(segFile.Segments) == 0 {
+			return nil, nil, nil, "", fmt.Errorf("%s has no segments", segPath)
+		}
+		for _, seg := range segFile.Segments {
+			allFrags = append(allFrags, seg.Fragments...)
+		}
+	}
+	label := fmt.Sprintf("%s + %d segment(s)", initPath, len(segmentPaths))
+	return initFile.Moov, rawInit, allFrags, label, nil
+}
+
+func decodeFile(path string) (*mp4.File, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, fmt.Errorf("open %s: %w", path, err)
+	}
+	defer f.Close()
+	file, err := mp4.DecodeFile(f)
+	if err != nil {
+		return nil, fmt.Errorf("decode %s: %w", path, err)
+	}
+	return file, nil
+}
+
+// resolveTrack returns the Track metadata to feed DecompressInit. If a
+// track-info JSON path is given, it is loaded and used as authoritative.
+// Otherwise the metadata is synthesised from the moov.
+func resolveTrack(moov *mp4.MoovBox, trackInfoPath string) (internal.Track, string, error) {
+	if trackInfoPath == "" {
+		t, err := synthesizeTrackFromMoov(moov)
+		return t, "synthesised from moov", err
+	}
+	data, err := os.ReadFile(trackInfoPath)
+	if err != nil {
+		return internal.Track{}, "", fmt.Errorf("read track info %s: %w", trackInfoPath, err)
+	}
+	var t internal.Track
+	if err := json.Unmarshal(data, &t); err != nil {
+		return internal.Track{}, "", fmt.Errorf("parse track info %s: %w", trackInfoPath, err)
+	}
+	if t.Role == "" || t.Timescale == nil {
+		return internal.Track{}, "", fmt.Errorf("track info %s missing required fields role/timescale",
+			trackInfoPath)
+	}
+	return t, "from " + trackInfoPath, nil
+}
+
+// initRoundtripStats holds size accounting and the decoded moov used to
+// decompress the moofs.
+type initRoundtripStats struct {
+	cmafInitBytes   int
+	locmafInitBytes int
+	gzipInitBytes   int
+	decodedMoov     *mp4.MoovBox
+}
+
+func roundtripMoov(moov *mp4.MoovBox, cmafInitBytes []byte, track internal.Track) (initRoundtripStats, error) {
+	compressedMoov, err := internal.CompressMoov(moov)
+	if err != nil {
+		return initRoundtripStats{}, fmt.Errorf("compress moov: %w", err)
+	}
+	locmafInit := createCompressedObject(uint64(internal.MoovHeader), compressedMoov, nil)
+
+	decodedInit, err := internal.DecompressInit(compressedMoov, track)
+	if err != nil {
+		return initRoundtripStats{}, fmt.Errorf("decompress init: %w", err)
+	}
+	if decodedInit == nil || decodedInit.Moov == nil {
+		return initRoundtripStats{}, fmt.Errorf("decompressed init has no moov")
+	}
+
+	if err := verifyMoovFidelity(moov, decodedInit.Moov); err != nil {
+		return initRoundtripStats{}, fmt.Errorf("moov fidelity: %w", err)
+	}
+
+	gzipSize, err := gzipSize(cmafInitBytes)
+	if err != nil {
+		return initRoundtripStats{}, fmt.Errorf("gzip init: %w", err)
+	}
+
+	return initRoundtripStats{
+		cmafInitBytes:   len(cmafInitBytes),
+		locmafInitBytes: len(locmafInit),
+		gzipInitBytes:   gzipSize,
+		decodedMoov:     decodedInit.Moov,
+	}, nil
+}
+
+// gzipSize returns the gzip-compressed size of data at default compression
+// level. Use this as the "what could plain gzip achieve" baseline.
+func gzipSize(data []byte) (int, error) {
+	var buf bytes.Buffer
+	w := gzip.NewWriter(&buf)
+	if _, err := w.Write(data); err != nil {
+		return 0, err
+	}
+	if err := w.Close(); err != nil {
+		return 0, err
+	}
+	return buf.Len(), nil
+}
+
+// fragmentRoundtripStats accumulates moof-level wire stats.
+type fragmentRoundtripStats struct {
+	count                int
+	cmafMoofBytes        int
+	locmafObjectBytes    int
+	locmafFullMoofBytes  int
+	locmafDeltaMoofBytes int
+	fullMoofCount        int
+	deltaMoofCount       int
+}
+
+func roundtripFragments(fragments []*mp4.Fragment, encoderMoov, decoderMoov *mp4.MoovBox,
+	verbose bool) (fragmentRoundtripStats, error) {
+	var compressor internal.MoofDeltaCompressor
+	var decompressor internal.MoofDeltaDecompressor
+	var stats fragmentRoundtripStats
+
+	if verbose {
+		fmt.Printf("%-5s %-7s %10s %10s %8s %s\n",
+			"frag#", "kind", "cmafMoof", "locmafObj", "ratio", "samples")
+	}
+
+	for idx, frag := range fragments {
+		if frag.Moof == nil || frag.Mdat == nil {
+			return stats, fmt.Errorf("fragment %d missing moof or mdat", idx)
+		}
+		cmafMoofSize := int(frag.Moof.Size())
+
+		headerID, props, err := compressor.CompressMoof(frag.Moof, encoderMoov)
+		if err != nil {
+			return stats, fmt.Errorf("fragment %d: compress moof: %w", idx, err)
+		}
+		locmafObject := createCompressedObject(uint64(headerID), props, frag.Mdat.Data)
+		locmafObjectSize := len(locmafObject) - len(frag.Mdat.Data)
+
+		seqnum := frag.Moof.Mfhd.SequenceNumber
+		reconMoof, reconMdat, err := decompressor.DecompressMoof(locmafObject, seqnum, decoderMoov)
+		if err != nil {
+			return stats, fmt.Errorf("fragment %d: decompress moof: %w", idx, err)
+		}
+		if !bytes.Equal(reconMdat, frag.Mdat.Data) {
+			return stats, fmt.Errorf("fragment %d: mdat mismatch (got %d bytes, want %d bytes)",
+				idx, len(reconMdat), len(frag.Mdat.Data))
+		}
+		if err := verifyFragmentFidelity(frag, reconMoof, encoderMoov, decoderMoov); err != nil {
+			return stats, fmt.Errorf("fragment %d fidelity: %w", idx, err)
+		}
+
+		stats.count++
+		stats.cmafMoofBytes += cmafMoofSize
+		stats.locmafObjectBytes += locmafObjectSize
+		kind := "delta"
+		if headerID == internal.MoofHeader {
+			kind = "full"
+			stats.fullMoofCount++
+			stats.locmafFullMoofBytes += locmafObjectSize
+		} else {
+			stats.deltaMoofCount++
+			stats.locmafDeltaMoofBytes += locmafObjectSize
+		}
+		if verbose {
+			ratio := float64(locmafObjectSize) / float64(cmafMoofSize)
+			fmt.Printf("%-5d %-7s %10d %10d %7.2fx %d\n",
+				idx, kind, cmafMoofSize, locmafObjectSize, ratio,
+				len(frag.Moof.Traf.Trun.Samples))
+		}
+	}
+	if stats.count == 0 {
+		return stats, fmt.Errorf("no fragments found in input")
+	}
+	return stats, nil
+}
+
+func printRoundtripReport(sourceLabel, trackSource string, track internal.Track,
+	init initRoundtripStats, moof fragmentRoundtripStats) {
+	fmt.Printf("\nLOCMAF round-trip report for %s\n", sourceLabel)
+	fmt.Printf("  track (%s): role=%s codec=%s timescale=%d\n",
+		trackSource, track.Role, track.Codec, derefInt(track.Timescale))
+	fmt.Printf("\nInit segment:\n")
+	fmt.Printf("  cmaf   = %6d B\n", init.cmafInitBytes)
+	fmt.Printf("  locmaf = %6d B  (%.1f%% of cmaf)\n",
+		init.locmafInitBytes, percent(init.locmafInitBytes, init.cmafInitBytes))
+	fmt.Printf("  gzip   = %6d B  (%.1f%% of cmaf)\n",
+		init.gzipInitBytes, percent(init.gzipInitBytes, init.cmafInitBytes))
+
+	fmt.Printf("\nMoofs (%d fragments: %d full + %d delta):\n",
+		moof.count, moof.fullMoofCount, moof.deltaMoofCount)
+	fmt.Printf("  cmaf   total = %7d B  (avg %5.1f B/moof)\n",
+		moof.cmafMoofBytes, avg(moof.cmafMoofBytes, moof.count))
+	fmt.Printf("  locmaf total = %7d B  (avg %5.1f B/moof, %.1f%% of cmaf)\n",
+		moof.locmafObjectBytes, avg(moof.locmafObjectBytes, moof.count),
+		percent(moof.locmafObjectBytes, moof.cmafMoofBytes))
+	if moof.fullMoofCount > 0 {
+		fmt.Printf("  locmaf full  = %7d B  (avg %5.1f B/full moof)\n",
+			moof.locmafFullMoofBytes, avg(moof.locmafFullMoofBytes, moof.fullMoofCount))
+	}
+	if moof.deltaMoofCount > 0 {
+		fmt.Printf("  locmaf delta = %7d B  (avg %5.1f B/delta moof)\n",
+			moof.locmafDeltaMoofBytes, avg(moof.locmafDeltaMoofBytes, moof.deltaMoofCount))
+	}
+
+	totalCmaf := init.cmafInitBytes + moof.cmafMoofBytes
+	totalLocmaf := init.locmafInitBytes + moof.locmafObjectBytes
+	fmt.Printf("\nCombined header overhead (init + moofs, excluding mdat payload):\n")
+	fmt.Printf("  cmaf   = %7d B\n", totalCmaf)
+	fmt.Printf("  locmaf = %7d B  (%.1f%% of cmaf, saving %d B)\n",
+		totalLocmaf, percent(totalLocmaf, totalCmaf), totalCmaf-totalLocmaf)
+	fmt.Printf("\nFidelity: OK — all %d fragments mdat-equal and structurally consistent.\n", moof.count)
+}
+
+func synthesizeTrackFromMoov(moov *mp4.MoovBox) (internal.Track, error) {
+	if moov == nil || moov.Trak == nil {
+		return internal.Track{}, fmt.Errorf("moov or trak missing")
+	}
+	trak := moov.Trak
+	if trak.Mdia == nil || trak.Mdia.Mdhd == nil {
+		return internal.Track{}, fmt.Errorf("mdhd missing")
+	}
+	if trak.Mdia.Minf == nil || trak.Mdia.Minf.Stbl == nil || trak.Mdia.Minf.Stbl.Stsd == nil {
+		return internal.Track{}, fmt.Errorf("stsd missing")
+	}
+	stsd := trak.Mdia.Minf.Stbl.Stsd
+	if len(stsd.Children) == 0 {
+		return internal.Track{}, fmt.Errorf("stsd has no children")
+	}
+
+	timescale := int(trak.Mdia.Mdhd.Timescale)
+	t := internal.Track{Timescale: &timescale}
+
+	switch entry := stsd.Children[0].(type) {
+	case *mp4.VisualSampleEntryBox:
+		t.Role = "video"
+		w := int(trak.Tkhd.Width >> 16)
+		h := int(trak.Tkhd.Height >> 16)
+		t.Width = &w
+		t.Height = &h
+		t.Codec = innerCodec(entry, entry.Type())
+	case *mp4.AudioSampleEntryBox:
+		t.Role = "audio"
+		sr := int(entry.SampleRate)
+		t.SampleRate = &sr
+		t.Codec = innerCodec(entry, entry.Type())
+	case *mp4.StppBox:
+		t.Role = "subtitle"
+		t.Codec = entry.Type()
+	case *mp4.WvttBox:
+		t.Role = "subtitle"
+		t.Codec = entry.Type()
+	default:
+		return internal.Track{}, fmt.Errorf("unsupported sample entry type %s", stsd.Children[0].Type())
+	}
+	return t, nil
+}
+
+// innerCodec returns the original four-CC for a sample entry. For encrypted
+// entries (encv/enca) it walks sinf.frma to find the wrapped codec; otherwise
+// it returns the sample entry type directly.
+func innerCodec(entry mp4.Box, fallback string) string {
+	var sinf *mp4.SinfBox
+	switch e := entry.(type) {
+	case *mp4.VisualSampleEntryBox:
+		sinf = e.Sinf
+	case *mp4.AudioSampleEntryBox:
+		sinf = e.Sinf
+	}
+	if sinf != nil && sinf.Frma != nil && sinf.Frma.DataFormat != "" {
+		return sinf.Frma.DataFormat
+	}
+	return fallback
+}
+
+// verifyMoovFidelity checks that the round-tripped moov has matching
+// timescale and sample entry type. LOCMAF intentionally drops fields that
+// can be re-derived (e.g. track_id, which the decoder always sets to 1),
+// so this is a structural check, not a byte-level one.
+func verifyMoovFidelity(orig, recon *mp4.MoovBox) error {
+	if orig.Mvhd.Timescale != recon.Mvhd.Timescale {
+		return fmt.Errorf("mvhd timescale: orig=%d recon=%d",
+			orig.Mvhd.Timescale, recon.Mvhd.Timescale)
+	}
+	if orig.Trak.Mdia.Mdhd.Timescale != recon.Trak.Mdia.Mdhd.Timescale {
+		return fmt.Errorf("mdhd timescale: orig=%d recon=%d",
+			orig.Trak.Mdia.Mdhd.Timescale, recon.Trak.Mdia.Mdhd.Timescale)
+	}
+	origEntry := orig.Trak.Mdia.Minf.Stbl.Stsd.Children[0]
+	reconEntry := recon.Trak.Mdia.Minf.Stbl.Stsd.Children[0]
+	if origEntry.Type() != reconEntry.Type() {
+		return fmt.Errorf("sample entry type: orig=%s recon=%s",
+			origEntry.Type(), reconEntry.Type())
+	}
+	return nil
+}
+
+// verifyFragmentFidelity checks that the round-tripped moof yields the same
+// effective samples as the original, after trex defaults are applied. The
+// original fragment is resolved against the source moov's trex (whose
+// track_id matches the source tfhd), while the reconstructed fragment uses
+// the decoded moov's trex (track_id always 1 — LOCMAF does not preserve it).
+func verifyFragmentFidelity(orig *mp4.Fragment, reconMoof *mp4.MoofBox,
+	origMoov, decodedMoov *mp4.MoovBox) error {
+	if origMoov.Mvex == nil || origMoov.Mvex.Trex == nil {
+		return fmt.Errorf("original moov missing trex")
+	}
+	if decodedMoov.Mvex == nil || decodedMoov.Mvex.Trex == nil {
+		return fmt.Errorf("decoded moov missing trex")
+	}
+	origTrex := origMoov.Mvex.Trex
+	reconTrex := decodedMoov.Mvex.Trex
+
+	origSamples, err := orig.GetFullSamples(origTrex)
+	if err != nil {
+		return fmt.Errorf("get original samples: %w", err)
+	}
+
+	reconFrag := mp4.NewFragment()
+	reconFrag.AddChild(reconMoof)
+	reconFrag.AddChild(&mp4.MdatBox{Data: orig.Mdat.Data})
+	reconSamples, err := reconFrag.GetFullSamples(reconTrex)
+	if err != nil {
+		return fmt.Errorf("get reconstructed samples: %w", err)
+	}
+
+	if len(origSamples) != len(reconSamples) {
+		return fmt.Errorf("sample count: orig=%d recon=%d",
+			len(origSamples), len(reconSamples))
+	}
+	origFlags := effectiveSampleFlags(orig.Moof.Traf, origTrex)
+	reconFlags := effectiveSampleFlags(reconFrag.Moof.Traf, reconTrex)
+	for i := range origSamples {
+		o, r := origSamples[i], reconSamples[i]
+		if o.Size != r.Size {
+			return fmt.Errorf("sample %d size: orig=%d recon=%d", i, o.Size, r.Size)
+		}
+		if o.Dur != r.Dur {
+			return fmt.Errorf("sample %d dur: orig=%d recon=%d", i, o.Dur, r.Dur)
+		}
+		if origFlags[i] != reconFlags[i] {
+			return fmt.Errorf("sample %d flags: orig=%#x recon=%#x",
+				i, origFlags[i], reconFlags[i])
+		}
+		if o.CompositionTimeOffset != r.CompositionTimeOffset {
+			return fmt.Errorf("sample %d cto: orig=%d recon=%d",
+				i, o.CompositionTimeOffset, r.CompositionTimeOffset)
+		}
+		if o.DecodeTime != r.DecodeTime {
+			return fmt.Errorf("sample %d dts: orig=%d recon=%d",
+				i, o.DecodeTime, r.DecodeTime)
+		}
+	}
+	return nil
+}
+
+// effectiveSampleFlags returns the per-sample flags after applying the
+// ISO 14496-12 §8.8.8.2 override: when first_sample_flags is present in the
+// trun, it replaces the per-sample value for sample 0. This matches how a
+// spec-compliant player resolves flags during playback, regardless of how
+// the trun's HasSampleFlags / HasFirstSampleFlags bits are set in memory.
+func effectiveSampleFlags(traf *mp4.TrafBox, trex *mp4.TrexBox) []uint32 {
+	trun := traf.Trun
+	tfhd := traf.Tfhd
+	defaultFlags := uint32(0)
+	if tfhd.HasDefaultSampleFlags() {
+		defaultFlags = tfhd.DefaultSampleFlags
+	} else if trex != nil {
+		defaultFlags = trex.DefaultSampleFlags
+	}
+	out := make([]uint32, len(trun.Samples))
+	for i := range trun.Samples {
+		if i == 0 {
+			if first, present := trun.FirstSampleFlags(); present {
+				out[i] = first
+				continue
+			}
+		}
+		if trun.HasSampleFlags() {
+			out[i] = trun.Samples[i].Flags
+		} else {
+			out[i] = defaultFlags
+		}
+	}
+	return out
+}
+
+func percent(n, d int) float64 {
+	if d == 0 {
+		return 0
+	}
+	return 100 * float64(n) / float64(d)
+}
+
+func avg(total, count int) float64 {
+	if count == 0 {
+		return 0
+	}
+	return float64(total) / float64(count)
+}
+
+func derefInt(p *int) int {
+	if p == nil {
+		return 0
+	}
+	return *p
+}

--- a/cmd/locmaf/roundtrip_test.go
+++ b/cmd/locmaf/roundtrip_test.go
@@ -1,0 +1,356 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/Eyevinn/moqlivemock/internal"
+	"github.com/Eyevinn/mp4ff/mp4"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	bundledAVCAsset  = "../../assets/test10s/video_400kbps_avc.mp4"
+	bundledHEVCAsset = "../../assets/test10s/video_900kbps_hevc.mp4"
+	bundledAACAsset  = "../../assets/test10s/audio_monotonic_128kbps_aac.mp4"
+	bundledOpusAsset = "../../assets/test10s/audio_monotonic_128kbps_opus.mp4"
+)
+
+// End-to-end coverage of runRoundtrip on every bundled codec.
+//
+// Each bundled asset is a fragmented MP4 containing one media track. The
+// test runs the full pipeline (parse, synthesise track metadata, compress
+// moov, decompress moov, compress every moof, decompress every moof, and
+// verify per-sample fidelity) and only asserts on the error result —
+// runRoundtrip itself reports per-fragment failures via err.
+
+func TestRunRoundtrip_AVC(t *testing.T) {
+	require.NoError(t, runRoundtrip(bundledAVCAsset, "", nil, "", false))
+}
+
+func TestRunRoundtrip_HEVC(t *testing.T) {
+	require.NoError(t, runRoundtrip(bundledHEVCAsset, "", nil, "", false))
+}
+
+func TestRunRoundtrip_AAC(t *testing.T) {
+	require.NoError(t, runRoundtrip(bundledAACAsset, "", nil, "", false))
+}
+
+func TestRunRoundtrip_Opus(t *testing.T) {
+	require.NoError(t, runRoundtrip(bundledOpusAsset, "", nil, "", false))
+}
+
+func TestRunRoundtrip_Verbose(t *testing.T) {
+	// Verbose mode prints a per-fragment table; only verify the pipeline
+	// still succeeds with verbose enabled.
+	require.NoError(t, runRoundtrip(bundledAVCAsset, "", nil, "", true))
+}
+
+func TestRunRoundtrip_WithTrackInfoJSON(t *testing.T) {
+	// Side-channel JSON path: write a minimal CMSF-shaped Track,
+	// then run roundtrip with -track-info pointing at it.
+	timescale := 12800
+	width := 384
+	height := 216
+	tr := internal.Track{
+		Role:      "video",
+		Codec:     "avc1",
+		Timescale: &timescale,
+		Width:     &width,
+		Height:    &height,
+	}
+	data, err := json.Marshal(tr)
+	require.NoError(t, err)
+	jsonPath := filepath.Join(t.TempDir(), "track.json")
+	require.NoError(t, os.WriteFile(jsonPath, data, 0o644))
+
+	require.NoError(t, runRoundtrip(bundledAVCAsset, "", nil, jsonPath, false))
+}
+
+func TestRunRoundtrip_NonexistentFile(t *testing.T) {
+	err := runRoundtrip("/no/such/file.mp4", "", nil, "", false)
+	require.Error(t, err)
+}
+
+// synthesizeTrackFromMoov unit tests — verify the catalog-side Track
+// shape inferred from a parsed moov for each media type.
+
+func TestSynthesizeTrackFromMoov_Video(t *testing.T) {
+	moov := mustLoadMoov(t, bundledAVCAsset)
+	tr, err := synthesizeTrackFromMoov(moov)
+	require.NoError(t, err)
+	require.Equal(t, "video", tr.Role)
+	require.Equal(t, "avc1", tr.Codec)
+	require.NotNil(t, tr.Timescale)
+	require.Positive(t, *tr.Timescale)
+	require.NotNil(t, tr.Width)
+	require.NotNil(t, tr.Height)
+	require.Positive(t, *tr.Width)
+	require.Positive(t, *tr.Height)
+	require.Nil(t, tr.SampleRate)
+}
+
+func TestSynthesizeTrackFromMoov_HEVC(t *testing.T) {
+	moov := mustLoadMoov(t, bundledHEVCAsset)
+	tr, err := synthesizeTrackFromMoov(moov)
+	require.NoError(t, err)
+	require.Equal(t, "video", tr.Role)
+	require.Equal(t, "hvc1", tr.Codec)
+}
+
+func TestSynthesizeTrackFromMoov_Audio(t *testing.T) {
+	moov := mustLoadMoov(t, bundledAACAsset)
+	tr, err := synthesizeTrackFromMoov(moov)
+	require.NoError(t, err)
+	require.Equal(t, "audio", tr.Role)
+	require.Equal(t, "mp4a", tr.Codec)
+	require.NotNil(t, tr.Timescale)
+	require.NotNil(t, tr.SampleRate)
+	require.Equal(t, 48000, *tr.SampleRate)
+	require.Nil(t, tr.Width)
+	require.Nil(t, tr.Height)
+}
+
+// resolveTrack covers both arms: explicit JSON wins; absent JSON falls
+// back to the moov-synthesised track.
+
+func TestResolveTrack_FromJSON(t *testing.T) {
+	moov := mustLoadMoov(t, bundledAVCAsset)
+
+	timescale := 90000
+	width := 1280
+	height := 720
+	tr := internal.Track{
+		Role:      "video",
+		Codec:     "avc1.640028",
+		Timescale: &timescale,
+		Width:     &width,
+		Height:    &height,
+	}
+	data, err := json.Marshal(tr)
+	require.NoError(t, err)
+	jsonPath := filepath.Join(t.TempDir(), "track.json")
+	require.NoError(t, os.WriteFile(jsonPath, data, 0o644))
+
+	resolved, source, err := resolveTrack(moov, jsonPath)
+	require.NoError(t, err)
+	require.Contains(t, source, "track.json")
+	require.Equal(t, "avc1.640028", resolved.Codec)
+	require.Equal(t, 90000, *resolved.Timescale)
+	require.Equal(t, 1280, *resolved.Width)
+}
+
+func TestResolveTrack_Synthesised(t *testing.T) {
+	moov := mustLoadMoov(t, bundledAVCAsset)
+	tr, source, err := resolveTrack(moov, "")
+	require.NoError(t, err)
+	require.Equal(t, "synthesised from moov", source)
+	require.Equal(t, "video", tr.Role)
+}
+
+func TestResolveTrack_MissingRequiredFields(t *testing.T) {
+	moov := mustLoadMoov(t, bundledAVCAsset)
+	// Track JSON with no role / no timescale — should be rejected.
+	jsonPath := filepath.Join(t.TempDir(), "bad.json")
+	require.NoError(t, os.WriteFile(jsonPath, []byte(`{"codec":"avc1"}`), 0o644))
+
+	_, _, err := resolveTrack(moov, jsonPath)
+	require.Error(t, err)
+}
+
+func TestResolveTrack_BadJSONPath(t *testing.T) {
+	moov := mustLoadMoov(t, bundledAVCAsset)
+	_, _, err := resolveTrack(moov, "/no/such/track.json")
+	require.Error(t, err)
+}
+
+// gzipSize is a small helper but exercised heavily in roundtrip stats;
+// pin its behaviour with two cases.
+
+func TestGzipSize_Compresses(t *testing.T) {
+	data := bytes.Repeat([]byte("hello world "), 100) // 1200 B, highly redundant
+	size, err := gzipSize(data)
+	require.NoError(t, err)
+	require.Less(t, size, len(data))
+}
+
+func TestGzipSize_Empty(t *testing.T) {
+	size, err := gzipSize(nil)
+	require.NoError(t, err)
+	// gzip header + trailer for empty input is small but non-zero.
+	require.Positive(t, size)
+}
+
+func TestGzipSize_Random(t *testing.T) {
+	// Random/incompressible data should not blow up; gzip output may be
+	// slightly larger than input, but the call must succeed.
+	data := make([]byte, 1024)
+	for i := range data {
+		data[i] = byte(i * 17) // not random, but not very compressible
+	}
+	_, err := gzipSize(data)
+	require.NoError(t, err)
+}
+
+// Flag-parsing surface of runRoundtripCommand: covers the mutual-
+// exclusion checks and the default-when-nothing-given branch.
+
+func TestRunRoundtripCommand_DefaultsToBundledInput(t *testing.T) {
+	// No flags → defaults to the bundled AVC asset (defaultRoundtripInput).
+	require.NoError(t, runRoundtripCommand(nil))
+}
+
+func TestRunRoundtripCommand_InputAndInitMutuallyExclusive(t *testing.T) {
+	err := runRoundtripCommand([]string{
+		"-input", bundledAVCAsset,
+		"-init", bundledAVCAsset,
+	})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "mutually exclusive")
+}
+
+func TestRunRoundtripCommand_InitRequiresSegment(t *testing.T) {
+	err := runRoundtripCommand([]string{"-init", bundledAVCAsset})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "-segment")
+}
+
+func TestRunRoundtripCommand_UnexpectedPositional(t *testing.T) {
+	err := runRoundtripCommand([]string{bundledAVCAsset})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "positional")
+}
+
+// The separate-input mode of runRoundtrip: split a bundled fMP4 into an
+// init segment file (ftyp + moov) and one media segment file
+// (moof + mdat for the first fragment), then run with -init / -segment.
+
+func TestRunRoundtrip_InitPlusSegmentMode(t *testing.T) {
+	initPath, segPath := splitBundledAVCToInitAndFirstSegment(t)
+	require.NoError(t, runRoundtrip("", initPath, []string{segPath}, "", false))
+}
+
+func TestRunRoundtrip_InitPlusMultipleSegments(t *testing.T) {
+	initPath, segs := splitBundledAVCToInitAndSegments(t, 3)
+	require.NoError(t, runRoundtrip("", initPath, segs, "", false))
+}
+
+// stringSlice (the segmentPaths flag.Value) is exercised by the flag
+// parser when the test above feeds -segment multiple times via the
+// runRoundtripCommand path. Cover the type directly here too.
+
+func TestSegmentPaths_AppendsAndJoins(t *testing.T) {
+	var s segmentPaths
+	require.Empty(t, s.String())
+	require.NoError(t, s.Set("a.m4s"))
+	require.NoError(t, s.Set("b.m4s"))
+	require.Equal(t, []string{"a.m4s", "b.m4s"}, []string(s))
+	require.Equal(t, "a.m4s,b.m4s", s.String())
+}
+
+// Smoke-test the testgen subcommand end-to-end: it should write the six
+// expected artifact files for the bundled AVC asset.
+
+func TestRunTestFileGeneratorCommand(t *testing.T) {
+	out := t.TempDir()
+	args := []string{"-input", bundledAVCAsset, "-out", out}
+	require.NoError(t, runTestFileGeneratorCommand(args))
+
+	for _, name := range []string{
+		cmafInitReferenceFile,
+		locmafInitEncodingFile,
+		locmafFullMoofObjectFile + "-1",
+		locmafFullMoofObjectFile + "-2",
+		locmafDeltaMoofObjectFile + "-1",
+		locmafDeltaMoofObjectFile + "-2",
+	} {
+		path := filepath.Join(out, name)
+		info, err := os.Stat(path)
+		require.NoError(t, err, "expected output file %s to exist", name)
+		require.Positive(t, info.Size(), "expected output file %s to be non-empty", name)
+	}
+}
+
+func TestRunTestFileGeneratorCommand_UnexpectedPositional(t *testing.T) {
+	err := runTestFileGeneratorCommand([]string{"extra-positional"})
+	require.Error(t, err)
+}
+
+// Helpers.
+
+func mustLoadMoov(t *testing.T, path string) *mp4.MoovBox {
+	t.Helper()
+	f, err := os.Open(path)
+	require.NoError(t, err)
+	defer f.Close()
+	file, err := mp4.DecodeFile(f)
+	require.NoError(t, err)
+	require.NotNil(t, file.Moov)
+	return file.Moov
+}
+
+// splitBundledAVCToInitAndFirstSegment decodes the bundled AVC asset and
+// writes (a) ftyp+moov to an init.mp4 and (b) the first fragment's
+// moof+mdat to a 1.m4s file in a temp dir. Returns their paths.
+func splitBundledAVCToInitAndFirstSegment(t *testing.T) (initPath, segPath string) {
+	t.Helper()
+	initPath, segs := splitBundledAVCToInitAndSegments(t, 1)
+	return initPath, segs[0]
+}
+
+func splitBundledAVCToInitAndSegments(t *testing.T, nSegments int) (initPath string, segPaths []string) {
+	t.Helper()
+	f, err := os.Open(bundledAVCAsset)
+	require.NoError(t, err)
+	defer f.Close()
+	file, err := mp4.DecodeFile(f)
+	require.NoError(t, err)
+	require.NotNil(t, file.Ftyp)
+	require.NotNil(t, file.Moov)
+	require.NotEmpty(t, file.Segments)
+
+	dir := t.TempDir()
+
+	var initBuf bytes.Buffer
+	require.NoError(t, file.Ftyp.Encode(&initBuf))
+	require.NoError(t, file.Moov.Encode(&initBuf))
+	initPath = filepath.Join(dir, "init.mp4")
+	require.NoError(t, os.WriteFile(initPath, initBuf.Bytes(), 0o644))
+
+	// Each .m4s carries one fragment's moof+mdat. Walk the fragments
+	// in stream order and emit nSegments files.
+	emitted := 0
+outer:
+	for _, seg := range file.Segments {
+		for _, frag := range seg.Fragments {
+			if emitted >= nSegments {
+				break outer
+			}
+			var sbuf bytes.Buffer
+			require.NoError(t, frag.Moof.Encode(&sbuf))
+			require.NoError(t, frag.Mdat.Encode(&sbuf))
+			path := filepath.Join(dir, segName(emitted+1))
+			require.NoError(t, os.WriteFile(path, sbuf.Bytes(), 0o644))
+			segPaths = append(segPaths, path)
+			emitted++
+		}
+	}
+	require.Equal(t, nSegments, emitted, "bundled asset did not yield enough fragments")
+	return initPath, segPaths
+}
+
+func segName(n int) string {
+	switch n {
+	case 1:
+		return "1.m4s"
+	case 2:
+		return "2.m4s"
+	case 3:
+		return "3.m4s"
+	default:
+		return "seg.m4s"
+	}
+}

--- a/cmd/locmaf/test_file_generator.go
+++ b/cmd/locmaf/test_file_generator.go
@@ -94,7 +94,7 @@ func loadProtectedTestGeneratorTrack(inputPath string) (*internal.ContentTrack, 
 
 func generateFullMoofObjects(track *internal.ContentTrack, count int) ([][]byte, error) {
 	objects := make([][]byte, 0, count)
-	for i := 0; i < count; i++ {
+	for i := range count {
 		var compressor internal.MoofDeltaCompressor
 		object, err := track.GenLocmafChunk(uint32(i), uint64(i), uint64(i+1), &compressor)
 		if err != nil {

--- a/docs/LOCMAF.md
+++ b/docs/LOCMAF.md
@@ -1,0 +1,913 @@
+# LOCMAF: Low Overhead CMAF for MOQ
+
+LOCMAF is a way to stream low-latency CMAF over [MOQT][MOQT] with an
+overhead comparable to [LOC][LOC]. It is intended as a
+packaging format in [CMSF][CMSF] and was developed as part of
+the Master Thesis work by Hugo Björs under the supervision of Torbjörn
+Einarsson at Eyevinn 2026.
+
+LOCMAF provides a way to reconstruct full CMAF headers, segments, and chunks
+which are semantically equivalent to the sender side input.
+They may differ in some syntactic details and total size, but all samples
+and associated metadata are identical.
+
+LOCMAF has been implemented by Hugo in a working MOQ server and client
+available publicly at [moqlivemock.demo.osaas.io][mlm-demo] and on
+GitHub in the two projects [Eyevinn/moqlivemock][moqlivemock] and
+[Eyevinn/warp-player][warp-player].
+
+This is a first version and may evolve depending on feedback and experience.
+
+## Background
+
+One reason that [LOC (Low Overhead Container)][LOC] was developed in
+connection to [MOQ Transport][MOQT] is that
+CMAF has a very high overhead for transporting individual
+data samples, such as video or audio frames.
+
+The minimal CMAF header for a single sample chunk is
+more than 100B (bytes), while LOC is typically 9B.
+In both cases there is an MOQT Object header of ~4B size.
+
+However, consecutive CMAF chunk headers are almost identical,
+so it should be possible to predict them from previous headers
+That would result in a compact wire representation
+of a series of CMAF chunks that can be translated back into
+full CMAF chunks on the receiving end and fed into an MSE/EME player.
+
+LOCMAF (Low Overhead CMAF) is such a compact wire
+representation of CMAF media fragments designed for streaming over MOQT
+that works well together with the [CMSF] catalog.
+It targets the same low-latency workload as Low-Latency HLS
+(LL-HLS) Parts and DASH Chunked CMAF — short segments built from CMAF chunks
+that, at the limit, contain a single sample — but extends the same idea further
+by exploiting the CMSF catalog side-channel and the predictability of consecutive
+`moof` boxes.
+
+LOCMAF can also be used to compress CMAF init segments (aka CMAF headers),
+but since these are only sent once, the gain is smaller. In that
+limited context of compressing one CMAF file, the general ISOBMFF/MP4
+compression proposed by Luke Curley in his
+[Compressed MP4][compressed-mp4] Internet Draft is an alternative.
+
+This document explains how LOCMAF achieves its very high compression
+ratio, the structural assumptions it makes about how MoQ groups are
+laid out, and how the format is positioned to evolve.
+
+## How MoQ groups map to CMAF
+
+In LL-HLS Parts and DASH Chunked CMAF, each segment is a sequence of CMAF
+chunks (one `moof` + one `mdat` per chunk). The chunk duration determines
+the glass-to-glass latency floor, but a shorter duration produces a
+higher total chunk overhead — which is exactly the cost LOCMAF is built to
+remove.
+
+The natural mapping to MoQ Transport is:
+
+- **One MoQ group per CMAF segment.** Group boundaries align with random
+  access points (RAPs), so a new subscriber can tune in at the start of any
+  group and decode immediately. For video, every group starts on an IDR
+  (an independent part in LL-HLS terms).
+- **One MoQ object per CMAF chunk.** Each object carries one `moof` + `mdat`
+  pair. At the extreme (sample-level fragmentation), every video frame and
+  every audio frame is one MoQ object.
+- **Audio groups aligned to video groups.** Most audio codecs (AAC, Opus,
+  AC-3, AC-4) have a RAP on essentially every frame, so audio doesn't need
+  alignment for tune-in. But tune-in is a *joint* operation: when a
+  subscriber starts a video group at wall-clock T, it also wants audio
+  starting at T so the two can be muxed and synchronised. We therefore
+  target the case where audio MOQ groups have the same duration as the video
+  ones.
+
+We want each group to be independent, but inside each group we assume
+that all objects are delivered in order. The main target of LOCMAF
+is to compress the series of moof boxes inside a group.
+
+## Where LOCMAF wins: the moof delta stream
+
+A typical `moof` box for N samples of unencrypted content is
+around `100 + 4*N` bytes in size, meaning `500B` for 100 samples,
+but `104B` for 1 sample, varying in overhead per sample from 5B to 104B.
+After the moof there is a 4B length and 4B `mdat` box type that add 8B
+to the overhead.
+
+In the moqlivemock test content, we have 1s segments/groups of 25 video frames and 46 or 47
+audio frames. The typical overhead from encoding the moofs for audio is therefore around 290B
+if grouping all audio frames into one object, but 4800B if sending them individually. The latter
+should be compared to 420B when using LOC.
+
+However, due to to the similarity of all the values in the moof boxes
+we can transfer the CMAF information much more efficiently.
+
+
+Looking more closely, consecutive raw `moof` boxes have very small differences in their boxes' values:
+
+- `tfhd` defaults (sample duration, size, flags) — usually identical across
+  every fragment in the group.
+- `tfdt.base_media_decode_time` — monotonically advances by the previous
+  fragment's duration; derivable from sum of sample durations.
+- `trun.samples[i].flags` — same value for every non-IDR sample; differs
+  for the first sample of each IDR-containing fragment.
+- `trun.samples[i].duration` - typically not sent, but instead uses default value from `trex` or `tfhd`
+  (relies on a commensurate media timescale — see "Prerequisite: commensurate media timescales" below).
+- `trun.samples[i].composition_time_offset` — only present for video with
+  B-frames and is then a small signed integer with a
+  repetitive pattern that follows the encoder's B-frame structure.
+- `trun.samples[i].size` — the only field that genuinely varies per sample.
+
+LOCMAF exploits this in two stages:
+
+1. **Tfhd against trex defaults.** When `tfhd` carries a value that
+   already matches the `trex` default in the moov, LOCMAF omits it.[^cmf2-defaults]
+2. **Delta encoding within a group.** The first `moof` object of every
+   group is a *full* LOCMAF moof. Each subsequent `moof` is a *delta* moof
+   that carries only the fields whose values differ from the previous moof
+   in the same group, plus a flag identifying which fields were deleted.
+   `base_media_decode_time` is derived implicitly by adding the previous
+   moof's total sample duration.
+
+Furthermore, after the `moof`, there is always an `mdat` box, carrying
+the actual metadata. That start with an 8B header `size (4B) + mdat`.
+In LOCMAF, these 8B are not sent, but the size is derived as
+the remaining size of the MOQT object, and the 4B `mdat` is not needed.
+
+Empirically, on sample-level fragmented streams across AVC, HEVC, AAC, Opus,
+AC-3, and AVC3 sources with no B-frames:
+
+- Full moof: ~8 B (single-sample group start with codec-specific overhead).
+- Delta moof: **2 B in steady state** — just the `MoofDeltaHeader` varint
+  plus a zero-length payload varint when no field changed.
+- Aggregate moof overhead: **~2.3% of CMAF wire bytes**, i.e. a 45:1
+  compression ratio on the `moof` headers themselves.
+
+A small jitter of 4–5 B appears on the delta carrying an IDR change in
+the sample-flags array, which is correct: the random-access flag flip is a
+real bit of information that must be transmitted.
+
+For *dense* moofs (livesim2-style segments holding 50–375 samples in a
+single moof), LOCMAF still removes around 50% of the moof overhead. But the
+delta stream's compounding benefit per-fragment is much larger when each
+fragment is small and similar to its neighbour — exactly the low-latency
+regime.
+
+### Prerequisite: commensurate media timescales
+
+The two-byte steady state described above depends on one assumption from
+the source side: consecutive `moof` boxes must actually be near-identical
+at the field level. The most important precondition is that **every frame
+has an exact integer duration in the chosen media timescale**, so the
+`trex`/`tfhd` default duration covers them and the delta moof can omit the per-sample duration array entirely. Two canonical examples:
+
+- **48 kHz AAC audio:** use timescale **48 000**, which makes one AAC
+  frame exactly **1024** ticks.
+- **60000/1001 fps video** (NTSC family): use timescale **60 000**, which
+  makes one video frame exactly **1001** ticks.
+
+With a commensurate timescale all sample durations equal a single integer
+constant. With a *mis*matched timescale (e.g. a generic 1000-tick-per-second
+timescale for 60000/1001 fps video), each frame's duration drifts by ±1
+tick to track the fractional rate; the per-sample duration array must
+then be sent on every fragment and the 2-byte steady-state delta moof is
+no longer achievable.
+
+## Media segment wire format
+
+A LOCMAF media segment is one MoQ object that carries one CMAF chunk —
+i.e. one `moof` + one `mdat` pair, encoded as a LOCMAF *object*. Every MoQ
+object is self-delimiting (the MoQ Transport layer already provides object
+length), so LOCMAF does not need a total-length field; it only needs to
+know where the moof properties end and the mdat begins.
+
+### Object framing
+
+```
++-----------------------------+
+| header_id        (varint)   |   top-level object kind
++-----------------------------+
+| properties_length (varint)  |   length of the properties block in bytes
++-----------------------------+
+| properties      (variable)  |   sequence of (field_id, value) tuples
++-----------------------------+
+| mdat raw payload (rest)     |   sample data, length = MoQ-object-len - above
++-----------------------------+
+```
+
+`header_id` and `properties_length` are variable-length integers. This
+implementation uses the same varint as MoQ Transport draft-16.
+
+MoQ Transport draft-17 and later replace the QUIC varint with a different
+variable-length integer encoding. A LOCMAF implementation that runs over
+draft-17+ MoQT MUST use the draft-17 varint instead, so the same wire
+format applies consistently across the MoQT control and data planes for a
+given session. All wire-cost numbers in this document assume the
+draft-16 / RFC 9000 varint.
+
+The mdat payload is the *contents* of the CMAF `mdat` box — the sample
+data, without the surrounding `size + 'mdat'` box header. The receiver
+reconstructs a standard `mdat` box by wrapping these bytes in an 8-byte
+ISO BMFF header.
+
+### Top-level object IDs
+
+| ID | Symbol            | Object kind                              |
+| -- | ----------------- | ---------------------------------------- |
+|  21 | `MoovHeader`      | LOCMAF moov (init data in the catalog)   |
+|  23 | `MoofHeader`      | full moof + mdat                         |
+|  25 | `MoofDeltaHeader` | delta moof + mdat                        |
+
+The numeric IDs **start at 21** so they do not collide with LOC's already
+defined property IDs (1–16 in draft-ietf-moq-loc-02). A LOCMAF object can
+therefore live alongside other LOC properties in a MoQ object's
+property/payload split: the LOCMAF init / full moof / delta moof object
+occupies an LOC *private* property slot (carried in the MoQ object
+payload), and other LOC public properties (e.g. Timestamp, Timescale,
+Video Frame Marking) ride in the MoQ object's properties field as usual.
+Storing LOCMAF as a public property is also allowed by the spec but is
+not the default.
+
+Receivers MUST skip (and log) unrecognised `header_id` values rather than
+abort. The `properties_length` lets a skipper advance past the properties
+block, and the MoQ object length terminates the unknown object cleanly.
+(See `MoofDeltaDecompressor.DecompressMoof` for the reference
+implementation.) This makes it possible to later add extra boxes such
+as `prft`.
+
+### Properties: field-tuple encoding
+
+The properties block is a flat sequence of `(field_id, value)` tuples.
+Field IDs are also MOQT varints, and the value encoding is determined by
+the **parity of the ID**:
+
+- **Even ID → scalar varint.** The value is a single MOQT varint. Length
+  is self-describing (1, 2, 4 or 8 bytes). No length prefix.
+- **Odd ID → length-prefixed bytes.** The tuple is `field_id | value_length
+  | value_bytes`, all three being varints / variable-length bytes.
+
+Field IDs may appear in any order; receivers MUST tolerate any ordering.
+The reference encoder emits IDs in ascending order so the wire bytes are
+deterministic.
+
+### Moof field reference
+
+All fields used in `MoofHeader` and `MoofDeltaHeader` objects. The "Source"
+column names the ISO BMFF source field; "Kind" indicates how the value is
+encoded on the wire.
+
+| ID | Symbol                                | Source ISO BMFF field                    | Kind        | Notes                                    |
+| -- | ------------------------------------- | ---------------------------------------- | ----------- | ---------------------------------------- |
+|  1 | `moofSampleSizes`                     | `trun.samples[i].sample_size`            | varint list | one entry per sample                     |
+|  2 | `moofSampleDescriptionIndex`          | `tfhd.sample_description_index`          | scalar      |                                          |
+|  3 | `moofSampleDurations`                 | `trun.samples[i].sample_duration`        | varint list | one entry per sample                     |
+|  4 | `moofDefaultSampleDuration`           | `tfhd.default_sample_duration`           | scalar      |                                          |
+|  5 | `moofSampleCompositionTimeOffsets`    | `trun.samples[i].sample_composition_time_offset` | signed varint list | zigzag-encoded; signed in source |
+|  6 | `moofDefaultSampleSize`               | `tfhd.default_sample_size`               | scalar      |                                          |
+|  7 | `moofSampleFlags`                     | `trun.samples[i].sample_flags`           | varint list | one entry per sample, 32-bit `sample_flags` packed as uint32 |
+|  8 | `moofDefaultSampleFlags`              | `tfhd.default_sample_flags`              | scalar      |                                          |
+|  9 | `moofInitializationVector`            | `senc.samples[i].InitializationVector`   | raw bytes   | concatenated IVs, length = `per_sample_iv_size × sample_count` |
+| 10 | `moofBaseMediaDecodeTime`             | `tfdt.base_media_decode_time`            | scalar      | always in full moof; in delta moof only when the actual BMDT diverges from the derived value (discontinuity / re-anchor) |
+| 11 | `moofSubsampleCount`                  | `senc.samples[i].subsample_count`        | varint list | one entry per sample                     |
+| 12 | `moofFirstSampleFlags`                | `trun.first_sample_flags`                | scalar      | only if `tr_flags.first_sample_flags_present` |
+| 13 | `moofBytesOfClearData`                | `senc.samples[i].subsamples[j].BytesOfClearData` | varint list | flat sequence across all sub-samples |
+| 14 | `moofSampleCount`                     | `trun.sample_count`                      | scalar      |                                          |
+| 15 | `moofBytesOfProtectedData`            | `senc.samples[i].subsamples[j].BytesOfProtectedData` | varint list | flat sequence across all sub-samples |
+| 16 | `moofPerSampleIVSize`                 | `senc.per_sample_iv_size`                | scalar      | only when it overrides `tenc.default_per_sample_iv_size` |
+| 17 | `moofDeltaDeletedLocmafIDs`           | —                                        | varint list | delta-moof only; IDs of fields removed since previous moof |
+
+The ID space is kept structurally aligned with the parity rule: every
+"default" / "scalar" field has an even ID, and every per-sample list field
+has an odd ID. The one exception is `moofInitializationVector` (ID 9, odd
+but raw bytes rather than a varint list), because IVs are uniformly-sized
+opaque byte runs.
+
+### Full moof: when each field is emitted
+
+The encoder produces a full moof by walking the source `moof`/`moov` pair
+and emitting only the fields whose values are NOT derivable from the
+catalog's moov (the trex defaults). The exact rules:
+
+| Field                              | Emitted when                                                                                            |
+| ---------------------------------- | ------------------------------------------------------------------------------------------------------- |
+| `moofSampleDescriptionIndex`       | `tfhd.HasSampleDescriptionIndex()` AND value ≠ `trex.default_sample_description_index`                  |
+| `moofDefaultSampleDuration`        | `tfhd.HasDefaultSampleDuration()` AND value ≠ `trex.default_sample_duration`                            |
+| `moofDefaultSampleSize`            | `tfhd.HasDefaultSampleSize()` AND value ≠ `trex.default_sample_size` AND `sample_count > 1`             |
+| `moofDefaultSampleFlags`           | `tfhd.HasDefaultSampleFlags()` AND value ≠ `trex.default_sample_flags`                                  |
+| `moofBaseMediaDecodeTime`          | always                                                                                                  |
+| `moofSampleCount`                  | always                                                                                                  |
+| `moofFirstSampleFlags`             | `trun.HasFirstSampleFlags()`                                                                            |
+| `moofSampleSizes`                  | `trun.HasSampleSize()` AND `sample_count > 1`                                                           |
+| `moofSampleDurations`              | `trun.HasSampleDuration()`                                                                              |
+| `moofSampleCompositionTimeOffsets` | `trun.HasSampleCompositionTimeOffset()`                                                                 |
+| `moofSampleFlags`                  | `trun.HasSampleFlags()`                                                                                 |
+| `moofPerSampleIVSize`              | senc present AND `per_sample_iv_size ≠ tenc.default_per_sample_iv_size`                                 |
+| `moofInitializationVector`         | senc present AND `per_sample_iv_size > 0` AND `len(senc.IVs) > 0`                                       |
+| `moofSubsampleCount`               | senc present AND `len(senc.subsamples) > 0`                                                             |
+| `moofBytesOfClearData`             | same as `moofSubsampleCount`                                                                            |
+| `moofBytesOfProtectedData`         | same as `moofSubsampleCount`                                                                            |
+
+The `moofSampleSizes` omission rule for single-sample fragments deserves
+note: when `sample_count == 1` and no per-sample size is sent, the receiver
+infers the single sample's size from the MoQ object's mdat-payload length
+(MoQ-object-length minus the object framing already consumed). This saves
+a few bytes per fragment in the sample-level fragmentation regime, which is
+the common case.
+
+### Delta moof: incremental encoding
+
+A delta moof carries only the fields whose effective values differ from
+the previous moof in the same group. Three rules govern the payload:
+
+1. **`moofBaseMediaDecodeTime` (ID 10) is normally derived, not emitted.**
+   The receiver computes the new BMDT as
+   `previous_bmdt + sum(previous_sample_durations)`, where
+   `sample_durations` are taken from either the previous moof's
+   `moofSampleDurations` list (if present) or the previous moof's
+   effective `default_sample_duration` × `sample_count`.
+
+   When the actual BMDT in the source diverges from the derived value
+   (audio pre-roll, splicing, stream-tear / re-anchor), the encoder
+   **emits ID 10 as an absolute value** in the delta moof to override
+   the derivation. The receiver checks for the field first and uses its
+   value when present; otherwise it falls back to the derivation. The
+   absolute override is encoded the same way as in a full moof — a
+   plain unsigned varint, not a zigzag delta.
+
+2. **Each field value is a *signed delta* of its previous representation**,
+   keyed by `moofDeltaValueKind(id)`:
+
+   | Kind             | When                                  | Encoding on wire                                                                  | Reconstruction                                                            |
+   | ---------------- | ------------------------------------- | --------------------------------------------------------------------------------- | ------------------------------------------------------------------------- |
+   | scalar           | even ID                               | single zigzag-encoded signed varint = `current_value − previous_value`            | `current_value = previous_value + delta`; re-encoded as the field's value |
+   | varint-list      | odd ID (except 9)                     | zigzag-signed deltas concatenated, one per element                                | element-wise sum with the previous list                                   |
+   | raw bytes        | ID 9 (`moofInitializationVector`)     | full IV bytes verbatim — IVs are cryptographically opaque, no delta makes sense   | overwrite previous IV bytes                                               |
+
+3. **`moofDeltaDeletedLocmafIDs` (ID 17) lists fields removed since the
+   previous moof.** It is a varint list of locmaf IDs. The decoder applies
+   the deletion before applying the deltas in (2). Used for transitions
+   like "first fragment had `moofFirstSampleFlags`, subsequent ones don't".
+
+An empty delta payload (`properties_length = 0`) is valid and means "no
+field changed since previous moof" — the steady-state case for
+sample-level fragmented streams. The on-wire object reduces to just
+`MoofDeltaHeader | 0 | mdat`, which is **2 bytes plus the mdat**.
+
+### Worked example: a one-sample-per-moof delta stream
+
+Consider an AVC video track fragmented one frame per moof, with the
+encoder having chosen `trex` defaults that match the steady-state per-frame
+values (typical for an mp4ff-encoded stream). A raw CMAF moof is ~100 B per
+fragment. The LOCMAF objects for the first three fragments of a group are:
+
+**Fragment 0 — full moof (IDR / group start), ~8–20 bytes depending on flags:**
+
+```
++----------------------------+
+| MoofHeader=23 (1 B)        |
++----------------------------+
+| properties_length (1 B)    |
++----------------------------+
+| moofSampleCount=1          |   2 B  (ID 14 + 1-byte varint)
+| moofBaseMediaDecodeTime    |   ≈2 B (ID 10 + bmdt varint, longer as bmdt grows)
+| moofFirstSampleFlags       |   2–5 B (ID 12 + sample_flags varint; the
+|                            |          sync-sample value 0x02000003 fits in 4 B)
++----------------------------+
+| mdat raw payload …         |
++----------------------------+
+```
+
+Only `moofSampleCount` and `moofBaseMediaDecodeTime` are mandatory; every
+other field is omitted when its source value matches the catalog's trex
+default or its `HasDefault*` flag is unset. For sample-level fragmentation
+where `tfhd` carries no overrides and `trun.first_sample_flags` is absent
+(per-sample flag carries the sync bit instead), the full moof shrinks to
+just the count + bmdt pair plus the LOCMAF framing — around 6 B.
+
+**Fragment 1 — delta moof, IDR → non-sync transition, ~4–5 bytes:**
+
+The only difference from the previous moof is that `first_sample_flags` is
+no longer present (the new fragment's leading frame is non-sync, with flags
+matching `tfhd.default_sample_flags`). The encoder emits:
+
+```
++-------------------------+
+| MoofDeltaHeader=25 (1B) |
++-------------------------+
+| properties_length (1 B) |
++-------------------------+
+| moofDeltaDeletedLocmafIDs       ← ID 17 (odd → length-prefixed)
+|   length=1, payload=[12]        ← "field 12 removed since previous"
++-------------------------+
+| mdat raw payload …      |
++-------------------------+
+```
+
+**Fragments 2..N-1 — delta moof, no field changed, 2 bytes:**
+
+```
++-------------------------+
+| MoofDeltaHeader=25 (1B) |
++-------------------------+
+| properties_length = 0   |   1 B
++-------------------------+
+| mdat raw payload …      |
++-------------------------+
+```
+
+This is the steady state. `moofBaseMediaDecodeTime` advances implicitly,
+all sample-level fields are unchanged from the previous moof, the
+two-byte LOCMAF wrapper carries the entire `moof` worth of information.
+
+Empirically measured against
+`assets/test10s/video_400kbps_avc.mp4` (250 fragments, 1 sample each):
+
+| metric                          | bytes  |
+| ------------------------------- | -----: |
+| CMAF moof total                 | 26 040 |
+| LOCMAF object total (no mdat)   |   592  |
+| LOCMAF full moof                |   19 (one)   |
+| LOCMAF delta moof, average      |   2.3  |
+
+Re-runnable via `go run ./cmd/locmaf roundtrip -verbose`.
+
+### Round-trip semantics
+
+For both full and delta moof reconstruction, the decoder reuses the moov
+parsed from the catalog's `initData`:
+
+- default values from `trex` in the reconstructed moov are used as
+  basis, but overruled by default values in `tfhd`.
+- `track_id` is taken from `moov.trak.tkhd.track_id`
+- The reconstructed sample's effective `sample_flags` for sample 0 follows
+  `first_sample_flags` (if present)
+
+These choices make the LOCMAF representation lossy at the byte level (the
+reconstructed `moof.Size()` may differ from the source) but lossless at
+the *playback* level (every sample has the same `size`, `dts`, `cts`,
+`flags`, and encryption metadata as the source) — *provided* the source
+also satisfies the structural assumptions below.
+
+#### `trun.tr_flags` is implicit
+
+LOCMAF carries no `trun.tr_flags` value. Encoding-side, `tr_flags` is
+consulted only to gate which `moofSampleXxx` fields are emitted;
+decoding-side, the reconstructed `trun` uses a fixed `tr_flags = 0xf01`
+plus conditional bits for `composition_time_offset_present` and
+`first_sample_flags_present`.[^trflags-impl] The implication: the reconstructed `trun` may
+declare per-sample arrays as "present" where the source omitted them via
+`tr_flags = 0`. Effective sample-level fidelity is preserved; byte-level
+identity of the `trun` box is not.
+
+#### Implicit `tfdt.baseMediaDecodeTime`
+
+A delta moof normally omits `moofBaseMediaDecodeTime`; the receiver
+derives the new BMDT as
+`previous_bmdt + sum(previous_sample_durations)`. If the prediction is
+wrong — audio pre-roll, splicing, or stream-tear / re-anchor — the
+encoder emits `moofBaseMediaDecodeTime` (id 10) as an absolute value in
+the delta moof, and the receiver uses that value instead of the
+derivation.
+
+### Moov field reference
+
+For completeness, the field-ID table used inside a `MoovHeader` object. The
+same parity rule applies (even ID → scalar varint, odd ID → length-prefixed
+bytes). The catalog Track object supplies `role`, `timescale` (per the
+catalog's `timescale` field, mapped to `mdhd.timescale`), `width`,
+`height`, `samplerate`, and `codec`, so those fields are *not* present in
+the LOCMAF moov payload — they live in the catalog instead.
+
+| ID | Symbol                          | Source box | Description                                    |
+| -- | ------------------------------- | ---------- | ---------------------------------------------- |
+|  1 | `moovColr`                      | stsd       | colour information box (raw bytes)             |
+|  2 | `moovMovieTimescale`            | mvhd       | movie timescale                                |
+|  3 | `moovPasp`                      | stsd       | pixel aspect ratio box (raw bytes)             |
+|  4 | `moovTkhdFlags`                 | tkhd       | track header flags                             |
+|  5 | `moovChnl`                      | stsd       | audio channel layout box (raw bytes)           |
+|  6 | `moovMediaTime`                 | elst       | edit-list media_time of the first entry (signed zigzag varint) |
+|  7 | `moovCodecConfigurationBox`     | stsd       | codec config record (avcC, hvcC, esds, …; raw bytes) |
+|  8 | `moovFormat`                    | stsd       | sample-entry FourCC packed as uint32           |
+|  9 | `moovDefaultKID`                | tenc       | default Key ID (16 bytes)                      |
+| 10 | `moovChannelCount`              | stsd       | audio channel count                            |
+| 11 | `moovDefaultConstantIV`         | tenc       | default constant IV bytes                      |
+| 12 | `moovSchemeType`                | schm       | protection scheme FourCC (cenc / cbcs)         |
+| 14 | `moovTencVersion`               | tenc       | tenc box version                               |
+| 16 | `moovDefaultCryptByteBlock`     | tenc       | pattern encryption: encrypted block count      |
+| 18 | `moovDefaultSkipByteBlock`      | tenc       | pattern encryption: skipped block count        |
+| 20 | `moovDefaultPerSampleIVSize`    | tenc       | per-sample IV size                             |
+| 22 | `moovDefaultConstantIVSize`     | tenc       | constant IV size                               |
+| 24 | `moovDefaultSampleDuration`     | trex       | track extension default sample duration        |
+| 26 | `moovDefaultSampleSize`         | trex       | track extension default sample size            |
+| 28 | `moovDefaultSampleFlags`        | trex       | track extension default sample flags           |
+
+The trex defaults at IDs 24/26/28 are the same defaults that the moof
+encoder compares against when deciding whether to omit a matching tfhd
+field — once the receiver decodes the moov it has the trex values needed
+to interpret incoming moofs.
+
+For CMSF without DRM, only IDs 2, 4, 7, 8 (and rarely 1, 3, 5, 10) are
+emitted; the moov payload typically lands at 50–80 B plus the codec config
+box. For encrypted content the tenc-related IDs (9, 11, 12, 14, 16, 18,
+20, 22) appear, and the moov grows by the size of the codec-specific keys
+and IVs.
+
+## Init segments: less critical, but still compressible
+
+CMAF init segments (the `ftyp + moov` pair) are sent once per track per
+subscriber session. In CMSF (Common Media MoQ Streaming Format) the init
+bytes ride inside the catalog Track object as a base64 `initData` field, so
+the subscriber sees them on subscribe rather than at every fragment.
+
+For a typical video stream that runs for minutes, the init is a one-time
+cost amortised over thousands of moof bytes. The wire-budget pressure is
+*not* the init — it is the per-fragment moof stream. So a simpler init
+encoding is acceptable.
+
+That said, LOCMAF does compress the init meaningfully:
+
+- For most moovs measured (650–1100 B), LOCMAF gets to **8–20% of CMAF**,
+  because it can drop fields that the catalog already carries (track role,
+  timescale, dimensions, sample rate, codec four-cc) and rebuild them on
+  the receiver from the catalog Track object.
+- For codec-config-heavy moovs (HEVC ~3 KB, where the bulk is VPS/SPS/PPS),
+  LOCMAF can only reach ~50–76% because the parameter-set bytes are opaque
+  blobs that have to be transmitted verbatim. In those cases plain gzip
+  actually compresses better because it entropy-codes the parameter-set
+  bitstream.
+
+Two reasonable simpler alternatives that could replace or coexist with
+LOCMAF-encoded init:
+
+- **Gzip-wrapped `ftyp + moov`.** Hits 45–55% of CMAF regardless of
+  content. Cheap to implement, codec-agnostic, but never as small as the
+  catalog-aware LOCMAF init on simple moovs.
+- **Standard ISO BMFF compressed-box wrapping** (ISO/IEC 14496-12 has a
+  generic mechanism for compressed box payloads). Carries any box,
+  including future ones, with a documented compression algorithm. Lets the
+  init encoding stay a strict subset of standard ISO BMFF.
+
+Because the catalog `initData` is a self-describing opaque blob from the
+catalog's point of view, all three encodings can coexist behind a header-ID
+varint as the first byte of the payload: `MoovHeader=21` for LOCMAF,
+`MoovGzipHeader=27` for gzip-wrapped CMAF, etc. Decoders dispatch on the
+leading varint before parsing the payload — no schema change to CMSF is
+required to support an additional encoding.
+
+## Forward extensibility
+
+LOCMAF object framing is uniform: every object is a `header_id` varint
+followed by a `payload_length` varint and the payload bytes. Receivers
+that encounter an unrecognised `header_id` log it and skip the payload
+by its declared length, so a sender can introduce new object types
+without breaking older readers.[^skip-impl]
+
+The obvious candidate for the next object type is **`prft` (Producer
+Reference Time)**[^prft-spec] for wall-clock signalling:
+
+- Low-latency live streaming benefits from explicit wall-clock mapping at
+  each fragment so receivers can compute the producer-to-glass latency
+  and align audio/video tune-in to absolute time.
+- `prft` carries `reference_track_ID` (uint32), a 64-bit NTP timestamp
+  (`NTP64`: upper 32 bits = seconds since 1900, **lower 32 bits =
+  fixed-point fraction** where the full 32-bit range represents one
+  second), and a `media_time` (uint32 or uint64). For a 60-fps stream at
+  sample-level fragmentation that's an extra object every ~16.667 ms.
+- The same delta-coding pattern applies: the first `prft` of a group is
+  full (track ID + absolute NTP + absolute media_time), subsequent ones
+  carry only the deltas. **Both deltas must be signed (zigzag-encoded
+  varints)** rather than unsigned, because:
+  - The producer's wall clock can be corrected backward (NTP sync
+    adjustment), making the NTP delta negative.
+  - With B-frames the encoder's composition-time-offset reordering means
+    a fragment's anchor in presentation order can precede the previous
+    fragment's; depending on how the implementation defines the prft
+    anchor (decode-time vs. presentation-time), media_time deltas can
+    therefore be negative.
+  - Stream re-anchoring (the same scenarios that justify the absolute
+    BMDT override for delta moofs) can move time backward.
+  Signed zigzag costs the same number of bytes as unsigned for typical
+  positive deltas — it just permits negative ones when needed.
+- The NTP deltas are still not tiny, though, because of the 32-bit NTP
+  fraction: a 16.667 ms increment at 60 fps is
+  `16.667 ms × 2³² / 1000 ms ≈ 71.6 million NTP ticks`; a 40 ms
+  increment at 25 fps is ~171.8 million; an AAC frame at 48 kHz
+  (≈ 21.33 ms) is ~91.6 million. Each of these fits in a 4-byte QUIC
+  varint (signed zigzag puts the magnitude in the same band), so the
+  NTP-delta payload alone is **~4 B per `prft` object**.
+- `media_time` delta is typically very small in the natural track
+  timescale (e.g. 1024 for AAC at 48 kHz, 1001 for 60000/1001 fps
+  video), encoding as a 1- or 2-byte zigzag varint.
+- Total steady-state cost per `prft` object: ~4 B NTP-delta + ~1–2 B
+  media_time-delta + 2 B LOCMAF wrapper = **~7–8 B**.
+
+A second-derivative optimisation would buy back some of that: if the
+frame rate is stable, the NTP delta is constant across consecutive
+fragments, so the *delta of the delta* is zero (or near-zero — small
+clock-jitter values). Encoding NTP as a delta-of-delta would shrink the
+steady-state `prft` to ~3 B per object. Worth keeping in mind, but only
+the simple delta scheme is needed to start.
+
+A third option is to **carry an approximate timestamp** instead of full
+NTP precision. Tune-in and audio/video sync rarely need sub-millisecond
+wall-clock accuracy; a microsecond-resolution timestamp (or even
+millisecond) is enough in practice. A LOCMAF `prft` variant that carries
+the high N bits of the NTP fraction (or replaces NTP with vi64
+microseconds-since-Unix-epoch, mirroring the LOC Timestamp property at
+id 6) shrinks the per-fragment NTP-delta from ~4 B to ~2 B: a 16.667 ms
+delta at microsecond resolution is 16 667, a 40 ms delta is 40 000 — both
+2-byte varints. Combined with delta-of-delta, the per-`prft` cost lands
+near the LOCMAF framing floor.
+
+Other plausible additions — `sidx` for in-band index, `emsg` for DASH events,
+`tkhd`/`mfhd` extensions — fit the same pattern: allocate a new top-level
+`header_id`, document the payload field IDs, and old decoders skip
+gracefully.
+
+## Possible improvements
+
+A few directions in which LOCMAF could be refined further, listed roughly
+by potential per-fragment byte savings.
+
+### Pack `sample_flags` more compactly
+
+The 32-bit ISO BMFF `sample_flags` field (ISO/IEC 14496-12:2022 §8.8.3.1)
+is bit-packed:
+
+| bits | field |
+| --- | --- |
+| 31–28 | reserved (zero) |
+| 27–26 | `is_leading` (2 bits) |
+| 25–24 | `sample_depends_on` (2 bits) |
+| 23–22 | `sample_is_depended_on` (2 bits) |
+| 21–20 | `sample_has_redundancy` (2 bits) |
+| 19–17 | `sample_padding_value` (3 bits) |
+| 16 | `sample_is_non_sync_sample` (1 bit) |
+| 15–0 | `sample_degradation_priority` (16 bits) |
+
+Information-theoretically a meaningful `sample_flags` value uses only
+about 5–7 bits — but the populated bits live high. A typical IDR encodes
+to `0x02000000` (≈ 33.5 million), a typical P-frame to `0x01010000`
+(≈ 16.8 million), so each per-sample entry lands in the **4-byte QUIC
+varint band** even though all the real information would fit in a single
+byte. The `sample_degradation_priority` low-16-bit field is essentially
+always zero in modern content (it is a legacy QoS hint).
+
+Two approaches would shrink the per-sample `moofSampleFlags` cost from
+4 B to 1 B:
+
+1. **Bit-reorder for transport.** Pack the populated fields into the low
+   bits before emitting the varint and re-expand to 32-bit on decode.
+   For instance: `(sample_is_non_sync_sample << 6) | (sample_depends_on << 4) | (sample_is_depended_on << 2) | is_leading` — fits in 7 bits, single-byte varint.
+2. **Per-track flag dictionary.** Most CMAF tracks see only 2–3 distinct
+   flag values (sync vs non-sync, with/without `is_depended_on`). The
+   first occurrence of each unique value gets a small index and
+   subsequent samples reference the index. With a 2-bit dictionary index
+   in the varint payload, a per-sample flag value collapses to 1 B.
+
+Either approach drops the IDR→P transition delta from ~4 B to ~1 B.
+Not currently the dominant cost, but it would close the gap for video
+streams that interleave IDRs and P-frames frequently (e.g. 1-second GOPs
+at 60 fps).
+
+### Carry `prft` with delta-coding
+
+Already sketched in "Forward extensibility": NTP-timestamp + media-time
+deltas as a separate top-level LOCMAF object. Realistic steady-state
+cost is **~7–8 B per `prft` object** with full NTP precision (NTP
+fraction deltas of tens of millions still need a 4-byte varint), ~3 B
+with delta-of-delta, or **down toward the framing floor with an
+approximate timestamp** (microsecond-resolution vi64, mirroring the LOC
+Timestamp property; per-fragment deltas of 16 667 or 40 000 µs fit in
+2-byte varints). Adds explicit wall-clock signalling without inflating
+the moof object itself.
+
+### Omit CENC per-sample IVs via counter prediction
+
+For `cenc` (and `cens`) protection schemes the per-sample IV is a
+big-endian integer counter, advanced sample-by-sample by exactly
+`ceil(total_encrypted_bytes_in_sample / 16)` per
+ISO/IEC 23001-7. Both endpoints know the previous IV and the
+previous sample's `bytesOfProtectedData` totals (LOCMAF IDs 13 and 15
+are already in the payload), so the receiver can derive the next IV
+deterministically. When the source follows the standard CENC counter,
+the encoder can omit `moofInitializationVector` (ID 9) entirely from
+both full and delta moofs — the receiver computes it.
+
+At 1 sample per fragment with 8-byte IVs that's **~480 B/s saved at
+60 fps**, and **~960 B/s at 16-byte IVs**, dropping to zero on the
+wire. Today the same data sits in id 9 as raw, non-delta-able bytes.
+
+When the encoder doesn't follow CENC counter semantics — random IVs,
+mid-track counter restart, a non-conformant per-track scheme — emit
+the absolute IV as today. This is the same predict-and-fallback
+pattern as the BMDT discontinuity override, just applied per-sample
+within the moof rather than per-moof.
+
+Caveats:
+
+- `cbcs` uses a constant IV from `tenc.default_constant_iv` and emits
+  no per-sample IV at all. Already optimal; no-op.
+- The counter is over **encrypted** bytes, which for sub-sample
+  encryption (most video) is the sum of `bytesOfProtectedData`, not
+  the full sample size.
+- `per_sample_iv_size` (8 or 16 bytes, from `tenc`) determines how
+  the counter wraps; 8-byte IVs are zero-extended to 128 bits before
+  arithmetic, but only the high or low 8 bytes appear on the wire.
+- First IV of a track is the anchor — carried in the full moof, same
+  as today.
+
+### Drop the per-object framing overhead floor
+
+Every LOCMAF object carries a header-ID varint (≥ 1 B) and a
+properties-length varint (≥ 1 B), so the minimum per-object cost is 2 B
+even with an empty payload. For ultra-low-bitrate audio (where the mdat
+is itself only a few hundred bytes) this 2 B floor is a measurable
+fraction of total overhead. Two possible mitigations:
+
+1. **Implicit framing for the most common case.** Treat a zero-byte
+   object payload (a MoQ object with no LOCMAF data) as an implicit
+   "delta moof, no field changed". This drops the floor to 0 B but
+   creates an ambiguity with reserved IDs and would need a careful
+   spec wording. Hugo's thesis §6.4 notes this trade-off explicitly.
+2. **Promote LOCMAF properties to LOC public properties.** Today
+   LOCMAF lives in the MoQ object payload (LOC's "private property"
+   slot). If LOCMAF properties were promoted to LOC public properties
+   in the MoQ object's properties field, the LOC framing would
+   identify the LOCMAF property directly and the redundant LOCMAF
+   header-ID varint could be dropped.
+
+### Carry codec config records in the catalog instead of the moov
+
+For codec-config-heavy moovs (HEVC `hvcC` ~2.5 KB, MPEG-H `mhaC`,
+VVC `vvcC`), the LOCMAF moov payload is dominated by the opaque
+codec config bytes. Moving them out of the LOCMAF moov and into the
+catalog Track as a base64 field would let the LOCMAF moov stay small
+across all codecs. This is a CMSF schema change rather than a LOCMAF
+wire-format change, so it's a separate decision, but worth flagging
+because LOCMAF's "we drop derivable fields" principle naturally
+extends here.
+
+### Pre-flight source validation
+
+Several LOCMAF assumptions are structural rather than enforced by the
+CMAF spec: contiguous `tfdt.baseMediaDecodeTime` across fragments,
+commensurate timescales (integer per-frame duration), single-track moov,
+stable `trex` defaults across the stream, and (for full `cmf2`
+conformance) `tfhd`-resident defaults. None of these are checked today —
+the encoder simply emits LOCMAF.
+
+An encoder mode that validates the source before turning LOCMAF on
+would catch:
+
+1. **Non-integer per-frame duration.** Verify that
+   `media_timescale × frame_period` is integer for the configured frame
+   rate / sample rate. Reject `1000 / 60000-over-1001` etc. (see the
+   "Prerequisite: commensurate media timescales" section).
+2. **Mismatched trex defaults.** Verify that the source's actual
+   per-fragment defaults (after `AddSampleDefaultValues`) genuinely match
+   the moov's `trex` — i.e. that the encoder isn't about to omit a
+   field that shouldn't be omitted.
+3. **Multi-track moov.** Reject any moov with more than one track (CMAF
+   allows only one anyway, but the LOCMAF code path assumes it).
+
+(BMDT contiguity is *not* a precondition: the encoder already re-anchors
+the timeline in-band by emitting an absolute `moofBaseMediaDecodeTime`
+in the delta moof whenever the derived value would be wrong. A warning
+log when this happens is useful operationally, but does not block
+LOCMAF encoding.)
+
+If validation fails, the publisher should either fix the source (e.g.
+re-package with the correct timescale) or fall back to a non-LOCMAF
+packaging — see next item.
+
+### Full CMAF chunk header as a fallback object kind
+
+Today the only top-level object kinds for media segments are
+`MoofHeader = 23` (full LOCMAF moof) and `MoofDeltaHeader = 25` (delta
+LOCMAF moof). BMDT discontinuities are handled in-band via the absolute
+`moofBaseMediaDecodeTime` override (see the Round-trip semantics
+section), so they do not need a fallback object kind. But other
+structural mismatches — fragments with field combinations the encoder
+can't express in the current vocabulary, or content with multi-entry
+edit lists — leave no clean escape hatch. Allocating two more IDs
+along the same lines as the init-side gzip discussion would close that
+gap:
+
+| ID (proposed) | Symbol | Object kind |
+| --- | --- | --- |
+| 31 | `MoofRawHeader` | raw CMAF `moof` (uncompressed) + mdat |
+| 33 | `MoofGzipHeader` | gzip-wrapped CMAF `moof` + mdat |
+
+`MoofRawHeader` carries the original CMAF `moof` bytes verbatim in the
+LOCMAF payload, followed by mdat. `MoofGzipHeader` carries the
+gzip-deflated `moof` bytes. Either is fully self-contained — no reliance
+on `trex` defaults, BMDT contiguity, or any other LOCMAF-side
+assumption. The encoder can switch on a per-fragment basis: emit the
+delta moof for fragments that fit, and a raw / gzip-wrapped CMAF
+fragment when the validator says no.
+
+The decoder dispatches on the header ID exactly as it already does for
+unknown objects — the `MoofDeltaDecompressor` would gain two new cases
+that take the LOCMAF payload, run the appropriate decompression (none
+for raw, gzip-inflate for the wrapped case), and return the
+reconstructed `moof` directly.
+
+It also gives an escape hatch for future LOCMAF revisions that
+introduce new object kinds: a sender talking to an older receiver can
+fall back to `MoofRawHeader` / `MoofGzipHeader` whenever the receiver
+doesn't recognise the new vocabulary.
+
+### Strict `cmf2` self-containment mode
+
+As noted in the "Where LOCMAF wins" section, the encoder currently
+omits `tfhd` defaults that match `trex`, which corresponds to what ffmpeg and
+other common packagers emit but does not strictly conform to CMAF
+`cmf2` (§7.7.3 requires each fragment to be decodable without the
+CMAF header). An encoder mode that always emits `tfhd` defaults
+would cost ~6 B per full moof (once per group) and produce fragments
+that survive isolated decoding after LOCMAF→CMAF reconstruction.
+
+## Summary
+
+- LOCMAF's biggest contribution is **per-fragment `moof` compression** in
+  the regime where MoQ groups are aligned to CMAF segments and each MoQ
+  object is one CMAF chunk. In sample-level fragmentation, delta moofs
+  collapse to 2 B in steady state — a 45:1 reduction in `moof` overhead.
+- **Init compression is a bonus** rather than the main goal. LOCMAF init
+  compresses simple moovs well (down to ~10% of CMAF), but on
+  codec-config-heavy moovs a generic compressor like gzip can match or
+  beat it. Alternative init encodings can coexist behind the header-ID
+  dispatch.
+- The **header-ID varint** acts as the type tag and is also where any
+  future format extension would live. Skipping unknown IDs is
+  implemented, so the format can grow (`prft`, `sidx`, future
+  additions) without coordinated upgrades while endpoints remain
+  in-house.
+
+[^cmf2-defaults]: The CMAF `cmf2` structural brand
+    (ISO/IEC 23000-19:2023 §7.7.3) requires that `default_sample_flags`,
+    sample duration, sample size, and sample description index
+    "shall be stored in each CMAF chunk's `trun` and/or `tfhd`" box
+    and explicitly notes that the corresponding values in the `trex`
+    "**can be set and ignored** … so each CMAF fragment is decodable
+    without access to that track CMAF header." In other words, a
+    strictly spec-compliant CMAF stream carries the defaults in `tfhd`,
+    not (only) in `trex`. In practice many encoders and packagers —
+    including common ffmpeg configurations — do not follow this and
+    place the defaults only in `trex`, producing fragments that are
+    not self-decodable. LOCMAF's reuse of `trex` values therefore
+    matches what those tools emit on the wire today; the reconstructed
+    CMAF fragments are still playable because the LOCMAF decoder seeds
+    `tfhd` from the catalog's `trex` during reconstruction. An encoder
+    flag to always emit the defaults in `tfhd` (full `cmf2`
+    self-containment) would cost a few extra bytes per full moof and is
+    straightforward to add if strict conformance becomes important.
+
+[^trflags-impl]: Reference implementation: `internal/locmaf.go:300` and
+    `mp4.TrunBox.SetFirstSampleFlags`.
+
+[^skip-impl]: Reference implementation of the skip-and-log path:
+    `internal.MoofDeltaDecompressor.DecompressMoof` in this repository.
+
+[^prft-spec]: `prft` is defined in ISO/IEC 14496-12 (the ISO Base Media
+    File Format) and is available as `mp4.PrftBox` in the `mp4ff`
+    library.
+
+## References
+
+### MoQ and CMAF specifications
+
+- [draft-ietf-moq-transport][MOQT] — Media over QUIC Transport
+- [draft-ietf-moq-cmsf][CMSF] — CMAF MoQ Streaming Format
+- [draft-ietf-moq-loc][LOC] — Low Overhead Container (LOC)
+- [draft-lcurley-compressed-mp4][compressed-mp4] — Compressed MP4
+  (Luke Curley)
+- [RFC 9000][rfc9000] — QUIC: A UDP-Based Multiplexed and Secure
+  Transport
+- **ISO/IEC 14496-12** — Information technology, Coding of audio-visual
+  objects, Part 12: ISO base media file format (ISO BMFF)
+- **ISO/IEC 23000-19:2023** — Common Media Application Format (CMAF)
+  for segmented media
+- **ISO/IEC 23001-7** — Common Encryption in ISO Base Media File Format
+  files (CENC)
+
+### Implementations and demos
+
+- [Eyevinn/moqlivemock][moqlivemock] — Go MoQ server and subscriber
+  used to prototype LOCMAF
+- [Eyevinn/warp-player][warp-player] — Browser MoQ player with LOCMAF
+  and EME support
+- [moqlivemock.demo.osaas.io][mlm-demo] — public demo of the LOCMAF +
+  DRM stack
+
+### Related work
+
+- **Efficient DRM in MoQ using Low Overhead CMAF** — Hugo Björs, KTH
+  Master Thesis, 2026 (to appear)
+
+[LOC]: https://datatracker.ietf.org/doc/draft-ietf-moq-loc/
+[MOQT]: https://datatracker.ietf.org/doc/draft-ietf-moq-transport/
+[CMSF]: https://datatracker.ietf.org/doc/draft-ietf-moq-cmsf/
+[compressed-mp4]: https://datatracker.ietf.org/doc/draft-lcurley-compressed-mp4/
+[rfc9000]: https://datatracker.ietf.org/doc/html/rfc9000
+[mlm-demo]: https://moqlivemock.demo.osaas.io
+[moqlivemock]: https://github.com/Eyevinn/moqlivemock
+[warp-player]: https://github.com/Eyevinn/warp-player

--- a/internal/asset.go
+++ b/internal/asset.go
@@ -459,7 +459,7 @@ func generateTrackGroups(tracksByType map[string][]ContentTrack) ([]TrackGroup, 
 			}
 			return videoTracks[i].SampleBitrate < videoTracks[j].SampleBitrate
 		})
-		for i := 0; i < len(videoTracks); i++ {
+		for i := range videoTracks {
 			if videoTracks[i].Duration != videoTracks[0].Duration {
 				return nil, fmt.Errorf("video tracks have different durations")
 			}
@@ -816,7 +816,7 @@ func calcCmafBitrate(ct *ContentTrack) (int, error) {
 		return 0, fmt.Errorf("measure CMAF chunk for %s: %w", ct.Name, err)
 	}
 	rawBytes := 0
-	for i := 0; i < batch; i++ {
+	for i := range batch {
 		rawBytes += len(ct.Samples[i].Data)
 	}
 	overheadBytes := len(chunk) - rawBytes + cmafObjectOverheadBytes

--- a/internal/asset_test.go
+++ b/internal/asset_test.go
@@ -276,7 +276,7 @@ func TestGen20sCMAFStreams(t *testing.T) {
 			require.NoError(t, err)
 			nrSamples := int(20 * tr.TimeScale / tr.SampleDur)
 			groupNr := uint32(0)
-			for nr := 0; nr < nrSamples; nr++ {
+			for nr := range nrSamples {
 				chunk, err := tr.GenCMAFChunk(groupNr, uint64(nr), uint64(nr+1))
 				require.NoError(t, err)
 				_, err = ofh.Write(chunk)
@@ -501,7 +501,7 @@ func checkDecryptedTracksMatchExactly(t *testing.T, drm *DRMInfo, suffix string)
 				require.NoError(t, err)
 				nrSamples := int(3 * tr.TimeScale / tr.SampleDur)
 				groupNr := uint32(0)
-				for nr := 0; nr < nrSamples; nr++ {
+				for nr := range nrSamples {
 					chunk, err := tr.GenCMAFChunk(groupNr, uint64(nr), uint64(nr+1))
 					if err != nil {
 						t.Fatalf("chunk generation failed for track=%s codec=%s scheme=%s encStatus=%s chunkNr=%d: %v",

--- a/internal/locmaf.go
+++ b/internal/locmaf.go
@@ -3,7 +3,7 @@ package internal
 import (
 	"bytes"
 	"fmt"
-	"sort"
+	"slices"
 	"strings"
 
 	"github.com/Eyevinn/mp4ff/mp4"
@@ -125,16 +125,21 @@ func extractImportantMoofFields(moof *mp4.MoofBox, moov *mp4.MoovBox) (map[locma
 	if tfhd == nil {
 		return nil, fmt.Errorf("tfhd is nil")
 	}
-	if tfhd.SampleDescriptionIndex != moov.Mvex.Trex.DefaultSampleDescriptionIndex {
+	trex := moov.Mvex.Trex
+	// Only emit a tfhd default when the tfhd actually carries the override flag
+	// AND its value differs from trex. Without the Has*() guard the zero from
+	// an unset tfhd field would be written as an explicit zero, suppressing
+	// the trex default on the decoder side.
+	if tfhd.HasSampleDescriptionIndex() && tfhd.SampleDescriptionIndex != trex.DefaultSampleDescriptionIndex {
 		importantFields[moofSampleDescriptionIndex] = appendVarint(nil, uint64(tfhd.SampleDescriptionIndex))
 	}
-	if tfhd.DefaultSampleDuration != moov.Mvex.Trex.DefaultSampleDuration {
+	if tfhd.HasDefaultSampleDuration() && tfhd.DefaultSampleDuration != trex.DefaultSampleDuration {
 		importantFields[moofDefaultSampleDuration] = appendVarint(nil, uint64(tfhd.DefaultSampleDuration))
 	}
-	if !singleSample && tfhd.DefaultSampleSize != moov.Mvex.Trex.DefaultSampleSize {
+	if !singleSample && tfhd.HasDefaultSampleSize() && tfhd.DefaultSampleSize != trex.DefaultSampleSize {
 		importantFields[moofDefaultSampleSize] = appendVarint(nil, uint64(tfhd.DefaultSampleSize))
 	}
-	if tfhd.DefaultSampleFlags != moov.Mvex.Trex.DefaultSampleFlags {
+	if tfhd.HasDefaultSampleFlags() && tfhd.DefaultSampleFlags != trex.DefaultSampleFlags {
 		importantFields[moofDefaultSampleFlags] = appendVarint(nil, uint64(tfhd.DefaultSampleFlags))
 	}
 
@@ -238,7 +243,14 @@ func decompressMoofUsingFieldValues(fieldValues map[locmafID][]byte, seqnum uint
 	if moov == nil || moov.Mvex == nil || moov.Mvex.Trex == nil {
 		return nil, fmt.Errorf("moov or trex not defined")
 	}
-	frag, err := mp4.CreateFragment(seqnum, 1)
+	// LOCMAF does not carry track_id (CMAF allows only one track per moov),
+	// so reuse whatever the moov advertises. Falls back to 1 if the caller
+	// hasn't populated tkhd.
+	trackID := uint32(1)
+	if moov.Trak != nil && moov.Trak.Tkhd != nil && moov.Trak.Tkhd.TrackID != 0 {
+		trackID = moov.Trak.Tkhd.TrackID
+	}
+	frag, err := mp4.CreateFragment(seqnum, trackID)
 	if err != nil {
 		return nil, fmt.Errorf("unable to create fragment: %w", err)
 	}
@@ -344,7 +356,7 @@ func decompressMoofUsingFieldValues(fieldValues map[locmafID][]byte, seqnum uint
 		return nil, fmt.Errorf("locmaf id=%d length mismatch", moofSampleSizes)
 	}
 
-	for i := 0; i < sampleCount; i++ {
+	for i := range sampleCount {
 		traf.Trun.AddSample(mp4.NewSample(uint32(sampleFlags[i]), uint32(sampleDurations[i]),
 			uint32(sampleSizes[i]), int32(sampleCompositionTimeOffsets[i])))
 	}
@@ -404,10 +416,13 @@ func DecompressInit(data []byte, track Track) (*mp4.InitSegment, error) {
 		trak.Tkhd.Flags = uint32(tkhdFlags)
 	}
 
-	mediaTime, ok := readVarint(moovMediaTime, fieldValues)
+	mediaTime, ok, err := readSignedVarint(moovMediaTime, fieldValues)
+	if err != nil {
+		return nil, fmt.Errorf("invalid locmaf id=%d: %w", moovMediaTime, err)
+	}
 	if ok {
 		elstEntry := ensureTrackElstEntry(trak)
-		elstEntry.MediaTime = int64(mediaTime)
+		elstEntry.MediaTime = mediaTime
 	}
 
 	trak.Mdia.Mdhd.Timescale = uint32(*track.Timescale)
@@ -602,9 +617,7 @@ func encodeFields(fields map[locmafID][]byte) []byte {
 	for key := range fields {
 		keys = append(keys, key)
 	}
-	sort.Slice(keys, func(i, j int) bool {
-		return keys[i] < keys[j]
-	})
+	slices.Sort(keys)
 
 	payload := make([]byte, 0)
 	for _, key := range keys {
@@ -676,10 +689,7 @@ func extractImportantMoovFields(moov *mp4.MoovBox) (map[locmafID][]byte, error) 
 
 	if track.Edts != nil && len(track.Edts.Elst) > 0 && len(track.Edts.Elst[0].Entries) > 0 {
 		mediaTime := track.Edts.Elst[0].Entries[0].MediaTime
-		if mediaTime < 0 {
-			return nil, fmt.Errorf("unable to set locmaf id=%d: negative media time", moovMediaTime)
-		}
-		importantFields[moovMediaTime] = appendVarint(nil, uint64(mediaTime))
+		importantFields[moovMediaTime] = appendSignedVarint(nil, mediaTime)
 	}
 
 	sampleEntry := track.Mdia.Minf.Stbl.Stsd.Children[0]
@@ -826,13 +836,21 @@ func ensurePrimarySampleEntry(init *mp4.InitSegment,
 }
 
 func createSampleEntryForFormat(format, mediaType string) mp4.Box {
+	switch format {
+	case "stpp":
+		// Namespace / schemaLocation are not currently carried in the
+		// LOCMAF moov payload, so the reconstructed StppBox has empty
+		// strings. Consumers that need the namespace should supply it
+		// out-of-band (e.g. as a catalog-side field) — see TODO.
+		return mp4.NewStppBox("", "", "")
+	case "wvtt":
+		return &mp4.WvttBox{}
+	}
 	switch mediaType {
 	case "audio":
-		entry := mp4.CreateAudioSampleEntryBox(format, 0, 0, 0, nil)
-		return entry
+		return mp4.CreateAudioSampleEntryBox(format, 0, 0, 0, nil)
 	default:
-		entry := mp4.CreateVisualSampleEntryBox(format, 0, 0, nil)
-		return entry
+		return mp4.CreateVisualSampleEntryBox(format, 0, 0, nil)
 	}
 }
 
@@ -1172,6 +1190,20 @@ func readVarint(id locmafID, fieldValues map[locmafID][]byte) (uint64, bool) {
 	return varint, true
 }
 
+// readSignedVarint reads a single zigzag-encoded signed varint from the
+// fieldValues map.
+func readSignedVarint(id locmafID, fieldValues map[locmafID][]byte) (int64, bool, error) {
+	value, ok := fieldValues[id]
+	if !ok {
+		return 0, false, nil
+	}
+	decoded, _, err := parseSignedVarint(value)
+	if err != nil {
+		return 0, true, err
+	}
+	return decoded, true, nil
+}
+
 // readVarintList reads a sequence of varints from the fieldValues map with the specified locmafID.
 // Returned values are: the uint64-encoded varint array and a bool representing
 // if the map contained a field with the specified locmafID.
@@ -1193,9 +1225,8 @@ func readVarintList(id locmafID, fieldValues map[locmafID][]byte) ([]uint64, boo
 	return varintList, true, nil
 }
 
-// readSignedVarintList reads a sequence of signed varints from the fieldValues map with the specified locmafID.
-// Returned values are: the uint64-encoded varint array and a bool representing
-// if the map contained a field with the specified locmafID.
+// readSignedVarintList reads a sequence of signed (zigzag-encoded) varints
+// for the given id. The bool is false if the field is absent.
 func readSignedVarintList(id locmafID, fieldValues map[locmafID][]byte) ([]int64, bool, error) {
 	value, ok := fieldValues[id]
 	if !ok {

--- a/internal/locmaf_delta.go
+++ b/internal/locmaf_delta.go
@@ -3,9 +3,11 @@ package internal
 import (
 	"bytes"
 	"fmt"
+	"log/slog"
 	"math"
 
 	"github.com/Eyevinn/mp4ff/mp4"
+	"github.com/quic-go/quic-go/quicvarint"
 )
 
 const moofDeltaDeletedLocmafIDs locmafID = 17
@@ -28,7 +30,7 @@ func (c *MoofDeltaCompressor) CompressMoof(moof *mp4.MoofBox, moov *mp4.MoovBox)
 		return MoofHeader, encodeFields(importantFields), nil
 	}
 
-	deltaFields, err := diffMoofFields(importantFields, c.previous)
+	deltaFields, err := diffMoofFields(importantFields, c.previous, moov)
 	if err != nil {
 		return 0, nil, err
 	}
@@ -51,7 +53,10 @@ type MoofDeltaDecompressor struct {
 }
 
 // DecompressMoof decompresses a locmaf object to create a moof box.
-// Both moof, and delta moof properties are accepted.
+// Both moof and delta moof object IDs are accepted. Objects carrying an
+// unrecognised header ID are silently skipped (after a warn-level log) so
+// receivers can interoperate with future LOCMAF additions like prft or
+// sidx. Skipped objects are signalled by a nil *MoofBox return value.
 func (d *MoofDeltaDecompressor) DecompressMoof(data []byte,
 	seqnum uint32, moov *mp4.MoovBox) (*mp4.MoofBox, []byte, error) {
 	object, err := parseLocmafObject(data)
@@ -62,12 +67,21 @@ func (d *MoofDeltaDecompressor) DecompressMoof(data []byte,
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to decompress moof property: %w", err)
 	}
+	if moof == nil {
+		return nil, nil, nil
+	}
 	return moof, object.mdatPayload, nil
 }
 
-// decompressMoofProptery converts a moof or delta moof property to a moof box.
+// decompressMoofProperty converts a moof or delta moof property to a moof
+// box. Unknown header IDs return a nil moof (caller treats as skip).
 func (d *MoofDeltaDecompressor) decompressMoofProperty(headerID locmafPropertyID, data []byte,
 	seqnum uint32, moov *mp4.MoovBox, mdatPayloadLength int) (*mp4.MoofBox, error) {
+	if headerID != MoofHeader && headerID != MoofDeltaHeader {
+		slog.Warn("locmaf: skipping unknown object",
+			"id", int(headerID), "payloadLength", len(data))
+		return nil, nil
+	}
 	if len(data) == 0 && headerID != MoofDeltaHeader {
 		return nil, fmt.Errorf("empty locmaf moof data")
 	}
@@ -89,8 +103,6 @@ func (d *MoofDeltaDecompressor) decompressMoofProperty(headerID locmafPropertyID
 			return nil, err
 		}
 		d.previous = cloneFieldValues(fieldValues)
-	default:
-		return nil, fmt.Errorf("unsupported moof header id=%d", headerID)
 	}
 
 	return decompressMoofUsingFieldValues(fieldValues, seqnum, moov, mdatPayloadLength)
@@ -106,11 +118,20 @@ func cloneFieldValues(fields map[locmafID][]byte) map[locmafID][]byte {
 
 // diffMoofFields returns the difference in each field value
 // as a map if the field value is not equal to the previous value.
-func diffMoofFields(current, previous map[locmafID][]byte) (map[locmafID][]byte, error) {
+//
+// moofBaseMediaDecodeTime is handled specially: a delta moof normally omits
+// it and the receiver derives BMDT as previous_bmdt + sum(previous_durations).
+// When the derivation does not match the actual current value (e.g. across
+// a splice, audio pre-roll, or stream-tear re-anchor), the absolute current
+// BMDT is emitted in the delta moof so the receiver can re-anchor in-band.
+func diffMoofFields(current, previous map[locmafID][]byte, moov *mp4.MoovBox) (map[locmafID][]byte, error) {
 	deltaFields := make(map[locmafID][]byte)
 
 	for key, currentValue := range current {
 		if key == moofBaseMediaDecodeTime {
+			if shouldEmitAbsoluteBMDT(currentValue, previous, moov) {
+				deltaFields[key] = append([]byte(nil), currentValue...)
+			}
 			continue
 		}
 		previousValue := previous[key]
@@ -137,14 +158,40 @@ func diffMoofFields(current, previous map[locmafID][]byte) (map[locmafID][]byte,
 	return deltaFields, nil
 }
 
+// shouldEmitAbsoluteBMDT reports whether the delta moof needs to carry the
+// absolute current BMDT (because the implicit derivation from the previous
+// moof's state would yield a different value, or because the derivation is
+// not possible at all).
+func shouldEmitAbsoluteBMDT(currentValue []byte, previous map[locmafID][]byte, moov *mp4.MoovBox) bool {
+	derived, err := deriveNextBaseMediaDecodeTime(previous, moov)
+	if err != nil {
+		return true
+	}
+	currentBMDT, _, err := quicvarint.Parse(currentValue)
+	if err != nil {
+		return true
+	}
+	return currentBMDT != derived
+}
+
 // applyMoofDelta creates a current field value map by looking at the previous map, and the current delta map.
+//
+// moofBaseMediaDecodeTime is handled specially: an explicit value in the
+// delta (an absolute BMDT, encoded the same way as in a full moof)
+// overrides the implicit derivation from previous_bmdt + sum(durations).
+// This lets the encoder re-anchor the timeline across a discontinuity
+// without a new top-level header ID.
 func applyMoofDelta(previous, deltaFields map[locmafID][]byte, moov *mp4.MoovBox) (map[locmafID][]byte, error) {
 	current := cloneFieldValues(previous)
-	baseMediaDecodeTime, err := deriveNextBaseMediaDecodeTime(previous, moov)
-	if err != nil {
-		return nil, err
+	if explicitBMDT, ok := deltaFields[moofBaseMediaDecodeTime]; ok {
+		current[moofBaseMediaDecodeTime] = append([]byte(nil), explicitBMDT...)
+	} else {
+		baseMediaDecodeTime, err := deriveNextBaseMediaDecodeTime(previous, moov)
+		if err != nil {
+			return nil, err
+		}
+		current[moofBaseMediaDecodeTime] = appendVarint(nil, baseMediaDecodeTime)
 	}
-	current[moofBaseMediaDecodeTime] = appendVarint(nil, baseMediaDecodeTime)
 
 	deletedFields, ok, err := readVarintList(moofDeltaDeletedLocmafIDs, deltaFields)
 	if err != nil {
@@ -158,6 +205,10 @@ func applyMoofDelta(previous, deltaFields map[locmafID][]byte, moov *mp4.MoovBox
 
 	for key, deltaValue := range deltaFields {
 		if key == moofDeltaDeletedLocmafIDs {
+			continue
+		}
+		if key == moofBaseMediaDecodeTime {
+			// Already applied above as an absolute override.
 			continue
 		}
 		value, err := applyMoofFieldDelta(key, deltaValue, previous[key])

--- a/internal/locmaf_delta_test.go
+++ b/internal/locmaf_delta_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/Eyevinn/mp4ff/bits"
 	"github.com/Eyevinn/mp4ff/mp4"
+	"github.com/quic-go/quic-go/quicvarint"
 	"github.com/stretchr/testify/require"
 )
 
@@ -60,6 +61,66 @@ func TestMoofDeltaRequiresPreviousMoof(t *testing.T) {
 	require.ErrorContains(t, err, "missing previous moof state")
 }
 
+// Forward-compat: a future LOCMAF revision may introduce additional
+// top-level objects (e.g. prft, sidx). Existing receivers should log and
+// skip such objects without erroring, so they can stream alongside the
+// known moof/moof-delta objects.
+func TestDecompressMoofSkipsUnknownObjects(t *testing.T) {
+	_, moov := loadVideoTrack(t)
+	const unknownHeaderID locmafPropertyID = 99
+	payload := encodeFields(map[locmafID][]byte{1: {0xab, 0xcd}})
+	object := createSizedLocmafProperty(unknownHeaderID, payload)
+
+	decoder := &MoofDeltaDecompressor{}
+	moof, mdat, err := decoder.DecompressMoof(object, 0, moov)
+	require.NoError(t, err)
+	require.Nil(t, moof)
+	require.Nil(t, mdat)
+}
+
+// A delta moof normally omits moofBaseMediaDecodeTime; the receiver derives
+// it from the previous moof's state. When the actual BMDT diverges (a
+// discontinuity such as a splice or stream-tear), the encoder must emit
+// moofBaseMediaDecodeTime as an absolute value in the delta moof and the
+// decoder must use that value verbatim instead of the derivation.
+func TestMoofDeltaEmitsAbsoluteBMDTOnDiscontinuity(t *testing.T) {
+	_, moov := loadVideoTrack(t)
+
+	// Previous moof: 2 samples × 512 ticks → contiguous next BMDT = 1024.
+	previous := map[locmafID][]byte{
+		moofBaseMediaDecodeTime:   appendVarint(nil, 0),
+		moofSampleCount:           appendVarint(nil, 2),
+		moofDefaultSampleDuration: appendVarint(nil, 512),
+	}
+
+	// Contiguous current (BMDT = 1024) should leave BMDT out of the delta.
+	contiguous := cloneFieldValues(previous)
+	contiguous[moofBaseMediaDecodeTime] = appendVarint(nil, 1024)
+	deltaContiguous, err := diffMoofFields(contiguous, previous, moov)
+	require.NoError(t, err)
+	require.NotContains(t, deltaContiguous, moofBaseMediaDecodeTime,
+		"contiguous BMDT should not appear in delta")
+
+	// Discontinuous current (BMDT = 999999) should be carried as absolute.
+	discontinuous := cloneFieldValues(previous)
+	discontinuous[moofBaseMediaDecodeTime] = appendVarint(nil, 999999)
+	deltaDiscontinuous, err := diffMoofFields(discontinuous, previous, moov)
+	require.NoError(t, err)
+	require.Contains(t, deltaDiscontinuous, moofBaseMediaDecodeTime,
+		"discontinuous BMDT should appear in delta")
+	emitted, _, err := quicvarint.Parse(deltaDiscontinuous[moofBaseMediaDecodeTime])
+	require.NoError(t, err)
+	require.EqualValues(t, 999999, emitted,
+		"absolute BMDT must be encoded as an unsigned varint, not a delta")
+
+	// Round-trip via applyMoofDelta restores the absolute value.
+	applied, err := applyMoofDelta(previous, deltaDiscontinuous, moov)
+	require.NoError(t, err)
+	restored, _, err := quicvarint.Parse(applied[moofBaseMediaDecodeTime])
+	require.NoError(t, err)
+	require.EqualValues(t, 999999, restored)
+}
+
 func TestMoofDeltaAllowsEmptyDeltaPayload(t *testing.T) {
 	track, moov := loadVideoTrack(t)
 	compressor := &MoofDeltaCompressor{}
@@ -101,7 +162,7 @@ func TestMoofDeltaFieldsUseSignedVarints(t *testing.T) {
 		),
 	}
 
-	deltaFields, err := diffMoofFields(current, previous)
+	deltaFields, err := diffMoofFields(current, previous, nil)
 	require.NoError(t, err)
 
 	durationDelta, ok, err := readSignedVarintList(
@@ -137,6 +198,7 @@ func TestMoofDeltaDeletedFieldsUseUnsignedVarints(t *testing.T) {
 		map[locmafID][]byte{
 			moofDefaultSampleDuration: appendVarint(nil, 5),
 		},
+		nil,
 	)
 	require.NoError(t, err)
 

--- a/internal/sub/sub.go
+++ b/internal/sub/sub.go
@@ -568,6 +568,10 @@ func (h *Handler) subscribeAndRead(ctx context.Context, s *moqtransport.Session,
 						"error", err)
 					return
 				}
+				if o.Payload == nil {
+					// Unknown LOCMAF object skipped; move on to the next one.
+					continue
+				}
 			}
 
 			if h.cenc != nil {
@@ -623,6 +627,11 @@ func decompressLocmafObject(payload []byte, seqnum uint32,
 	moof, mdatData, err := decompressor.DecompressMoof(payload, seqnum, moov)
 	if err != nil {
 		return nil, err
+	}
+	if moof == nil {
+		// Unknown LOCMAF object — already logged in the decompressor; emit
+		// nothing so the receiver moves on to the next object.
+		return nil, nil
 	}
 
 	frag := mp4.NewFragment()


### PR DESCRIPTION
## Summary

Three commits, grouped by intent:

- **`fix: improve locmaf encoder/decoder; add roundtrip CLI`** — encoder/decoder fidelity fixes (tfhd `Has*()` gating, signed `elst.media_time`, stpp/wvtt subtitle sample entries, `track_id` propagation, skip-and-log for unknown LOCMAF object header IDs, absolute `moofBaseMediaDecodeTime` override on BMDT discontinuity). Plus a new `cmd/locmaf roundtrip` subcommand that compresses + decompresses an fMP4 (or init + segment pair) through LOCMAF, verifies sample-level fidelity, and prints cmaf/locmaf/gzip size statistics. Optional `-track-info` JSON side-channel for the catalog-side metadata. Survives the livesim2 sweep on 42/43 assets (the one failure is a saved `Not Found\n` text file).
- **`docs: add LOCMAF design document`** — new `docs/LOCMAF.md` covering rationale, MoQ↔CMAF group mapping, where LOCMAF wins (with the commensurate-timescale prerequisite as a subsection), media segment wire format (object framing, top-level IDs, field-tuple parity rule, full-moof emission rules, delta-moof incremental encoding, worked example), round-trip semantics (`tr_flags` implicit handling, BMDT derivation/override), moov field reference, init segment options, forward extensibility via header-ID space (sketches `prft` with signed-zigzag deltas, delta-of-delta, and approximate-timestamp), possible improvements (sample_flags repacking, prft delta-coding, CENC IV elision via counter prediction, framing-floor reduction, codec-config in catalog, source validation, raw/gzip moof fallback, strict cmf2 mode), and a References section.
- **`docs: update CHANGELOG and README for LOCMAF additions`** — CHANGELOG entries for the encoder/decoder fixes and the roundtrip subcommand; README points at `docs/LOCMAF.md` and documents the new subcommand alongside `testgen`.

## Test plan

- [x] `go build ./moqlivemock/...`
- [x] `go test ./moqlivemock/...` — all internal/pub/sub/mlmtest tests pass
- [x] `cmd/locmaf roundtrip` on bundled `assets/test10s/*` — 250-fragment AVC and 471-fragment AAC streams reach 2.3 B / 2.0 B steady-state delta moofs respectively, sample-level fidelity verified
- [x] `cmd/locmaf roundtrip -init … -segment …` on the livesim2 asset library — 42/43 OK; the only failure is `vvc-wrapper/init.mp4`, which is literal `Not Found\n` text, not a real fMP4
- [x] `cmd/locmaf roundtrip -track-info track.json` — side-channel JSON path validated on a livesim2 V300 fragment
- [x] `TestMoofDeltaEmitsAbsoluteBMDTOnDiscontinuity` — new unit test for the BMDT override path
- [x] `TestDecompressMoofSkipsUnknownObjects` — new unit test for forward-compat skip path
- [x] `golangci-lint` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)