### PR TITLE
chore(release): prepare v0.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.10.0] - 2026-06-02
+
+LOCMAF v0.2 wire codec aligned with the IETF draft, running side-by-side
+with v0.1.
+
 ### Added
 
 - LOCMAF v0.2 wire codec (`internal/locmafv02`): a renumbered, independent
@@ -30,6 +35,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `run_mlmpub_fingerprint.sh`: convenience script that runs mlmpub with the
   in-memory ECDSA fingerprint certificate and ClearKey/ECCP encryption for
   browser testing
+
+### Changed
+
+- Bumped `golang.org/x/net` to v0.55.0 (GO-2026-5026)
 
 ## [0.9.0] - 2026-05-17
 
@@ -332,7 +341,8 @@ Full [MOQ Transport draft-14][moqt-d14] compliance release.
 
 - initial version of the repo
 
-[Unreleased]: https://github.com/Eyevinn/moqlivemock/releases/tag/v0.9.0...HEAD
+[Unreleased]: https://github.com/Eyevinn/moqlivemock/releases/tag/v0.10.0...HEAD
+[0.10.0]: https://github.com/Eyevinn/moqlivemock/releases/tag/v0.9.0...v0.10.0
 [0.9.0]: https://github.com/Eyevinn/moqlivemock/releases/tag/v0.8.0...v0.9.0
 [0.8.0]: https://github.com/Eyevinn/moqlivemock/releases/tag/v0.7.0...v0.8.0
 [0.7.0]: https://github.com/Eyevinn/moqlivemock/releases/tag/v0.6.1...v0.7.0

--- a/internal/version.go
+++ b/internal/version.go
@@ -8,8 +8,8 @@ import (
 )
 
 var (
-	commitVersion string = "0.9.0"      // Should be updated during build
-	commitDate    string = "1779001365" // commitDate in Epoch seconds (can be filled/updated in during build)
+	commitVersion string = "0.10.0"     // Should be updated during build
+	commitDate    string = "1780432147" // commitDate in Epoch seconds (can be filled/updated in during build)
 )
 
 // GetVersion - get version, commitHash and  commitDate depending on what is inserted


### PR DESCRIPTION
## Release v0.10.0

LOCMAF v0.2 wire codec aligned with the IETF draft, running side-by-side with v0.1.

### Added

- **LOCMAF v0.2 wire codec** (`internal/locmafv02`): a renumbered, independent implementation of the LOCMAF packaging specified by the IETF draft [draft-einarsson-moq-locmaf](https://datatracker.ietf.org/doc/draft-einarsson-moq-locmaf/). Runs side-by-side with the v0.1 codec. The v0.2 catalog ships a raw, uncompressed CMAF Header (no `moov` compression); only the `moof` is encoded as LOCMAF full/delta property blocks. Wire-format `locmafVersion` is `"0.2"`. `prft`, `styp`, and `emsg` field carriage are not yet emitted by mlmpub, but those are additive (new reserved field IDs) and land under the same `"0.2"` version.
- **LOCMAF v0.2 namespaces in mlmpub**: `locmaf-v0.2/clear` (always), `locmaf-v0.2/drm-{scheme}` and `locmaf-v0.2/eccp-{scheme}`. Catalog `Track.Packaging` stays `"locmaf"` for both v0.1 and v0.2; `locmafVersion` is the discriminator.
- **LOCMAF v0.2 subscriber support in mlmsub**: dispatches on `locmafVersion` (empty/`"0.1"` → v0.1 codec, `"0.2"` → v0.2 codec) and decodes full and delta moofs back into standard CMAF fragments for the mux/video/audio outputs. Includes ECCP (ClearKey) decrypt support via the `senc`/`saio`/`saiz` round-trip.
- `run_mlmpub_fingerprint.sh`: convenience script that runs mlmpub with the in-memory ECDSA fingerprint certificate and ClearKey/ECCP encryption for browser testing.

### Changed

- Bumped `golang.org/x/net` to v0.55.0 (GO-2026-5026).

🤖 Generated with [Claude Code](https://claude.com/claude-code)