### PR TITLE
feat: retrieve catalog via relative joining FETCH

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+Catalog retrieval now uses a relative joining FETCH, aligned to the live edge.
+
+### Added
+
+- `mlmsub -catalog-mode` flag selecting how the catalog is retrieved:
+  `joining` (default), `subscribe` (legacy), or `fetch` (legacy standalone). The
+  default fetches the MSF/CMSF catalog via SUBSCRIBE plus a relative joining
+  FETCH (offset 0) per [draft-ietf-moq-msf-01][msf-01] §5, so the client gets the
+  latest catalog group in a single round-trip.
+- Publisher-side joining FETCH resolution: the catalog object is served from a
+  FETCH when the requested range covers `{0,0}`.
+
+### Changed
+
+- Bumped `github.com/Eyevinn/moqtransport` to v0.9.0, which adds the
+  publisher-side joining FETCH support this feature depends on.
+- Bumped `github.com/quic-go/webtransport-go` to the Eyevinn v0.11.0 fork and
+  `github.com/quic-go/quic-go` to v0.60.0; the fork sends/accepts the legacy
+  `WEBTRANSPORT_MAX_SESSIONS` codepoint and emits the full WebTransport SETTINGS
+  bundle itself, so the manual workarounds in `mlmpub`/`mlmsub` are removed.
+
 ## [0.11.1] - 2026-06-08
 
 Interop robustness: the test client can no longer hang during MoQ SETUP, and the

--- a/README.md
+++ b/README.md
@@ -142,9 +142,16 @@ implementations can be tested against a reference asset.
 ## Session setup
 
 After session establishment, the server announces all configured namespaces.
-For CMSF and LOC namespaces the client subscribes to the catalog track first,
-then to the media tracks listed in that catalog. For moq-mi there is no
+For CMSF and LOC namespaces the client retrieves the catalog track first, then
+subscribes to the media tracks listed in that catalog. For moq-mi there is no
 catalog, so the client subscribes directly to the fixed track names.
+
+By default the catalog is retrieved with a SUBSCRIBE (Filter Type = Largest
+Object) plus a relative joining FETCH at offset 0, per
+[draft-ietf-moq-msf-01][msf-01] §5, so the client gets the latest catalog group
+aligned to the live edge in a single round-trip. The `mlmsub -catalog-mode` flag
+selects the strategy: `joining` (default), `subscribe` (legacy plain SUBSCRIBE),
+or `fetch` (legacy standalone FETCH).
 
 The bundled `mlmsub` client connects to a single namespace (default: `cmsf/clear`,
 configurable via `-namespace`). It subscribes to the first video and audio track

--- a/cmd/mlmpub/handler.go
+++ b/cmd/mlmpub/handler.go
@@ -49,13 +49,10 @@ func (s *server) runServer(ctx context.Context) error {
 			EnableStreamResetPartialDelivery: true,
 		},
 	}
+	// ConfigureHTTP3Server (webtransport-go v0.11.0) sends the full set of
+	// WebTransport SETTINGS, including the WT_MAX_SESSIONS and flow-control
+	// codepoints Safari 26.4+ requires. See https://github.com/Eyevinn/warp-player/issues/88
 	webtransport.ConfigureHTTP3Server(h3Server)
