### PR TITLE
Release v0.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.12.0] - 2026-07-06
+
 Catalog retrieval now uses a relative joining FETCH, aligned to the live edge.
+LOCMAF packaging also advanced to v0.3 and moved to the external
+`Eyevinn/locmaf` module.
 
 ### Added
 
@@ -431,7 +435,8 @@ Full [MOQ Transport draft-14][moqt-d14] compliance release.
 
 - initial version of the repo
 
-[Unreleased]: https://github.com/Eyevinn/moqlivemock/releases/tag/v0.11.1...HEAD
+[Unreleased]: https://github.com/Eyevinn/moqlivemock/releases/tag/v0.12.0...HEAD
+[0.12.0]: https://github.com/Eyevinn/moqlivemock/releases/tag/v0.11.1...v0.12.0
 [0.11.1]: https://github.com/Eyevinn/moqlivemock/releases/tag/v0.11.0...v0.11.1
 [0.11.0]: https://github.com/Eyevinn/moqlivemock/releases/tag/v0.10.0...v0.11.0
 [0.10.0]: https://github.com/Eyevinn/moqlivemock/releases/tag/v0.9.0...v0.10.0

--- a/internal/version.go
+++ b/internal/version.go
@@ -8,8 +8,8 @@ import (
 )
 
 var (
-	commitVersion string = "0.11.1"     // Should be updated during build
-	commitDate    string = "1780953297" // commitDate in Epoch seconds (can be filled/updated in during build)
+	commitVersion string = "0.12.0"     // Should be updated during build
+	commitDate    string = "1783332000" // commitDate in Epoch seconds (can be filled/updated in during build)
 )
 
 // GetVersion - get version, commitHash and  commitDate depending on what is inserted


### PR DESCRIPTION
Cuts the **v0.12.0** release for moqlivemock.

The LOCMAF v0.3 (external `Eyevinn/locmaf` module) and joining-FETCH catalog work already landed on `main` (#96); this PR adds the release metadata.

- `CHANGELOG.md`: `[Unreleased]` → `## [0.12.0]`, link refs updated.
- `internal/version.go`: `commitVersion` → `0.12.0`.

Build and `internal` tests pass. (CI's `coverage/coveralls` drop is expected — the LOCMAF codec moved to the external module.)
