### PR TITLE
fix: report LOCMAF wire bitrate correctly in CMSF catalog

### DIFF
--- a/docs/LOCMAF.md
+++ b/docs/LOCMAF.md
@@ -187,6 +187,42 @@ delta stream's compounding benefit per-fragment is much larger when each
 fragment is small and similar to its neighbour — exactly the low-latency
 regime.
 
+### Catalog `bitrate` impact on the bundled assets
+
+The CMSF catalog `bitrate` field reports the wire bitrate of the track,
+including the relevant per-object framing overhead. On the bundled
+`assets/test10s` content at one sample per MoQ object (the default for
+`mlmpub`), the LOCMAF and CMAF reports look like this:
+
+| track | sample [bps] | cmaf [bps] | locmaf [bps] | saved [bps] | saved % |
+| ----- | -----------: | ---------: | -----------: | ----------: | ------: |
+| `audio_monotonic_128kbps_aac`  | 128 001 | 171 501 | 131 887 | 39 614 | 23.1 % |
+| `audio_monotonic_128kbps_opus` | 128 400 | 174 800 | 132 536 | 42 264 | 24.2 % |
+| `audio_monotonic_192kbps_ac3`  | 192 000 | 221 000 | 194 636 | 26 364 | 11.9 % |
+| `video_400kbps_avc`            | 373 200 | 396 400 | 376 488 | 19 912 |  5.0 % |
+| `video_400kbps_hevc`           | 299 392 | 322 592 | 302 680 | 19 912 |  6.2 % |
+| `video_600kbps_avc`            | 559 505 | 582 705 | 562 793 | 19 912 |  3.4 % |
+| `video_600kbps_hevc`           | 408 785 | 431 985 | 412 073 | 19 912 |  4.6 % |
+| `video_900kbps_avc`            | 844 504 | 867 704 | 847 792 | 19 912 |  2.3 % |
+| `video_900kbps_hevc`           | 610 182 | 633 382 | 613 470 | 19 912 |  3.1 % |
+
+The savings figure is **per object, not per byte of mdat**: 19 912 bps
+saved / 8 / 25 fps ≈ 99.6 bytes saved per moof, matching the
+"~100 B CMAF moof becomes a 2 B LOCMAF delta moof" headline. The
+per-track *percentage* therefore looks smaller on high-bitrate video
+(the mdat dominates) and larger on low-bitrate audio (the moof header
+is a much bigger fraction of the wire cost). For the 128 kbps AAC track
+that the user typically asks about, the catalog bitrate drops from
+171.5 kbps (CMAF) to 131.9 kbps (LOCMAF) — a 23% saving against the
+CMAF-reported wire bitrate, and only ~3% above the raw sample bitrate
+(the remaining LOCMAF wire cost is ~2 B/object × ~47 obj/s ≈ 750 bps
+plus 8 B/object MoQ framing).
+
+These numbers come from the `internal.calcLocmafBitrate` measurement
+path: one full + one delta LOCMAF chunk generated with a fresh
+`MoofDeltaCompressor`, amortised over a 1 s MoQ group. Re-runnable via
+`go test ./internal/ -run TestLocmafBitrateIsLowerThanCmaf -v`.
+
 ### Prerequisite: commensurate media timescales
 
 The two-byte steady state described above depends on one assumption from

--- a/internal/asset.go
+++ b/internal/asset.go
@@ -556,9 +556,20 @@ func (a *Asset) GenCMAFCatalogEntry(namespace string, prot ProtectionType,
 			}
 
 			frameRate := float64(ct.TimeScale) / float64(ct.SampleDur)