-	// Add newer WebTransport setting codepoints for Safari 26.4+ compatibility.
-	// webtransport-go only sends the old draft-02 setting (0x2b603742).
-	// Safari requires the draft-13/14 or draft-15 codepoint to recognize WebTransport support.
-	// See https://github.com/Eyevinn/warp-player/issues/88
-	h3Server.AdditionalSettings[0x14e9cd29] = 1 // SETTINGS_WT_MAX_SESSIONS (draft-13/14)
-	h3Server.AdditionalSettings[0x2c7cf000] = 1 // SETTINGS_WT_ENABLED (draft-15)
 	wt := webtransport.Server{
 		H3: h3Server,
 		CheckOrigin: func(r *http.Request) bool {

--- a/cmd/mlmsub/handler.go
+++ b/cmd/mlmsub/handler.go
@@ -66,16 +66,10 @@ func dialQUIC(ctx context.Context, addr string, alpn string) (moqtransport.Conne
 	return quicmoq.NewClient(conn), nil
 }
 
-// settingWebTransportMaxSessions is HTTP/3 SETTINGS_WEBTRANSPORT_MAX_SESSIONS
-// (draft-ietf-webtrans-http3). Advertising it on the client side is technically
-// a server-only setting per the spec, but several deployed relays built on
-// web-transport-quinn (Cloudflare's WT endpoint, moq-rs / cdn.moq.dev, …) call
-// the same supports_webtransport() check on the client's SETTINGS frame and
-// close the connection with H3_NO_ERROR when it is missing. Sending it makes
-// the WT handshake succeed against those relays at no cost on conformant ones.
-const settingWebTransportMaxSessions = 0xc671706a
-
 func dialWebTransport(ctx context.Context, addr string, alpn string) (moqtransport.Connection, error) {
+	// webtransport-go (Eyevinn fork on v0.11.0) sends and accepts the legacy
+	// WEBTRANSPORT_MAX_SESSIONS codepoint itself, so deployed web-transport-quinn
+	// relays (moq-rs / cdn.moq.dev, Cloudflare) interoperate without extra setup.
 	dialer := webtransport.Dialer{
 		TLSClientConfig: &tls.Config{
 			InsecureSkipVerify: true,
@@ -85,9 +79,6 @@ func dialWebTransport(ctx context.Context, addr string, alpn string) (moqtranspo
 			EnableStreamResetPartialDelivery: true,
 		},
 		ApplicationProtocols: []string{alpn},
-		AdditionalSettings: map[uint64]uint64{
-			settingWebTransportMaxSessions: 1,
-		},
 	}
 	_, session, err := dialer.Dial(ctx, ensureURLPort(addr, "443"), nil)
 	if err != nil {

--- a/cmd/mlmsub/main.go
+++ b/cmd/mlmsub/main.go
@@ -52,6 +52,7 @@ type options struct {
 	namespace    string
 	loglevel     string
 	fetchCatalog bool
+	catalogMode  string
 	acceptAny    bool
 	discover     bool
 	catalogTrack string
@@ -81,7 +82,9 @@ func parseOptions(fs *flag.FlagSet, args []string) (*options, error) {
 	fs.StringVar(&opts.subsname, "subsname", "", "Substring to match for selecting subtitle track (e.g. 'wvtt' or 'stpp')")
 	fs.StringVar(&opts.namespace, "namespace", "cmsf/clear", "MoQ namespace to use")
 	fs.StringVar(&opts.loglevel, "loglevel", "info", "Log level: debug, info, warning, error")
-	fs.BoolVar(&opts.fetchCatalog, "fetchcatalog", false, "Use FETCH instead of SUBSCRIBE for catalog")
+	fs.StringVar(&opts.catalogMode, "catalog-mode", "joining",
+		"Catalog retrieval: 'joining' (default), 'subscribe' (legacy), or 'fetch' (legacy standalone)")
+	fs.BoolVar(&opts.fetchCatalog, "fetchcatalog", false, "Deprecated: alias for -catalog-mode fetch")
 	fs.BoolVar(&opts.acceptAny, "accept-any", false, "Accept any announced namespace")
 	fs.BoolVar(&opts.discover, "discover", false, "Discovery mode: list announced namespaces and exit")
 	fs.StringVar(&opts.catalogTrack, "catalog-track", "catalog", "Catalog track name (e.g. 'catalog' or 'catalog.json')")
@@ -185,6 +188,7 @@ func runClient(ctx context.Context, opts *options) error {
 		AudioName:    opts.audioname,
 		SubsName:     opts.subsname,
 		UseFetch:     opts.fetchCatalog,
+		CatalogMode:  opts.catalogMode,
 		AcceptAny:    opts.acceptAny,
 		Discover:     opts.discover,
 		CatalogTrack: opts.catalogTrack,

--- a/go.mod
+++ b/go.mod
@@ -7,8 +7,8 @@ require (
 	github.com/Eyevinn/moqtransport v0.8.2
 	github.com/Eyevinn/mp4ff v0.52.0
 	github.com/mengelbart/qlog v0.1.0
-	github.com/quic-go/quic-go v0.59.1
-	github.com/quic-go/webtransport-go v0.10.0
+	github.com/quic-go/quic-go v0.60.0
+	github.com/quic-go/webtransport-go v0.11.0
 	github.com/stretchr/testify v1.11.1
 )
 
@@ -26,4 +26,4 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 
-replace github.com/quic-go/webtransport-go => github.com/Eyevinn/webtransport-go v0.0.0-20260428203517-12aa0d7199e5
+replace github.com/quic-go/webtransport-go => github.com/Eyevinn/webtransport-go v0.0.0-20260616094103-94b8f28c0917

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.25.0
 
 require (
 	github.com/Dash-Industry-Forum/livesim2 v1.9.0
-	github.com/Eyevinn/moqtransport v0.8.2
+	github.com/Eyevinn/moqtransport v0.9.0
 	github.com/Eyevinn/mp4ff v0.52.0
 	github.com/mengelbart/qlog v0.1.0
 	github.com/quic-go/quic-go v0.60.0

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
 github.com/Dash-Industry-Forum/livesim2 v1.9.0 h1:7NTv3f+9gszh9mX7p6ltaTJmLlR400S+R4pjWrzpLKQ=
 github.com/Dash-Industry-Forum/livesim2 v1.9.0/go.mod h1:AtqFe2WBX6TSoHlpHw7Hh/IWttqDRnoN+VnysQyssiA=
-github.com/Eyevinn/moqtransport v0.8.2 h1:L1AlJuWmZZBFna/k4CiLsJnyTheLlaIYNixXr9V+fcs=
-github.com/Eyevinn/moqtransport v0.8.2/go.mod h1:5ewYH8aUA0sCYVLb34zaIfqSaPWZOxu5lTUsiWO3kfk=
+github.com/Eyevinn/moqtransport v0.9.0 h1:LOPeLozXu6NJ9cUZ42uOlUbDnYhTi7l9HofDZ9kMxJM=
+github.com/Eyevinn/moqtransport v0.9.0/go.mod h1:jrJLq5ZgFJfUBd6YGUq4B31DF57AbL+oyONIvrS24Xc=
 github.com/Eyevinn/mp4ff v0.52.0 h1:QJUi2PtROeZGkcumbX7f4/91Jz6dlhjeKzpwSdCoYG8=
 github.com/Eyevinn/mp4ff v0.52.0/go.mod h1:LKZAf3K+OtWYdzlvte8uafD/e3g2aK2WcsgVohvjccU=
 github.com/Eyevinn/webtransport-go v0.0.0-20260616094103-94b8f28c0917 h1:l4NI/aiwXLOzDsFaaSEP2HU3b6ZvB9ai3Yd8pkZjueg=

--- a/go.sum
+++ b/go.sum
@@ -4,8 +4,8 @@ github.com/Eyevinn/moqtransport v0.8.2 h1:L1AlJuWmZZBFna/k4CiLsJnyTheLlaIYNixXr9
 github.com/Eyevinn/moqtransport v0.8.2/go.mod h1:5ewYH8aUA0sCYVLb34zaIfqSaPWZOxu5lTUsiWO3kfk=
 github.com/Eyevinn/mp4ff v0.52.0 h1:QJUi2PtROeZGkcumbX7f4/91Jz6dlhjeKzpwSdCoYG8=
 github.com/Eyevinn/mp4ff v0.52.0/go.mod h1:LKZAf3K+OtWYdzlvte8uafD/e3g2aK2WcsgVohvjccU=
-github.com/Eyevinn/webtransport-go v0.0.0-20260428203517-12aa0d7199e5 h1:vzaoTakGI3gADG+mrYqjBdZGJc899JJQFQrsU+1WCfY=
-github.com/Eyevinn/webtransport-go v0.0.0-20260428203517-12aa0d7199e5/go.mod h1:ocpwcCqYQbWRGNaCYlToTUVgjsbh0yEjLAyXl8yAIdA=
+github.com/Eyevinn/webtransport-go v0.0.0-20260616094103-94b8f28c0917 h1:l4NI/aiwXLOzDsFaaSEP2HU3b6ZvB9ai3Yd8pkZjueg=
+github.com/Eyevinn/webtransport-go v0.0.0-20260616094103-94b8f28c0917/go.mod h1:SHgEzUFVyj+9WUSuGB1P6Zd351Pww2leWV3SwlTovkA=
 github.com/beevik/etree v1.5.0 h1:iaQZFSDS+3kYZiGoc9uKeOkUY3nYMXOKLl6KIJxiJWs=
 github.com/beevik/etree v1.5.0/go.mod h1:gPNJNaBGVZ9AwsidazFZyygnd+0pAU38N4D+WemwKNs=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
@@ -22,10 +22,12 @@ github.com/mengelbart/qlog v0.1.0 h1:8cDMuCMcKtzkPXUU5FF7OBwqKiy+De0GKvIvNawifoA
 github.com/mengelbart/qlog v0.1.0/go.mod h1:nIlGcUugkfDu41B8LKdAwjHQ1NxAF54D9hS2EDOlVyk=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/quic-go/go-ossfuzz-seeds v0.1.0 h1:APacT+iIaNF6fd8AGEiN3bT/Jtkd2jz4v4TzM7MFjy0=
+github.com/quic-go/go-ossfuzz-seeds v0.1.0/go.mod h1:3IOHRbJIc+L6YKMwfDtJAM9Vj9k0YY4muhuyUYk5tbk=
 github.com/quic-go/qpack v0.6.0 h1:g7W+BMYynC1LbYLSqRt8PBg5Tgwxn214ZZR34VIOjz8=
 github.com/quic-go/qpack v0.6.0/go.mod h1:lUpLKChi8njB4ty2bFLX2x4gzDqXwUpaO1DP9qMDZII=
-github.com/quic-go/quic-go v0.59.1 h1:0Gmua0HW1Tv7ANR7hUYwRyD0MG5OJfgvYSZasGZzBic=
-github.com/quic-go/quic-go v0.59.1/go.mod h1:upnsH4Ju1YkqpLXC305eW3yDZ4NfnNbmQRCMWS58IKU=
+github.com/quic-go/quic-go v0.60.0 h1:xcQioE8OM66UQLeUMHltK1CCcOu3JbVB4JAQdDQSB+0=
+github.com/quic-go/quic-go v0.60.0/go.mod h1:wpKpjmPpftl30sL6pFh7REVpjbcCVy4zt2vDyK1TuJk=
 github.com/rogpeppe/go-internal v1.10.0 h1:TMyTOH3F/DB16zRVcYyreMH6GnZZrwQVAoYjRBZyWFQ=
 github.com/rogpeppe/go-internal v1.10.0/go.mod h1:UQnix2H7Ngw/k4C5ijL5+65zddjncjaFoBhdsK/akog=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=

--- a/internal/integration_test.go
+++ b/internal/integration_test.go
@@ -3,6 +3,7 @@ package internal_test
 import (
 	"bytes"
 	"io"
+	"strings"
 	"sync"
 	"testing"
 	"testing/synctest"
@@ -137,6 +138,74 @@ func TestCatalogExchange(t *testing.T) {
 
 		catalogBuf.WaitForLen(1)
 
+		assert.Contains(t, catalogBuf.String(), "video_", "catalog should contain video tracks")
+		assert.Contains(t, catalogBuf.String(), "audio_", "catalog should contain audio tracks")
+
+		shutdown(sConn, cConn)
+	})
+}
+
+// TestJoiningCatalog exercises the default catalog-retrieval path: a SUBSCRIBE
+// (Largest Object) plus a relative joining FETCH (offset 0). It also verifies
+// the catalog is delivered exactly once — the joining FETCH provides the
+// baseline and the subscription's replayed object 0 (<= largest) is deduped.
+func TestJoiningCatalog(t *testing.T) {
+	asset, catalog := loadTestAsset(t)
+
+	synctest.Test(t, func(t *testing.T) {
+		sConn, cConn := memConnPair()
+
+		ph := newPubHandler(asset, catalog)
+		go ph.Handle(t.Context(), sConn)
+
+		catalogBuf := newSyncBuffer()
+		sh := &sub.Handler{
+			Namespace:   []string{testNamespace},
+			Outs:        map[string]io.Writer{"catalog": catalogBuf},
+			Logfh:       io.Discard,
+			VideoName:   "NONE",
+			AudioName:   "NONE",
+			CatalogMode: "joining",
+		}
+		go func() { _ = sh.RunWithConn(t.Context(), cConn) }()
+
+		catalogBuf.WaitForLen(1)
+		// Let the background subscription-update goroutine run so it processes
+		// (and skips) the publisher's replayed object 0 before we assert.
+		synctest.Wait()
+
+		out := catalogBuf.String()
+		assert.Contains(t, out, "video_", "catalog should contain video tracks")
+		assert.Contains(t, out, "audio_", "catalog should contain audio tracks")
+		assert.Equal(t, 1, strings.Count(out, `"tracks"`),
+			"catalog should be delivered exactly once (fetch baseline; subscription duplicate deduped)")
+
+		shutdown(sConn, cConn)
+	})
+}
+
+// TestSubscribeCatalogLegacy keeps coverage of the legacy subscribe-only path.
+func TestSubscribeCatalogLegacy(t *testing.T) {
+	asset, catalog := loadTestAsset(t)
+
+	synctest.Test(t, func(t *testing.T) {
+		sConn, cConn := memConnPair()
+
+		ph := newPubHandler(asset, catalog)
+		go ph.Handle(t.Context(), sConn)
+
+		catalogBuf := newSyncBuffer()
+		sh := &sub.Handler{
+			Namespace:   []string{testNamespace},
+			Outs:        map[string]io.Writer{"catalog": catalogBuf},
+			Logfh:       io.Discard,
+			VideoName:   "NONE",
+			AudioName:   "NONE",
+			CatalogMode: "subscribe",
+		}
+		go func() { _ = sh.RunWithConn(t.Context(), cConn) }()
+
+		catalogBuf.WaitForLen(1)
 		assert.Contains(t, catalogBuf.String(), "video_", "catalog should contain video tracks")
 		assert.Contains(t, catalogBuf.String(), "audio_", "catalog should contain audio tracks")
 

--- a/internal/pub/fetchrange_test.go
+++ b/internal/pub/fetchrange_test.go
@@ -1,0 +1,36 @@
+package pub
+
+import (
+	"testing"
+
+	"github.com/Eyevinn/moqtransport"
+	"github.com/stretchr/testify/assert"
+)
+
+// TestLocationInFetchRange verifies the catalog FETCH range check: the catalog's
+// single object at {group:0, object:0} is served only for a range that covers
+// it, and not for any other group or object.
+func TestLocationInFetchRange(t *testing.T) {
+	loc := func(g, o uint64) moqtransport.Location { return moqtransport.Location{Group: g, Object: o} }
+	catalog := loc(0, 0)
+
+	cases := []struct {
+		name        string
+		start, end  moqtransport.Location
+		wantCatalog bool
+	}{
+		{"relative joining offset 0", loc(0, 0), loc(0, 1), true}, // [{0,0},{0,1})
+		{"standalone whole group 0", loc(0, 0), loc(0, 0), true},  // EndObject 0 = whole group
+		{"standalone up to later group", loc(0, 0), loc(5, 0), true},
+		{"start at object 1", loc(0, 1), loc(0, 5), false},
+		{"start at group 5", loc(5, 0), loc(5, 1), false},
+		{"end before catalog (group 0 excluded)", loc(0, 0), loc(0, 0), true}, // group 0 always included when start {0,0}
+	}
+	for _, c := range cases {
+		assert.Equal(t, c.wantCatalog, locationInFetchRange(catalog, c.start, c.end), c.name)
+	}
+
+	// A non-catalog object (e.g. {5,0}) is only in range when explicitly requested.
+	assert.False(t, locationInFetchRange(loc(5, 0), loc(0, 0), loc(0, 1)), "object {5,0} not in catalog range")
+	assert.True(t, locationInFetchRange(loc(5, 0), loc(5, 0), loc(5, 1)), "object {5,0} in {5,0}-{5,1}")
+}

--- a/internal/pub/pub.go
+++ b/internal/pub/pub.go
@@ -112,6 +112,27 @@ func (h *Handler) findNamespace(ns []string) *NamespaceEntry {
 	return nil
 }
 
+// locationLess reports whether a precedes b in (group, object) order.
+func locationLess(a, b moqtransport.Location) bool {
+	if a.Group != b.Group {
+		return a.Group < b.Group
+	}
+	return a.Object < b.Object
+}
+
+// locationInFetchRange reports whether loc falls within a FETCH's requested
+// [start, end) range. An EndObject of 0 means "to the end of EndGroup" per the
+// FETCH semantics (draft-ietf-moq-transport §9.16.3).
+func locationInFetchRange(loc, start, end moqtransport.Location) bool {
+	if locationLess(loc, start) {
+		return false
+	}
+	if end.Object == 0 {
+		return loc.Group <= end.Group
+	}
+	return locationLess(loc, end)
+}
+
 func (h *Handler) getFetchHandler() moqtransport.FetchHandler {
 	return moqtransport.FetchHandlerFunc(
 		func(w *moqtransport.FetchResponseWriter, m *moqtransport.FetchMessage) {
@@ -149,22 +170,33 @@ func (h *Handler) getFetchHandler() moqtransport.FetchHandler {
 				slog.Error("failed to get fetch stream", "error", err)
 				return
 			}
-			catalogJSON, err := json.Marshal(nsEntry.Catalog)
-			if err != nil {
-				slog.Error("failed to marshal catalog", "error", err)
-				return
+			// The catalog is a single object at {group:0, object:0}. Honor the
+			// requested range (resolved by the transport for joining fetches):
+			// serve the object only when [StartLocation, EndLocation) covers
+			// {0,0}; any other group or object yields an empty response. This is
+			// what a relative joining FETCH (offset 0) against the catalog's
+			// largest location {0,0} asks for.
+			catalogLoc := moqtransport.Location{Group: 0, Object: 0}
+			if locationInFetchRange(catalogLoc, m.StartLocation, m.EndLocation) {
+				catalogJSON, err := json.Marshal(nsEntry.Catalog)
+				if err != nil {
+					slog.Error("failed to marshal catalog", "error", err)
+					return
+				}
+				if _, err = fs.WriteObject(0, 0, 0, 0, catalogJSON); err != nil {
+					slog.Error("failed to write catalog via fetch", "error", err)
+					return
+				}
+				slog.Info("served catalog via FETCH", "namespace", m.Namespace,
+					"fetchType", m.FetchType, "start", m.StartLocation, "end", m.EndLocation)
+			} else {
+				slog.Info("FETCH range excludes catalog object {0,0}; empty response",
+					"namespace", m.Namespace, "start", m.StartLocation, "end", m.EndLocation)
 			}
-			_, err = fs.WriteObject(0, 0, 0, 0, catalogJSON)
-			if err != nil {
-				slog.Error("failed to write catalog via fetch", "error", err)
-				return
-			}
-			err = fs.Close()
-			if err != nil {
+			if err = fs.Close(); err != nil {
 				slog.Error("failed to close fetch stream", "error", err)
 				return
 			}
-			slog.Info("served catalog via FETCH", "namespace", m.Namespace)
 		})
 }
 
@@ -217,7 +249,14 @@ func (h *Handler) getSubscribeHandler(ctx context.Context) moqtransport.Subscrib
 				return
 			}
 			if m.Track == "catalog" {
-				err := w.Accept()
+				// Advertise the catalog's largest location so subscribers can
+				// resolve a relative Joining FETCH (offset 0) against this
+				// subscription per MSF draft-01 §5. The catalog is a single full
+				// object at {group:0, object:0}. We still write object 0 on the
+				// subscription below for backward compatibility with
+				// subscribe-only clients; joining clients dedupe it against the
+				// FETCH (objects <= largest are skipped on the subscription).
+				err := w.Accept(moqtransport.WithLargestLocation(&moqtransport.Location{Group: 0, Object: 0}))
 				if err != nil {
 					slog.Error("failed to accept subscription", "error", err)
 					return

--- a/internal/sub/joining_test.go
+++ b/internal/sub/joining_test.go
@@ -1,0 +1,29 @@
+package sub
+
+import (
+	"testing"
+
+	"github.com/Eyevinn/moqtransport"
+	"github.com/stretchr/testify/assert"
+)
+
+// TestAfterLocation verifies the dedup predicate used by the joining-catalog
+// path: objects at or before the subscription's largest location are covered by
+// the joining FETCH and must be skipped on the subscription.
+func TestAfterLocation(t *testing.T) {
+	largest := moqtransport.Location{Group: 4, Object: 2}
+	cases := []struct {
+		group, object uint64
+		want          bool
+	}{
+		{4, 2, false}, // == largest: covered by the fetch, skip
+		{4, 1, false}, // earlier object, same group
+		{3, 9, false}, // earlier group
+		{4, 3, true},  // next object in the same group
+		{5, 0, true},  // later group
+	}
+	for _, c := range cases {
+		o := &moqtransport.Object{GroupID: c.group, ObjectID: c.object}
+		assert.Equal(t, c.want, afterLocation(o, largest), "group=%d object=%d", c.group, c.object)
+	}
+}

--- a/internal/sub/sub.go
+++ b/internal/sub/sub.go
@@ -33,7 +33,8 @@ type Handler struct {
 	VideoName    string
 	AudioName    string
 	SubsName     string
-	UseFetch     bool
+	UseFetch     bool     // Deprecated: equivalent to CatalogMode == "fetch"
+	CatalogMode  string   // "joining" (default), "subscribe", or "fetch"
 	AcceptAny    bool     // Accept any announced namespace
 	Discover     bool     // Discovery mode: list namespaces and exit
 	CatalogTrack string   // Catalog track name (default "catalog")
@@ -152,13 +153,25 @@ func (h *Handler) handle(ctx context.Context, conn moqtransport.Connection) {
 		return
 	}
 
+	mode := h.CatalogMode
 	if h.UseFetch {
-		err = h.fetchCatalog(ctx, session, h.Namespace)
-	} else {
+		mode = "fetch"
+	}
+	if mode == "" {
+		mode = "joining"
+	}
+	switch mode {
+	case "joining":
+		err = h.joiningCatalog(ctx, session, h.Namespace)
+	case "subscribe":
 		err = h.subscribeToCatalog(ctx, session, h.Namespace)
+	case "fetch":
+		err = h.fetchCatalog(ctx, session, h.Namespace)
+	default:
+		err = fmt.Errorf("unknown catalog mode %q (want joining, subscribe, or fetch)", mode)
 	}
 	if err != nil {
-		slog.Error("failed to subscribe to catalog", "error", err)
+		slog.Error("failed to retrieve catalog", "error", err, "mode", mode)
 		err = conn.CloseWithError(0, "internal error")
 		if err != nil {
 			slog.Error("failed to close connection", "error", err)
@@ -374,6 +387,113 @@ func (h *Handler) handle(ctx context.Context, conn moqtransport.Connection) {
 		return
 	}
 	<-ctx.Done()
+}
+
+// applyCatalog parses a catalog object payload, stores it as the current
+// catalog, logs it, and writes it to the "catalog" output if configured.
+func (h *Handler) applyCatalog(payload []byte, label string) error {
+	var cat internal.Catalog
+	if err := json.Unmarshal(payload, &cat); err != nil {
+		return err
+	}
+	h.catalog = &cat
+	if slog.Default().Enabled(context.Background(), slog.LevelInfo) {
+		fmt.Fprintf(os.Stderr, "%s: %s\n", label, h.catalog.String())
+	}
+	if w := h.Outs["catalog"]; w != nil {
+		indented, err := json.MarshalIndent(h.catalog, "", "  ")
+		if err != nil {
+			return err
+		}
+		if _, err := w.Write(append(indented, '\n')); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// afterLocation reports whether object o lies strictly after loc in
+// (group, object) order.
+func afterLocation(o *moqtransport.Object, loc moqtransport.Location) bool {
+	if o.GroupID != loc.Group {
+		return o.GroupID > loc.Group
+	}
+	return o.ObjectID > loc.Object
+}
+
+// joiningCatalog retrieves the catalog the spec-recommended way (MSF draft-01
+// §5): a SUBSCRIBE with Filter Type Largest Object plus a relative Joining FETCH
+// (offset 0). The FETCH delivers the latest complete catalog (object 0 of the
+// current group) plus any deltas up to the live edge; the SUBSCRIBE then carries
+// subsequent updates. Objects at or before the subscription's largest location
+// are already covered by the FETCH and are skipped on the subscription, so this
+// also transparently dedupes a publisher that still replays object 0 on the
+// subscription.
+func (h *Handler) joiningCatalog(ctx context.Context, s *moqtransport.Session, namespace []string) error {
+	rs, err := s.Subscribe(ctx, namespace, h.CatalogTrack)
+	if err != nil {
+		return err
+	}
+	largest, hasLargest := rs.LargestLocation()
+	if !hasLargest {
+		rs.Close()
+		return fmt.Errorf("catalog subscription reported no content; cannot perform joining fetch")
+	}
+
+	// Relative joining FETCH, offset 0: namespace and track are derived by the
+	// publisher from the subscription, so they must be empty here.
+	rt, err := s.Fetch(ctx, nil, "", moqtransport.WithJoiningFetchRelative(rs.RequestID(), 0))
+	if err != nil {
+		rs.Close()
+		return err
+	}
+	// Read the complete catalog from the joining fetch. Object 0 of the group is
+	// the full catalog. mlmpub publishes a single static catalog object (no
+	// deltas), so one read suffices. We deliberately do not drain to EOF:
+	// moqtransport's RemoteTrack.ReadObject has no fetch-complete signal and
+	// would block once the buffer empties. Draining deltas is future work that
+	// needs a fetch-done signal in moqtransport.
+	o, rerr := rt.ReadObject(ctx)
+	if rerr != nil {
+		rt.Close()
+		rs.Close()
+		return fmt.Errorf("joining fetch: reading catalog: %w", rerr)
+	}
+	if aerr := h.applyCatalog(o.Payload, "catalog (joining fetch)"); aerr != nil {
+		rt.Close()
+		rs.Close()
+		return aerr
+	}
+	slog.Info("fetched catalog via joining fetch",
+		"groupID", o.GroupID, "objectID", o.ObjectID, "payloadLength", len(o.Payload))
+	rt.Close()
+
+	// Continue reading catalog updates on the subscription, skipping anything
+	// already covered by the FETCH (location <= largest).
+	go func() {
+		defer rs.Close()
+		for {
+			o, rerr := rs.ReadObject(ctx)
+			if rerr != nil {
+				if rerr != io.EOF {
+					slog.Debug("catalog subscription ended", "error", rerr)
+				}
+				return
+			}
+			if !afterLocation(o, largest) {
+				slog.Debug("skipping catalog object already covered by fetch",
+					"groupID", o.GroupID, "objectID", o.ObjectID)
+				continue
+			}
+			if aerr := h.applyCatalog(o.Payload, "catalog update"); aerr != nil {
+				slog.Error("failed to apply catalog update", "error", aerr)
+				continue
+			}
+			slog.Info("received catalog update",
+				"groupID", o.GroupID, "objectID", o.ObjectID, "payloadLength", len(o.Payload))
+		}
+	}()
+	return nil
 }
 
 func (h *Handler) subscribeToCatalog(ctx context.Context, s *moqtransport.Session, namespace []string) error {


### PR DESCRIPTION
## Summary

Retrieve the MSF/CMSF catalog via a **relative joining FETCH** instead of a standalone SUBSCRIBE, so the subscriber gets the latest catalog group aligned with the live edge in a single round-trip.

Adds a `-catalog-mode` flag to `mlmsub` (`joining` is now the default; `subscribe` and `fetch` remain as legacy options).

## Changes

- `internal/sub`: issue a relative joining FETCH for the catalog and resolve it on receipt (`joining_test.go` added).
- `internal/pub`: resolve joining FETCH on the publisher side (`fetchrange_test.go` added).
- `cmd/mlmsub`: `-catalog-mode` flag; joining is the default path.
- Integration test covering the joining-FETCH catalog round-trip.
- deps: webtransport-go → v0.11.0 Eyevinn fork, quic-go → v0.60.0 (drops the manual WT_MAX_SESSIONS workarounds in the handlers).
- deps: require moqtransport **v0.9.0**, which adds the joining-FETCH support this feature depends on.

## Testing

- `go build` + `go test ./...` pass, including against the published moqtransport v0.9.0 (`GOWORK=off`).
- Live `mlmsub` ↔ `mlmpub`: joining-FETCH catalog retrieval and audio/video media flow verified on **draft 14 and draft 16**, producing valid muxed CMAF.

## Depends on

moqtransport **v0.9.0** (released).
