### PR TITLE
fix: bound interop SETUP by deadline; refuse silent WebTransport draft-14 downgrade

### DIFF
--- a/cmd/mlmsub/main.go
+++ b/cmd/mlmsub/main.go
@@ -223,6 +223,9 @@ func runClient(ctx context.Context, opts *options) error {
 	default:
 		alpn = "moq-00"
 	}
+	// Record what we offer so the session refuses to silently downgrade to
+	// draft-14 over WebTransport if the peer omits the WT-Protocol header.
+	h.Protocols = []string{alpn}
 
 	return runClientWithDial(ctx, opts.addr, useWebTransport, alpn, h, outs)
 }

--- a/cmd/mlmtest/main.go
+++ b/cmd/mlmtest/main.go
@@ -176,7 +176,7 @@ func runSession(ctx context.Context, conn moqtransport.Connection, draft int) (*
 			}
 		}),
 	}
-	if err := s.Run(conn); err != nil {
+	if err := s.RunContext(ctx, conn); err != nil {
 		return nil, fmt.Errorf("session setup: %w", err)
 	}
 	return s, nil
@@ -275,10 +275,10 @@ func runPublisherSession(
 		}),
 		SubscribeHandler: moqtransport.SubscribeHandlerFunc(
 			func(w *moqtransport.SubscribeResponseWriter, m *moqtransport.SubscribeMessage) {
-			_ = w.Accept()
-		}),
+				_ = w.Accept()
+			}),
 	}
-	if err := s.Run(conn); err != nil {
+	if err := s.RunContext(ctx, conn); err != nil {
 		return nil, fmt.Errorf("publisher session setup: %w", err)
 	}
 	if err := s.Announce(ctx, namespace); err != nil {

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.25.0
 
 require (
 	github.com/Dash-Industry-Forum/livesim2 v1.9.0
-	github.com/Eyevinn/moqtransport v0.8.1
+	github.com/Eyevinn/moqtransport v0.8.2
 	github.com/Eyevinn/mp4ff v0.52.0
 	github.com/mengelbart/qlog v0.1.0
 	github.com/quic-go/quic-go v0.59.1

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
 github.com/Dash-Industry-Forum/livesim2 v1.9.0 h1:7NTv3f+9gszh9mX7p6ltaTJmLlR400S+R4pjWrzpLKQ=
 github.com/Dash-Industry-Forum/livesim2 v1.9.0/go.mod h1:AtqFe2WBX6TSoHlpHw7Hh/IWttqDRnoN+VnysQyssiA=
-github.com/Eyevinn/moqtransport v0.8.1 h1:FMzlHMEh/5Sy2Vfvy7ntvbMPmDB2eGYYBIWHfiN+moo=
-github.com/Eyevinn/moqtransport v0.8.1/go.mod h1:xzseX5ZPFBxV0o+wZFqJNJCg3K+6qD+jFy0Qsch1K2M=
+github.com/Eyevinn/moqtransport v0.8.2 h1:L1AlJuWmZZBFna/k4CiLsJnyTheLlaIYNixXr9V+fcs=
+github.com/Eyevinn/moqtransport v0.8.2/go.mod h1:5ewYH8aUA0sCYVLb34zaIfqSaPWZOxu5lTUsiWO3kfk=
 github.com/Eyevinn/mp4ff v0.52.0 h1:QJUi2PtROeZGkcumbX7f4/91Jz6dlhjeKzpwSdCoYG8=
 github.com/Eyevinn/mp4ff v0.52.0/go.mod h1:LKZAf3K+OtWYdzlvte8uafD/e3g2aK2WcsgVohvjccU=
 github.com/Eyevinn/webtransport-go v0.0.0-20260428203517-12aa0d7199e5 h1:vzaoTakGI3gADG+mrYqjBdZGJc899JJQFQrsU+1WCfY=

--- a/internal/sub/sub.go
+++ b/internal/sub/sub.go
@@ -34,9 +34,10 @@ type Handler struct {
 	AudioName    string
 	SubsName     string
 	UseFetch     bool
-	AcceptAny    bool   // Accept any announced namespace
-	Discover     bool   // Discovery mode: list namespaces and exit
-	CatalogTrack string // Catalog track name (default "catalog")
+	AcceptAny    bool     // Accept any announced namespace
+	Discover     bool     // Discovery mode: list namespaces and exit
+	CatalogTrack string   // Catalog track name (default "catalog")
+	Protocols    []string // Application protocols offered to the peer (ALPN / WT subprotocol)
 
 	catalog    *internal.Catalog
 	mux        *CmafMux
@@ -71,6 +72,7 @@ func (h *Handler) runDiscover(ctx context.Context, conn moqtransport.Connection)
 		Handler:             h.getHandler(),
 		SubscribeHandler:    h.getSubscribeHandler(),
 		InitialMaxRequestID: initialMaxRequestID,
+		Protocols:           h.Protocols,
 		Qlogger:             qlog.NewQLOGHandler(h.Logfh, "MoQ QLOG", "MoQ QLOG", conn.Perspective().String(), moqt.Schema),
 	}
 	err := session.Run(conn)
@@ -130,6 +132,7 @@ func (h *Handler) startSession(conn moqtransport.Connection) (*moqtransport.Sess
 		Handler:             h.getHandler(),
 		SubscribeHandler:    h.getSubscribeHandler(),
 		InitialMaxRequestID: initialMaxRequestID,
+		Protocols:           h.Protocols,
 		Qlogger:             qlog.NewQLOGHandler(h.Logfh, "MoQ QLOG", "MoQ QLOG", conn.Perspective().String(), moqt.Schema),
 	}
 	if err := session.Run(conn); err != nil {


### PR DESCRIPTION
## Summary

Two related draft-16 interop-robustness fixes, kept as separate commits.

### 1. Bound interop SETUP by the per-test deadline — `fix(mlmtest)`

Each interop test case ran under a context with a deadline, but the deadline
only covered the QUIC dial — `runSession`/`runPublisherSession` called
`Session.Run`, which ignores it. A relay that completed the QUIC/ALPN handshake
but never sent a usable `SERVER_SETUP` (observed against moq-rs-draft-16) hung
the client indefinitely, blocking the whole sequential interop matrix
(englishm/moq-interop-runner#70, see also #69). Now uses `Session.RunContext`
so the per-test deadline also bounds the MoQ SETUP exchange; a stuck peer fails
the test cleanly instead of hanging.

### 2. Refuse silent draft-14 downgrade over WebTransport — `feat(mlmsub)`

Over WebTransport the subscriber relied on the negotiated `WT-Protocol`
subprotocol to pick the MoQ version. If a draft-16 peer omitted the
`WT-Protocol` response header, the session silently fell back to offering only
draft-14 in-band, which mis-negotiates against a draft-16-only server. mlmsub
now records the offered protocol (`Handler.Protocols` → `Session.Protocols`) so
the session refuses to downgrade when the peer returns no `WT-Protocol` and we
offered only draft-16+ (facebookexperimental/moxygen#173).

## Dependency

⚠️ Depends on **Eyevinn/moqtransport#11** (`Session.RunContext` and
`Session.Protocols`). The expected sequence: merge + tag moqtransport, then bump
the `moqtransport` requirement in `go.mod` here. Until that release lands, CI
that builds against the published moqtransport will fail; the changes are
verified locally through the workspace `go.work`.

## Refs

- englishm/moq-interop-runner#70 — raw-QUIC client hang against moq-rs-draft-16
- facebookexperimental/moxygen#173 — WebTransport `WT-Protocol` negotiation
