### PR TITLE
chore(release): prepare v0.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.0] - 2026-05-17
+
+LOCMAF (Low Overhead CMAF) packaging support and audio loop drift fixes.
+
 ### Added
 
 - LOCMAF (Low Overhead CMAF) packaging: a LOC-inspired variant of CMAF that
@@ -51,6 +55,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - CENC IV reuse across CMAF fragments: track per-`ContentTrack` running IV
   and chain it through successive `GenCMAFChunk` calls using mp4ff's new
   `EncryptFragment` return value (mp4ff #499)
+- Audio 10s loop sources regenerated with uniform per-sample durations
+  (AAC 469x1024, Opus 500x960, AC-3 313x1536), no trailing short sample,
+  no `elst`, `baseMediaDecodeTime` starting at 0. `GenCMAFChunk` now
+  emits `orig.Dur` instead of `t.SampleDur` so a future non-uniform
+  source cannot silently produce sub-frame timing slop at the loop wrap.
+  Codec cycle periods average exactly 10s wall-clock (AAC 4-loop/40s,
+  Opus 1-loop/10s, AC-3 2-loop/20s); `CalcSample`'s snap-logic produces
+  a drift-free `[469,469,469,468]`-style pattern with
+  `1875 * 1024 == 40 * TimeScale` exactly. New `utils/contentgen/trimaudio`
+  post-processor strips whole-frame encoder priming, drops the trailing
+  short sample, trims to the codec's target frame count, removes the
+  `elst`, and re-anchors tfdts at 0
 
 ### Changed
 
@@ -292,7 +308,8 @@ Full [MOQ Transport draft-14][moqt-d14] compliance release.
 
 - initial version of the repo
 
-[Unreleased]: https://github.com/Eyevinn/moqlivemock/releases/tag/v0.8.0...HEAD
+[Unreleased]: https://github.com/Eyevinn/moqlivemock/releases/tag/v0.9.0...HEAD
+[0.9.0]: https://github.com/Eyevinn/moqlivemock/releases/tag/v0.8.0...v0.9.0
 [0.8.0]: https://github.com/Eyevinn/moqlivemock/releases/tag/v0.7.0...v0.8.0
 [0.7.0]: https://github.com/Eyevinn/moqlivemock/releases/tag/v0.6.1...v0.7.0
 [0.6.1]: https://github.com/Eyevinn/moqlivemock/releases/tag/v0.6.0...v0.6.1

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,11 +25,16 @@ go mod vendor               # Vendor dependencies
 - `cmd/mlmpub/` - Publisher application serving media tracks (video, audio, subtitles)
 - `cmd/mlmsub/` - Subscriber application receiving media
 - `cmd/mlmtest/` - Interop test client for [moq-interop-runner](https://github.com/englishm/moq-interop-runner)
+- `cmd/locmaf/` - LOCMAF reference-asset generator and `roundtrip` validator
 - `internal/` - Shared internal packages:
   - `asset.go` - Asset loading and track management
-  - `catalog.go` - MSF/CMSF catalog generation
+  - `catalog.go` - MSF/CMSF catalog generation (CMAF, LOC, LOCMAF packaging)
   - `subtitle.go` - Dynamic subtitle generation (WVTT/STPP)
   - `moqgroup.go` - MoQ group/object handling
+  - `locmaf.go` - LOCMAF full-moof encode/decode and the `moov`→`initData` codec
+  - `locmaf_delta.go` - `MoofDeltaCompressor` / `MoofDeltaDecompressor` keeping
+    the per-track previous-moof state used for delta moofs
+- `docs/LOCMAF.md` - LOCMAF packaging design, wire format, and version policy
 
 ### MoQ Transport Dependency
 
@@ -41,10 +46,47 @@ Version negotiation uses ALPN (`moqt-16` for draft-16, `moq-00` for draft-14) an
 
 ### Multi-Namespace Architecture
 
-mlmpub announces one or more namespaces, each with its own catalog:
+mlmpub announces one or more namespaces. CMSF and LOCMAF namespaces each have
+their own catalog filtered by protection type; LOC uses an MSF catalog; moq-mi
+is catalogless.
+
+CMSF (CMAF chunks):
 - `cmsf/clear` — always present, clear (unencrypted) tracks
 - `cmsf/drm-{scheme}` — when `-drmpath` is set, commercial DRM tracks (`_drm` suffix)
 - `cmsf/eccp-{scheme}` — when `-kid`/`-iv` are set, ClearKey/ECCP tracks (`_eccp` suffix)
+
+LOCMAF (Low Overhead CMAF — LOC-style key-value encoding of `moof`/`moov`):
+- `locmaf/clear` — always present, clear tracks
+- `locmaf/drm-{scheme}` — when `-drmpath` is set
+- `locmaf/eccp-{scheme}` — when `-kid`/`-iv` are set
+- Tracks carry `packaging: "locmaf"` and a `locmafVersion` string
+  (currently `"0.1"`, tracked by the `internal.LocmafVersion` constant)
+
+### LOCMAF specification versioning
+
+The LOCMAF wire format and behaviour are versioned independently of
+moqlivemock releases. When the version changes (`internal.LocmafVersion`,
+the `Revision history` table in `docs/LOCMAF.md`, and the document version
+banner near the top of `docs/LOCMAF.md`):
+
+1. Bump `internal.LocmafVersion` and the docs in the same commit.
+2. After that commit lands on `main`, tag it with an annotated tag
+   `locmaf-v<MAJOR>.<MINOR>` so the spec is permanently citable as
+   `docs/LOCMAF.md@locmaf-v<MAJOR>.<MINOR>`:
+
+   ```
+   git tag -a locmaf-v0.2 <sha> -m "LOCMAF specification v0.2"
+   git push origin locmaf-v0.2
+   ```
+
+   `locmaf-v0.1` was tagged on commit `d5c5e04`.
+
+Tags use the `locmaf-v` prefix to keep them separate from moqlivemock
+release tags (`vX.Y.Z`).
+
+LOC (raw codec frames, one per object) and moq-mi (catalogless):
+- `msf/clear` — LOC packaging (AVC + AAC/Opus, HEVC for `hev1.*`)
+- `moq-mi/clear` — moq-mi packaging with fixed track names `video0` / `audio0`
 
 Key types in `internal/pub/pub.go`:
 - `NamespaceEntry` — pairs a namespace tuple with its catalog
@@ -55,8 +97,8 @@ Key types in `internal/asset.go`:
 - `ContentTrack.Protection` — identifies how a track is encrypted
 - `Asset.Drm` / `Asset.Eccp` — independent DRM configs
 
-`GenCMAFCatalogEntry(namespace, protectionType, timestamp)` generates a catalog
-filtered to the specified protection type.
+`GenCMAFCatalogEntry(namespace, protectionType, timestamp)` generates a CMSF or
+LOCMAF catalog filtered to the specified protection type.
 
 ### Handler Pattern
 

--- a/internal/version.go
+++ b/internal/version.go
@@ -8,8 +8,8 @@ import (
 )
 
 var (
-	commitVersion string = "0.8.0"      // Should be updated during build
-	commitDate    string = "1777975200" // commitDate in Epoch seconds (can be filled/updated in during build)
+	commitVersion string = "0.9.0"      // Should be updated during build
+	commitDate    string = "1779001365" // commitDate in Epoch seconds (can be filled/updated in during build)
 )
 
 // GetVersion - get version, commitHash and  commitDate depending on what is inserted


### PR DESCRIPTION
## [0.9.0] - 2026-05-17

LOCMAF (Low Overhead CMAF) packaging support and audio loop drift fixes.

### Added

- LOCMAF (Low Overhead CMAF) packaging: a LOC-inspired variant of CMAF that
  encodes only the non-derivable `moof`/`moov` fields as MoQT key-value pairs
  using QUIC varints. The first object of every group is a LOCMAF *full* moof
  (carries every required field); subsequent objects in the group are LOCMAF
  *delta* moofs that only carry the fields that changed since the previous
  moof. Signed fields (composition time offsets, delta differences) use
  zigzag-encoded varints. The catalog `initData` field is the LOCMAF-encoded
  `moov`, so subscribers reconstruct a valid CMAF init segment by decoding
  the LOCMAF fields and merging them into an empty CMAF template
- LOCMAF namespaces in mlmpub: `locmaf/clear` (always), `locmaf/drm-{scheme}`
  (when `-drmpath` is set) and `locmaf/eccp-{scheme}` (when `-kid`/`-iv` are
  set). LOCMAF carries all information needed to reconstruct a valid CMAF
  file and therefore supports both commercial DRM (CPIX) and ClearKey/ECCP
- LOCMAF subscriber support in mlmsub: decodes full and delta moofs against
  the LOCMAF-encoded `moov` from the catalog and rewrites a standard CMAF
  fragment for the mux/video/audio outputs
- `cmd/locmaf` test asset generator: writes a CMAF init segment, the
  matching LOCMAF init, and two LOCMAF objects (full moof + delta moof) so
  other LOCMAF implementations can test against a reference asset. Output is
  encrypted (cbcs) to exercise the encrypted-field path. Input and output
  paths are configurable via `-input` / `-out`
- `cmd/locmaf roundtrip` subcommand: encodes a fragmented MP4 through the
  LOCMAF encoder/decoder, verifies sample-level fidelity (mdat byte-equal
  and matching size / duration / effective flags / composition-time offset
  / decode time per ISO 14496-12 §8.8.8.2), and prints wire-overhead
  statistics for the init segment and per-moof. Useful for validating
  LOCMAF compression and fidelity against arbitrary fMP4 inputs
- `MoofDeltaCompressor` / `MoofDeltaDecompressor` types in `internal` that
  maintain the per-track previous-moof state used to encode and decode
  LOCMAF delta moofs
- `locmafVersion` string field on CMSF catalog `Track` entries when
  `packaging == "locmaf"`, currently `"0.1"`. Lets receivers detect that
  the encoder is ahead and fall back to a non-LOCMAF packaging rather
  than silently mis-decoding a behaviourally-changed field. Tracked by
  the `internal.LocmafVersion` constant. See `docs/LOCMAF.md` for the
  rationale and the planned stabilisation path

### Fixed

- CENC IV reuse across CMAF fragments: track per-`ContentTrack` running IV
  and chain it through successive `GenCMAFChunk` calls using mp4ff's new
  `EncryptFragment` return value (mp4ff #499)
- Audio 10s loop sources regenerated with uniform per-sample durations
  (AAC 469x1024, Opus 500x960, AC-3 313x1536), no trailing short sample,
  no `elst`, `baseMediaDecodeTime` starting at 0. `GenCMAFChunk` now
  emits `orig.Dur` instead of `t.SampleDur` so a future non-uniform
  source cannot silently produce sub-frame timing slop at the loop wrap.
  Codec cycle periods average exactly 10s wall-clock (AAC 4-loop/40s,
  Opus 1-loop/10s, AC-3 2-loop/20s); `CalcSample`'s snap-logic produces
  a drift-free `[469,469,469,468]`-style pattern with
  `1875 * 1024 == 40 * TimeScale` exactly. New `utils/contentgen/trimaudio`
  post-processor strips whole-frame encoder priming, drops the trailing
  short sample, trims to the codec's target frame count, removes the
  `elst`, and re-anchors tfdts at 0

### Changed

- Bumped mp4ff to v0.52.0 (new `EncryptFragment` signature returning the
  next IV so callers can avoid IV reuse on cenc)

