### PR TITLE
docs(LOCMAF): add document version banner, logo, and revision history

### DIFF
--- a/docs/LOCMAF.md
+++ b/docs/LOCMAF.md
@@ -1,4 +1,22 @@
+<p align="center">
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="assets/logo-dark.svg">
+    <source media="(prefers-color-scheme: light)" srcset="assets/logo-light.svg">
+    <img alt="LOCMAF — Low Overhead CMAF for MOQ" src="assets/logo-light.svg" width="640">
+  </picture>
+</p>
+
 # LOCMAF: Low Overhead CMAF for MOQ
+
+**Document version:** 0.1 (2026-05-17)
+**Wire-format `locmafVersion`:** `"0.1"`
+
+The document version and the wire-format `locmafVersion` are kept in
+lockstep until there is a reason to diverge. Frozen snapshots are
+preserved as git tags on this repository (`locmaf-v0.1`, …); for an
+immutable copy of a given version, view this file at the matching tag.
+See [Revision history](#revision-history) at the bottom of this
+document for a summary of changes between versions.
 
 LOCMAF is a way to stream low-latency CMAF over [MOQT][MOQT] with an
 overhead comparable to [LOC][LOC]. It is intended as a
@@ -28,7 +46,9 @@ available publicly at [moqlivemock.demo.osaas.io][mlm-demo] and on
 GitHub in the two projects [Eyevinn/moqlivemock][moqlivemock] and
 [Eyevinn/warp-player][warp-player].
 
-This is a first version and may evolve depending on feedback and experience.
+This is a first version of the format and may evolve depending on
+feedback and experience — see [Revision history](#revision-history)
+below.
 
 ## Background
 
@@ -1301,6 +1321,17 @@ that survive isolated decoding after LOCMAF→CMAF reconstruction.
 
 - **Efficient DRM in MoQ using Low Overhead CMAF** — Hugo Björs, KTH
   Master Thesis, 2026 (to appear)
+
+## Revision history
+
+| Document version | Wire `locmafVersion` | Date       | Summary                                                       |
+| ---------------- | -------------------- | ---------- | ------------------------------------------------------------- |
+| 0.1              | `"0.1"`              | 2026-05-17 | First documented version. Initial wire format and DRM signal. |
+
+Frozen snapshots of this document are preserved as git tags on this
+repository (`locmaf-v0.1`, …). To read the document exactly as it
+existed for a given version, view this file at the matching tag on
+GitHub.
 
 [LOC]: https://datatracker.ietf.org/doc/draft-ietf-moq-loc/
 [MOQT]: https://datatracker.ietf.org/doc/draft-ietf-moq-transport/

--- a/docs/assets/logo-dark.svg
+++ b/docs/assets/logo-dark.svg
@@ -1,0 +1,74 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 820 140" role="img" aria-label="LOCMAF — Low Overhead CMAF for MOQ (dark-background variant).">
+  <defs>
+    <linearGradient id="cmafGradD2" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#FFC069"/>
+      <stop offset="100%" stop-color="#FC9900"/>
+    </linearGradient>
+    <linearGradient id="deltaGradD2" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#A8DCF2"/>
+      <stop offset="100%" stop-color="#61B5E5"/>
+    </linearGradient>
+  </defs>
+
+  <!-- LEFT: big CMAF chunks (high-contrast variants of the gradient). -->
+  <g transform="translate(8,28)">
+    <g transform="translate(0,0)">
+      <rect x="0" y="0"  width="32" height="14" rx="2" fill="url(#cmafGradD2)"/>
+      <rect x="0" y="16" width="32" height="68" rx="2" fill="url(#cmafGradD2)" opacity="0.78"/>
+    </g>
+    <g transform="translate(40,0)">
+      <rect x="0" y="0"  width="32" height="14" rx="2" fill="url(#cmafGradD2)"/>
+      <rect x="0" y="16" width="32" height="68" rx="2" fill="url(#cmafGradD2)" opacity="0.78"/>
+    </g>
+    <g transform="translate(80,0)">
+      <rect x="0" y="0"  width="32" height="14" rx="2" fill="url(#cmafGradD2)"/>
+      <rect x="0" y="16" width="32" height="68" rx="2" fill="url(#cmafGradD2)" opacity="0.78"/>
+    </g>
+  </g>
+
+  <g font-family="ui-monospace, Menlo, Consolas, monospace" font-size="10" fill="#cfcfcf">
+    <text x="24" y="22"  text-anchor="middle">moof</text>
+    <text x="24" y="128" text-anchor="middle">mdat</text>
+  </g>
+
+  <!-- Compress wedge (stroke-only). -->
+  <g transform="translate(132,40)" fill="none" stroke="#cfcfcf" stroke-width="1.75" stroke-linejoin="round">
+    <path d="M0 0 L42 24 L42 40 L0 64 Z"/>
+  </g>
+
+  <!-- Tiny deltas. -->
+  <g transform="translate(186,60)">
+    <rect x="0"  y="0" width="14" height="22" rx="2" fill="url(#deltaGradD2)"/>
+    <rect x="20" y="0" width="14" height="22" rx="2" fill="url(#deltaGradD2)"/>
+    <rect x="40" y="0" width="14" height="22" rx="2" fill="url(#deltaGradD2)"/>
+  </g>
+
+  <!-- Decompress wedge. -->
+  <g transform="translate(254,40)" fill="none" stroke="#cfcfcf" stroke-width="1.75" stroke-linejoin="round">
+    <path d="M0 24 L42 0 L42 64 L0 40 Z"/>
+  </g>
+
+  <!-- RIGHT: reconstructed big chunks. -->
+  <g transform="translate(304,28)">
+    <g transform="translate(0,0)">
+      <rect x="0" y="0"  width="32" height="14" rx="2" fill="url(#cmafGradD2)"/>
+      <rect x="0" y="16" width="32" height="68" rx="2" fill="url(#cmafGradD2)" opacity="0.78"/>
+    </g>
+    <g transform="translate(40,0)">
+      <rect x="0" y="0"  width="32" height="14" rx="2" fill="url(#cmafGradD2)"/>
+      <rect x="0" y="16" width="32" height="68" rx="2" fill="url(#cmafGradD2)" opacity="0.78"/>
+    </g>
+    <g transform="translate(80,0)">
+      <rect x="0" y="0"  width="32" height="14" rx="2" fill="url(#cmafGradD2)"/>
+      <rect x="0" y="16" width="32" height="68" rx="2" fill="url(#cmafGradD2)" opacity="0.78"/>
+    </g>
+  </g>
+
+  <!-- Wordmark — pure white with a slightly tighter weight for dark backgrounds. -->
+  <g transform="translate(448,0)">
+    <text x="0" y="82" font-family="'LevelOne','Helvetica Neue',Arial,sans-serif"
+          font-size="62" font-weight="700" letter-spacing="2" fill="#FFFFFF">LOCMAF</text>
+    <text x="2" y="112" font-family="'LevelOne','Helvetica Neue',Arial,sans-serif"
+          font-size="14" letter-spacing="2" fill="#61B5E5">LOW OVERHEAD CMAF FOR MOQ</text>
+  </g>
+</svg>

--- a/docs/assets/logo-light.svg
+++ b/docs/assets/logo-light.svg
@@ -1,0 +1,74 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 820 140" role="img" aria-label="LOCMAF — Low Overhead CMAF for MOQ (light-background variant).">
+  <defs>
+    <linearGradient id="cmafGradL" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#FFB347"/>
+      <stop offset="100%" stop-color="#FC9900"/>
+    </linearGradient>
+    <linearGradient id="deltaGradL" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#7FC4EB"/>
+      <stop offset="100%" stop-color="#3F9BD2"/>
+    </linearGradient>
+  </defs>
+
+  <!-- LEFT: big CMAF chunks. -->
+  <g transform="translate(8,28)">
+    <g transform="translate(0,0)">
+      <rect x="0" y="0"  width="32" height="14" rx="2" fill="url(#cmafGradL)"/>
+      <rect x="0" y="16" width="32" height="68" rx="2" fill="url(#cmafGradL)" opacity="0.85"/>
+    </g>
+    <g transform="translate(40,0)">
+      <rect x="0" y="0"  width="32" height="14" rx="2" fill="url(#cmafGradL)"/>
+      <rect x="0" y="16" width="32" height="68" rx="2" fill="url(#cmafGradL)" opacity="0.85"/>
+    </g>
+    <g transform="translate(80,0)">
+      <rect x="0" y="0"  width="32" height="14" rx="2" fill="url(#cmafGradL)"/>
+      <rect x="0" y="16" width="32" height="68" rx="2" fill="url(#cmafGradL)" opacity="0.85"/>
+    </g>
+  </g>
+
+  <g font-family="ui-monospace, Menlo, Consolas, monospace" font-size="10" fill="#5a5a5a">
+    <text x="24" y="22"  text-anchor="middle">moof</text>
+    <text x="24" y="128" text-anchor="middle">mdat</text>
+  </g>
+
+  <!-- Compress wedge (dark stroke for light backgrounds). -->
+  <g transform="translate(132,40)" fill="none" stroke="#4a4a4a" stroke-width="1.75" stroke-linejoin="round">
+    <path d="M0 0 L42 24 L42 40 L0 64 Z"/>
+  </g>
+
+  <!-- Tiny deltas. -->
+  <g transform="translate(186,60)">
+    <rect x="0"  y="0" width="14" height="22" rx="2" fill="url(#deltaGradL)"/>
+    <rect x="20" y="0" width="14" height="22" rx="2" fill="url(#deltaGradL)"/>
+    <rect x="40" y="0" width="14" height="22" rx="2" fill="url(#deltaGradL)"/>
+  </g>
+
+  <!-- Decompress wedge. -->
+  <g transform="translate(254,40)" fill="none" stroke="#4a4a4a" stroke-width="1.75" stroke-linejoin="round">
+    <path d="M0 24 L42 0 L42 64 L0 40 Z"/>
+  </g>
+
+  <!-- RIGHT: reconstructed big chunks. -->
+  <g transform="translate(304,28)">
+    <g transform="translate(0,0)">
+      <rect x="0" y="0"  width="32" height="14" rx="2" fill="url(#cmafGradL)"/>
+      <rect x="0" y="16" width="32" height="68" rx="2" fill="url(#cmafGradL)" opacity="0.85"/>
+    </g>
+    <g transform="translate(40,0)">
+      <rect x="0" y="0"  width="32" height="14" rx="2" fill="url(#cmafGradL)"/>
+      <rect x="0" y="16" width="32" height="68" rx="2" fill="url(#cmafGradL)" opacity="0.85"/>
+    </g>
+    <g transform="translate(80,0)">
+      <rect x="0" y="0"  width="32" height="14" rx="2" fill="url(#cmafGradL)"/>
+      <rect x="0" y="16" width="32" height="68" rx="2" fill="url(#cmafGradL)" opacity="0.85"/>
+    </g>
+  </g>
+
+  <!-- Wordmark in near-black so it reads on a white GitHub README. -->
+  <g transform="translate(448,0)">
+    <text x="0" y="82" font-family="'LevelOne','Helvetica Neue',Arial,sans-serif"
+          font-size="62" font-weight="700" letter-spacing="2" fill="#1a1a1a">LOCMAF</text>
+    <text x="2" y="112" font-family="'LevelOne','Helvetica Neue',Arial,sans-serif"
+          font-size="14" letter-spacing="2" fill="#3F9BD2">LOW OVERHEAD CMAF FOR MOQ</text>
+  </g>
+</svg>


### PR DESCRIPTION
## Summary

- Adds the LOCMAF logo (light + dark variants via `<picture>`) at the top of `docs/LOCMAF.md`, copied from the `Eyevinn/locmaf` project.
- Adds an explicit version banner near the top:
  - **Document version:** 0.1 (2026-05-17)
  - **Wire-format `locmafVersion`:** `"0.1"`
- Adds a **Revision history** table at the bottom listing the 0.1 row and explaining the git-tag snapshot policy (`locmaf-v0.1`, …).
- Replaces the old "This is a first version…" sentence with a pointer to the revision history.

This is the lightweight versioning approach: one file, version stated prominently, immutable snapshots via git tags. We split into `LOCMAF-v0.1.md` only if/when there are two live versions to maintain.

After merge, tag this commit as `locmaf-v0.1` so `…/blob/locmaf-v0.1/docs/LOCMAF.md` becomes the permalink for the 0.1 spec.

## Test plan

- [ ] Render `docs/LOCMAF.md` on GitHub and confirm the logo + banner display correctly in both light and dark modes.
- [ ] Confirm the [Revision history](#revision-history) anchor link from the intro works.
- [ ] After merge: `git tag locmaf-v0.1 <merge sha> && git push origin locmaf-v0.1`