-			cmafBitrate, err := calcCmafBitrate(&ct)
-			if err != nil {
-				return nil, fmt.Errorf("could not calculate CMAF bitrate for track %s: %w", ct.Name, err)
+			var (
+				bitrate int
+				bErr    error
+			)
+			if packaging == "locmaf" {
+				bitrate, bErr = calcLocmafBitrate(&ct)
+				if bErr != nil {
+					return nil, fmt.Errorf("could not calculate LOCMAF bitrate for track %s: %w", ct.Name, bErr)
+				}
+			} else {
+				bitrate, bErr = calcCmafBitrate(&ct)
+				if bErr != nil {
+					return nil, fmt.Errorf("could not calculate CMAF bitrate for track %s: %w", ct.Name, bErr)
+				}
 			}
 
 			track := Track{
@@ -570,7 +581,7 @@ func (a *Asset) GenCMAFCatalogEntry(namespace string, prot ProtectionType,
 				AltGroup:    &altGroup,
 				InitData:    initData,
 				Codec:       ct.SpecData.Codec(),
-				Bitrate:     &cmafBitrate,
+				Bitrate:     &bitrate,
 				Timescale:   Ptr(int(ct.TimeScale)),
 				Language:    ct.Language,
 			}
@@ -825,6 +836,57 @@ func calcCmafBitrate(ct *ContentTrack) (int, error) {
 	overheadBytes := len(chunk) - rawBytes + cmafObjectOverheadBytes
 	objectRate := float64(ct.TimeScale) / float64(ct.SampleDur) / float64(batch)
 	return int(float64(ct.SampleBitrate) + 8*float64(overheadBytes)*objectRate), nil
+}
+
+// calcLocmafBitrate returns the wire bitrate of a LOCMAF-packaged track in
+// bits per second. It measures one full and one delta LOCMAF chunk (using
+// adjacent samples from the start of the loop) and amortises the per-group
+// full moof over a 1-second group of subsequent delta moofs. The full moof
+// happens once per MoQ group; deltas happen every other object.
+func calcLocmafBitrate(ct *ContentTrack) (int, error) {
+	batch := ct.SampleBatch
+	if batch <= 0 {
+		batch = 1
+	}
+	if uint64(batch) > uint64(len(ct.Samples)) {
+		batch = len(ct.Samples)
+	}
+	if batch == 0 || ct.SampleDur == 0 || ct.TimeScale == 0 {
+		return int(ct.SampleBitrate), nil
+	}
+	var compressor MoofDeltaCompressor
+	fullChunk, err := ct.GenLocmafChunk(0, 0, uint64(batch), &compressor)
+	if err != nil {
+		return 0, fmt.Errorf("measure LOCMAF full chunk for %s: %w", ct.Name, err)
+	}
+	deltaChunk, err := ct.GenLocmafChunk(1, uint64(batch), 2*uint64(batch), &compressor)
+	if err != nil {
+		return 0, fmt.Errorf("measure LOCMAF delta chunk for %s: %w", ct.Name, err)
+	}
+	rawFull := 0
+	for i := range batch {
+		rawFull += len(ct.Samples[i].Data)
+	}
+	rawDelta := 0
+	for i := range batch {
+		rawDelta += len(ct.Samples[batch+i].Data)
+	}
+	fullOverhead := len(fullChunk) - rawFull + cmafObjectOverheadBytes
+	deltaOverhead := len(deltaChunk) - rawDelta + cmafObjectOverheadBytes
+
+	// Objects per second = samples per second / batch.
+	objectsPerSec := float64(ct.TimeScale) / float64(ct.SampleDur) / float64(batch)
+	// One full moof per MoQ group (one group per second at MoqGroupDurMS=1000).
+	fullsPerSec := 1000.0 / float64(MoqGroupDurMS)
+	deltasPerSec := objectsPerSec - fullsPerSec
+	if deltasPerSec < 0 {
+		// Very large batches (one object spans multiple groups) — keep
+		// the math sane by collapsing to a single full-equivalent rate.
+		fullsPerSec = objectsPerSec
+		deltasPerSec = 0
+	}
+	extraBytesPerSec := float64(fullOverhead)*fullsPerSec + float64(deltaOverhead)*deltasPerSec
+	return int(float64(ct.SampleBitrate) + 8*extraBytesPerSec), nil
 }
 
 // calcLOCBitrate returns the wire bitrate of a LOC-packaged track in bits per

--- a/internal/bitrate_test.go
+++ b/internal/bitrate_test.go
@@ -100,6 +100,48 @@ func TestLOCBitrateHEVCExceedsParameterSetOverheadAVC(t *testing.T) {
 	}
 }
 
+// TestLocmafBitrateIsLowerThanCmaf asserts that for the same source track
+// the LOCMAF catalog bitrate is strictly lower than the CMAF catalog
+// bitrate. This guards against regressions where the locmaf-packaged
+// Track ends up reporting the CMAF wire bitrate (which was the case
+// before calcLocmafBitrate was introduced).
+func TestLocmafBitrateIsLowerThanCmaf(t *testing.T) {
+	asset, err := LoadAsset("../assets/test10s", 1, 1)
+	require.NoError(t, err)
+
+	cmafCat, err := asset.GenCMAFCatalogEntry("cmsf/clear", ProtectionNone, 0, "cmaf")
+	require.NoError(t, err)
+	locmafCat, err := asset.GenCMAFCatalogEntry("locmaf/clear", ProtectionNone, 0, "locmaf")
+	require.NoError(t, err)
+
+	cmafByName := indexTracks(cmafCat.Tracks, "")
+	locmafByName := indexTracks(locmafCat.Tracks, "")
+	require.NotEmpty(t, cmafByName)
+	require.NotEmpty(t, locmafByName)
+
+	for name, cmafTrack := range cmafByName {
+		locmafTrack, ok := locmafByName[name]
+		require.True(t, ok, "track %s missing from LOCMAF catalog", name)
+		require.NotNil(t, cmafTrack.Bitrate)
+		require.NotNil(t, locmafTrack.Bitrate)
+
+		// LOCMAF moofs are dramatically smaller than CMAF moofs at
+		// sample-level fragmentation; the per-track bitrate must reflect
+		// that.
+		require.Less(t, *locmafTrack.Bitrate, *cmafTrack.Bitrate,
+			"%s: LOCMAF bitrate %d should be lower than CMAF bitrate %d",
+			name, *locmafTrack.Bitrate, *cmafTrack.Bitrate)
+
+		// LOCMAF should still exceed the raw sample bitrate — there is
+		// always some per-object framing and the per-group full moof.
+		ct := asset.GetTrackByName(name)
+		require.NotNil(t, ct)
+		require.Greater(t, *locmafTrack.Bitrate, int(ct.SampleBitrate),
+			"%s: LOCMAF bitrate %d should exceed raw sample bitrate %d",
+			name, *locmafTrack.Bitrate, ct.SampleBitrate)
+	}
+}
+
 func indexTracks(tracks []Track, suffix string) map[string]Track {
 	out := make(map[string]Track, len(tracks))
 	for _, tr := range tracks {


### PR DESCRIPTION
## Summary

Follow-up to #82. Catalog generation (`internal.GenCMAFCatalogEntry`)
was calling `calcCmafBitrate` for every track regardless of packaging,
so LOCMAF-packaged tracks reported the CMAF wire bitrate. Example:
**128 kbps AAC at one-sample-per-object reported 171.5 kbps** in the
catalog instead of the realistic ~131.9 kbps.

New `internal.calcLocmafBitrate` measures one full + one delta LOCMAF
chunk with a fresh `MoofDeltaCompressor` and amortises the per-group
full moof over a 1-second group of subsequent delta moofs:

```
overhead/sec = full_overhead * (1 / group_dur)
             + delta_overhead * (objects/sec - 1 / group_dur)
bitrate      = sample_bitrate + 8 * overhead/sec
```

`GenCMAFCatalogEntry` dispatches on `packaging == "locmaf"` and calls
the appropriate calculator.

## Changes

- `internal/asset.go` — new `calcLocmafBitrate`, dispatch in
  `GenCMAFCatalogEntry`.
- `internal/bitrate_test.go` — new `TestLocmafBitrateIsLowerThanCmaf`
  regression test: LOCMAF catalog bitrate must be both (a) lower than
  the CMAF catalog bitrate for the same track and (b) higher than the
  raw sample bitrate.
- `docs/LOCMAF.md` — new "Catalog `bitrate` impact on the bundled
  assets" subsection with measured numbers for the test10s tracks (AAC
  drops 171.5 → 131.9 kbps; constant ~99.6 B saved per moof at 25 fps
  video).

## Measured bitrates on `assets/test10s`

| track | raw | cmaf | locmaf | saved |
| --- | ---: | ---: | ---: | ---: |
| `audio_monotonic_128kbps_aac` | 128 001 | 171 501 | 131 887 | 23.1% |
| `audio_monotonic_128kbps_opus` | 128 400 | 174 800 | 132 536 | 24.2% |
| `audio_monotonic_192kbps_ac3` | 192 000 | 221 000 | 194 636 | 11.9% |
| `video_400kbps_avc` | 373 200 | 396 400 | 376 488 | 5.0% |
| `video_400kbps_hevc` | 299 392 | 322 592 | 302 680 | 6.2% |
| `video_600kbps_avc` | 559 505 | 582 705 | 562 793 | 3.4% |
| `video_900kbps_avc` | 844 504 | 867 704 | 847 792 | 2.3% |
| `video_900kbps_hevc` | 610 182 | 633 382 | 613 470 | 3.1% |

The constant 19 912 bps saved across the 25 fps video tracks (≈ 99.6 B
saved per moof) matches the doc's "~100 B CMAF moof becomes a 2 B
LOCMAF delta moof" steady-state. Percentage savings are larger on audio
because the mdat is smaller per object.

## Test plan

- [x] `go build ./moqlivemock/...`
- [x] `go test ./moqlivemock/...` — all tests pass
- [x] `TestLocmafBitrateIsLowerThanCmaf` covers nine bundled tracks
- [x] Existing `TestBitrateExposesPackagingDifferences` and
      `TestLOCBitrateHEVCExceedsParameterSetOverheadAVC` still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)