### PR TITLE
chore(release): prepare v0.11.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.11.1] - 2026-06-08
+
+Interop robustness: the test client can no longer hang during MoQ SETUP, and the
+WebTransport client no longer silently downgrades to draft-14.
+
 ### Fixed
 
 - `mlmtest` interop client no longer hangs when a relay completes the QUIC/ALPN
@@ -385,7 +390,8 @@ Full [MOQ Transport draft-14][moqt-d14] compliance release.
 
 - initial version of the repo
 
-[Unreleased]: https://github.com/Eyevinn/moqlivemock/releases/tag/v0.11.0...HEAD
+[Unreleased]: https://github.com/Eyevinn/moqlivemock/releases/tag/v0.11.1...HEAD
+[0.11.1]: https://github.com/Eyevinn/moqlivemock/releases/tag/v0.11.0...v0.11.1
 [0.11.0]: https://github.com/Eyevinn/moqlivemock/releases/tag/v0.10.0...v0.11.0
 [0.10.0]: https://github.com/Eyevinn/moqlivemock/releases/tag/v0.9.0...v0.10.0
 [0.9.0]: https://github.com/Eyevinn/moqlivemock/releases/tag/v0.8.0...v0.9.0

--- a/internal/version.go
+++ b/internal/version.go
@@ -8,8 +8,8 @@ import (
 )
 
 var (
-	commitVersion string = "0.11.0"     // Should be updated during build
-	commitDate    string = "1780562086" // commitDate in Epoch seconds (can be filled/updated in during build)
+	commitVersion string = "0.11.1"     // Should be updated during build
+	commitDate    string = "1780953297" // commitDate in Epoch seconds (can be filled/updated in during build)
 )
 
 // GetVersion - get version, commitHash and  commitDate depending on what is inserted


### PR DESCRIPTION
Release prep for **v0.11.1** — an interop-robustness release.

Rolls the `[Unreleased]` CHANGELOG entries into a dated `[0.11.1]` section and bumps `internal/version.go` (`commitVersion` → `0.11.1`, `commitDate` → 2026-06-08). The Dockerfile builds without ldflags, so this bump is what makes the published `mlmtest` image report `0.11.1`.

Contents (already on main from #92/#93):
- **Fixed** — `mlmtest` no longer hangs when a relay never finishes MoQ SETUP (moq-rs-draft-16); bounded via `Session.RunContext` ([moq-interop-runner#70](https://github.com/englishm/moq-interop-runner/issues/70)).
- **Changed** — `mlmsub` refuses silent draft-14 downgrade over WebTransport when `WT-Protocol` is absent ([moxygen#173](https://github.com/facebookexperimental/moxygen/issues/173)).
- **Changed** — bumped `moqtransport` to v0.8.2.

After merge: tag `v0.11.1` on main → `docker-mlmtest.yml` republishes `ghcr.io/eyevinn/mlmtest:latest`, which the interop runner pulls on its next run.