### PR TITLE
feat(cc608): inject CTA-608 captions in the CMAF/LOCMAF/LOC/moq-mi serve paths

### DIFF
--- a/cmd/mlmpub/main.go
+++ b/cmd/mlmpub/main.go
@@ -25,6 +25,7 @@ import (
 	"time"
 
 	"github.com/Eyevinn/moqlivemock/internal"
+	"github.com/Eyevinn/moqlivemock/internal/cc608"
 	"github.com/Eyevinn/moqlivemock/internal/pub"
 )
 
@@ -62,6 +63,7 @@ type options struct {
 	scheme           string
 	laURL            string
 	drmConfigPath    string
+	cc608            bool
 	version          bool
 }
 
@@ -92,6 +94,8 @@ func parseOptions(fs *flag.FlagSet, args []string) (*options, error) {
 	fs.StringVar(&opts.laURL, "laurl", "", "ClearKey/ECCP license acquisition URL announced in catalog."+
 		" Falls back to http://localhost:{sideport}/clearkey if not set.")
 	fs.StringVar(&opts.drmConfigPath, "drmpath", "", "path to a drm config file")
+	fs.BoolVar(&opts.cc608, "cc608", false,
+		"inject auto-generated CTA-608 CC1 captions into AVC/HEVC video")
 	fs.BoolVar(&opts.version, "version", false, fmt.Sprintf("Get %s version", appName))
 	err := fs.Parse(args[1:])
 	return &opts, err
@@ -182,6 +186,14 @@ func runServer(opts *options) error {
 		return err
 	}
 	slog.Info("added subtitle tracks", "wvtt", wvttLangs, "stpp", stppLangs)
+
+	// Enable in-band CTA-608 caption injection on video tracks when requested.
+	// A nil generator (the default) is a complete no-op; the AVC/HEVC-vs-other
+	// codec gate is applied per track at serve time.
+	if opts.cc608 {
+		asset.SetCC608Generator(cc608.New(cc608.Config{Enabled: true}))
+		slog.Info("enabled CTA-608 caption injection (CC1) on AVC/HEVC video tracks")
+	}
 
 	now := time.Now().UnixMilli()
 	var namespaces []pub.NamespaceEntry

--- a/internal/asset.go
+++ b/internal/asset.go
@@ -12,7 +12,10 @@ import (
 	"github.com/Eyevinn/mp4ff/bits"
 	"github.com/Eyevinn/mp4ff/mp4"
 
+	"github.com/Eyevinn/go-608/carriage"
 	"github.com/Eyevinn/locmaf"
+
+	"github.com/Eyevinn/moqlivemock/internal/cc608"
 )
 
 const (
@@ -65,6 +68,11 @@ type ContentTrack struct {
 	// mp4.EncryptFragment chains IVs across fragments (incremented by the number of
 	// encrypted AES blocks) so that callers using the same key avoid IV reuse.
 	currentIV []byte
+	// cc608 is the optional CTA-608 caption generator for a video track. A nil
+	// generator (the default) means captions are off; it is nil-safe, so all
+	// caption logic is a complete no-op unless SetCC608Generator installs an
+	// enabled generator. Only ever set on AVC/HEVC video tracks.
+	cc608 *cc608.Generator
 }
 
 type Asset struct {
@@ -108,6 +116,27 @@ func (a *Asset) GetSubtitleTrackByName(name string) *SubtitleTrack {
 		}
 	}
 	return nil
+}
+
+// SetCC608Generator installs gen as the CTA-608 caption generator on every
+// video content track of the asset. Audio and subtitle tracks are untouched.
+// Passing a nil or disabled generator leaves captioning off (a complete no-op);
+// the actual AVC/HEVC-vs-other codec gate is applied later at serve time via
+// cc608.CodecFor, so AV1 video tracks simply produce no captions.
+func (a *Asset) SetCC608Generator(gen *cc608.Generator) {
+	for gi := range a.Groups {
+		for ti := range a.Groups[gi].Tracks {
+			if a.Groups[gi].Tracks[ti].ContentType == "video" {
+				a.Groups[gi].Tracks[ti].cc608 = gen
+			}
+		}
+	}
+}
+
+// CC608Generator returns the track's CTA-608 caption generator, or nil when
+// captions are off. The returned *cc608.Generator is nil-safe.
+func (t *ContentTrack) CC608Generator() *cc608.Generator {
+	return t.cc608
 }
 
 // AddSubtitleTracks adds WVTT and STPP subtitle tracks for the given languages.
@@ -874,7 +903,7 @@ func calcCmafBitrate(ct *ContentTrack) (int, error) {
 	if batch == 0 || ct.SampleDur == 0 || ct.TimeScale == 0 {
 		return int(ct.SampleBitrate), nil
 	}
-	chunk, err := ct.GenCMAFChunk(0, 0, uint64(batch))
+	chunk, err := ct.GenCMAFChunk(0, 0, uint64(batch), nil)
 	if err != nil {
 		return 0, fmt.Errorf("measure CMAF chunk for %s: %w", ct.Name, err)
 	}
@@ -904,11 +933,11 @@ func calcLocmafBitrate(ct *ContentTrack) (int, error) {
 		return int(ct.SampleBitrate), nil
 	}
 	state := locmaf.NewState()
-	fullChunk, err := ct.GenLocmafChunk(0, 0, uint64(batch), state)
+	fullChunk, err := ct.GenLocmafChunk(0, 0, uint64(batch), state, nil)
 	if err != nil {
 		return 0, fmt.Errorf("measure LOCMAF full chunk for %s: %w", ct.Name, err)
 	}
-	deltaChunk, err := ct.GenLocmafChunk(1, uint64(batch), 2*uint64(batch), state)
+	deltaChunk, err := ct.GenLocmafChunk(1, uint64(batch), 2*uint64(batch), state, nil)
 	if err != nil {
 		return 0, fmt.Errorf("measure LOCMAF delta chunk for %s: %w", ct.Name, err)
 	}
@@ -972,14 +1001,27 @@ func Ptr[T any](v T) *T {
 	return &v
 }
 
+// ccSplice carries one MoQ group's CTA-608 caption schedule so createFragment
+// can splice the right SEI in front of each frame's first VCL NALU. A nil
+// *ccSplice (or one with a nil SEI slice) disables splicing entirely, keeping
+// caption injection a complete no-op. The schedule is computed once per group
+// (in GenMoQGroup) and shared by every chunk of that group; GroupStartNr is the
+// group's first sample number, so the SEI for the frame at sample sampleNr is
+// SEI[sampleNr-GroupStartNr].
+type ccSplice struct {
+	GroupStartNr uint64
+	SEI          [][]byte
+	Codec        carriage.Codec
+}
+
 // GenCMAFChunk returns a raw CMAF chunk consisting of endNr-startNr samples.
 // The number is 0-based relative to the UNIX epoch.
 // Therefore nr is translated into data for the time interval
 // [nr*d.sampleDur, (nr+1)*d.sampleDur].
 // This is calculated based on wrap-around given the loopDuration
-// of the asset.
-func (t *ContentTrack) GenCMAFChunk(chunkNr uint32, startNr, endNr uint64) ([]byte, error) {
-	f, err := t.createFragment(chunkNr, startNr, endNr)
+// of the asset. cc is the optional per-group caption schedule (nil = no captions).
+func (t *ContentTrack) GenCMAFChunk(chunkNr uint32, startNr, endNr uint64, cc *ccSplice) ([]byte, error) {
+	f, err := t.createFragment(chunkNr, startNr, endNr, cc)
 	if err != nil {
 		return nil, fmt.Errorf("unable to create fragment: %w", err)
 	}
@@ -1009,12 +1051,12 @@ func (t *ContentTrack) GenCMAFChunk(chunkNr uint32, startNr, endNr uint64) ([]by
 // `state` as the in-group reference: an empty state yields a full
 // header, subsequent calls with the same state yield delta headers.
 func (t *ContentTrack) GenLocmafChunk(chunkNr uint32, startNr, endNr uint64,
-	state *locmaf.State) ([]byte, error) {
+	state *locmaf.State, cc *ccSplice) ([]byte, error) {
 	if state == nil {
 		return nil, fmt.Errorf("locmaf state is nil")
 	}
 
-	f, err := t.createFragment(chunkNr, startNr, endNr)
+	f, err := t.createFragment(chunkNr, startNr, endNr, cc)
 	if err != nil {
 		return nil, fmt.Errorf("unable to create fragment: %w", err)
 	}
@@ -1039,8 +1081,13 @@ func (t *ContentTrack) GenLocmafChunk(chunkNr uint32, startNr, endNr uint64,
 	return obj, nil
 }
 
-// createFragment creates a fragment from the track with sequence number chunkNr, and samples from startNr to endNr
-func (t *ContentTrack) createFragment(chunkNr uint32, startNr, endNr uint64) (*mp4.Fragment, error) {
+// createFragment creates a fragment from the track with sequence number chunkNr,
+// and samples from startNr to endNr. When cc carries a per-group CTA-608 schedule
+// the matching SEI NAL is spliced in front of each frame's first VCL NALU before
+// the sample is added — and thus before any encryption in the callers — so the
+// captions ride inside the encrypted payload. A nil cc (or one whose SEI does not
+// cover the frame) leaves the sample data untouched, i.e. a complete no-op.
+func (t *ContentTrack) createFragment(chunkNr uint32, startNr, endNr uint64, cc *ccSplice) (*mp4.Fragment, error) {
 	f, err := mp4.CreateFragment(chunkNr, trackID)
 	if err != nil {
 		return nil, err
@@ -1048,6 +1095,18 @@ func (t *ContentTrack) createFragment(chunkNr uint32, startNr, endNr uint64) (*m
 	for sampleNr := startNr; sampleNr < endNr; sampleNr++ {
 		startTime, origNr := t.CalcSample(uint64(sampleNr))
 		orig := t.Samples[origNr]
+		// Splice the frame's CTA-608 SEI in when captions are enabled. The
+		// splice allocates a fresh slice, so t.Samples is never mutated.
+		data := orig.Data
+		if cc != nil && cc.SEI != nil {
+			if idx := int(sampleNr - cc.GroupStartNr); idx >= 0 && idx < len(cc.SEI) && len(cc.SEI[idx]) > 0 {
+				spliced, err := cc608.SpliceSEIBeforeVCL(orig.Data, cc.SEI[idx], cc.Codec)
+				if err != nil {
+					return nil, fmt.Errorf("cc608: splice SEI for sample %d: %w", sampleNr, err)
+				}
+				data = spliced
+			}
+		}
 		// Use the source sample's actual duration. For uniform-duration
 		// sources this equals t.SampleDur; for a source with a short
 		// trailing sample (which we no longer ship, but defensively support)
@@ -1058,10 +1117,10 @@ func (t *ContentTrack) createFragment(chunkNr uint32, startNr, endNr uint64) (*m
 			Sample: mp4.Sample{
 				Flags: orig.Flags,
 				Dur:   orig.Dur,
-				Size:  uint32(len(orig.Data)),
+				Size:  uint32(len(data)),
 			},
 			DecodeTime: startTime,
-			Data:       orig.Data,
+			Data:       data,
 		}
 		f.AddFullSample(fs)
 	}

--- a/internal/asset_test.go
+++ b/internal/asset_test.go
@@ -389,7 +389,7 @@ func TestGen20sCMAFStreams(t *testing.T) {
 			nrSamples := int(20 * tr.TimeScale / tr.SampleDur)
 			groupNr := uint32(0)
 			for nr := range nrSamples {
-				chunk, err := tr.GenCMAFChunk(groupNr, uint64(nr), uint64(nr+1))
+				chunk, err := tr.GenCMAFChunk(groupNr, uint64(nr), uint64(nr+1), nil)
 				require.NoError(t, err)
 				_, err = ofh.Write(chunk)
 				require.NoError(t, err)
@@ -533,7 +533,7 @@ func checkDecryptedTracksMatchExactly(t *testing.T, drm *DRMInfo, suffix string)
 				nrSamples := int(3 * tr.TimeScale / tr.SampleDur)
 				groupNr := uint32(0)
 				for nr := range nrSamples {
-					chunk, err := tr.GenCMAFChunk(groupNr, uint64(nr), uint64(nr+1))
+					chunk, err := tr.GenCMAFChunk(groupNr, uint64(nr), uint64(nr+1), nil)
 					if err != nil {
 						t.Fatalf("chunk generation failed for track=%s codec=%s scheme=%s encStatus=%s chunkNr=%d: %v",
 							tr.Name, tr.SpecData.Codec(), drm.ContentProtections[0].Scheme, encryptionStatus, nr, err)

--- a/internal/batch_test.go
+++ b/internal/batch_test.go
@@ -197,14 +197,14 @@ func TestGenCMAFChunkWithBatch(t *testing.T) {
 					batchSize := track.SampleBatch
 
 					// Generate a chunk with the configured batch size
-					chunk, err := track.GenCMAFChunk(0, 0, uint64(batchSize))
+					chunk, err := track.GenCMAFChunk(0, 0, uint64(batchSize), nil)
 					require.NoError(t, err)
 					require.NotNil(t, chunk)
 
 					// For video tracks with batch > 1, the chunk should be larger than a single sample chunk
 					if track.ContentType == "video" && batchSize > 1 {
 						// Generate a single sample chunk for comparison
-						singleChunk, err := track.GenCMAFChunk(0, 0, 1)
+						singleChunk, err := track.GenCMAFChunk(0, 0, 1, nil)
 						require.NoError(t, err)
 
 						// The multi-sample chunk should be larger than the single sample chunk

--- a/internal/cc608_wiring_test.go
+++ b/internal/cc608_wiring_test.go
@@ -1,0 +1,164 @@
+package internal
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/Eyevinn/go-608/carriage"
+	"github.com/Eyevinn/go-608/cta608"
+	"github.com/Eyevinn/mp4ff/avc"
+	"github.com/Eyevinn/mp4ff/mp4"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/Eyevinn/moqlivemock/internal/cc608"
+)
+
+// groupNrClock is a MoQ group number chosen so its wall-clock second is
+// 12:34:56 UTC (45296 s after midnight), giving a deterministic caption to
+// assert against: row 13 = "12:34:56.000", row 14 = "GRP 45296".
+const groupNrClock = 45296
+
+// mdatData decodes a raw CMAF chunk (moof+mdat) and returns the mdat payload,
+// which for a single-sample chunk is that sample's 4-byte-length-prefixed AVCC
+// NAL stream (with the CTA-608 SEI spliced in when captions are on).
+func mdatData(t *testing.T, chunk []byte) []byte {
+	t.Helper()
+	r := bytes.NewReader(chunk)
+	moofBox, err := mp4.DecodeBox(0, r)
+	require.NoError(t, err)
+	mdatBox, err := mp4.DecodeBox(moofBox.Size(), r)
+	require.NoError(t, err)
+	mdat, ok := mdatBox.(*mp4.MdatBox)
+	require.True(t, ok, "second box should be mdat, got %T", mdatBox)
+	return mdat.Data
+}
+
+// decodeGroupCaption feeds a whole group's per-object SEI through the cta608
+// decoder in order and returns the number of on-screen flips plus the text of
+// rows 13 and 14 at the last flip.
+func decodeGroupCaption(t *testing.T, objects []MoQObject, codec carriage.Codec) (flips int, row13, row14 string) {
+	t.Helper()
+	var dec cta608.Decoder
+	for i, obj := range objects {
+		nalus, err := avc.GetNalusFromSample(mdatData(t, obj))
+		require.NoErrorf(t, err, "object %d", i)
+		f1, _, err := carriage.FieldPairs(nalus, codec)
+		require.NoErrorf(t, err, "object %d FieldPairs", i)
+		if len(f1) == 0 {
+			continue
+		}
+		require.NoErrorf(t, dec.Feed(f1), "object %d decode", i)
+		if dec.Changed() {
+			flips++
+			row13 = rowText(dec.Screen(), 13)
+			row14 = rowText(dec.Screen(), 14)
+		}
+	}
+	return flips, row13, row14
+}
+
+// rowText concatenates the text of the decoded screen row with the given index.
+func rowText(s cta608.Screen, idx int) string {
+	for _, r := range s.Rows {
+		if r.Index != idx {
+			continue
+		}
+		var text string
+		for _, run := range r.Runs {
+			text += run.Text
+		}
+		return text
+	}
+	return ""
+}
+
+// TestGenMoQGroupCC608_CMAF verifies that with an enabled generator installed
+// via SetCC608Generator, a CMAF-packaged video group carries a decodable CTA-608
+// CC1 caption for both AVC and HEVC. It also confirms one flip per group (one
+// pop-on cue per wall-clock second).
+func TestGenMoQGroupCC608_CMAF(t *testing.T) {
+	cases := []struct {
+		name  string
+		codec carriage.Codec
+	}{
+		{"video_400kbps_avc", carriage.CodecAVC},
+		{"video_400kbps_hevc", carriage.CodecHEVC},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			asset, err := LoadAsset("../assets/test10s", 1, 1)
+			require.NoError(t, err)
+			asset.SetCC608Generator(cc608.New(cc608.Config{Enabled: true}))
+
+			ct := asset.GetTrackByName(c.name)
+			require.NotNil(t, ct)
+
+			mg, err := GenMoQGroup(ct, groupNrClock, 1, MoqGroupDurMS, "cmaf")
+			require.NoError(t, err)
+			require.Equal(t, 25, len(mg.MoQObjects), "25 fps => 25 objects in a 1s group")
+
+			flips, row13, row14 := decodeGroupCaption(t, mg.MoQObjects, c.codec)
+			assert.Equal(t, 1, flips, "one pop-on cue per group")
+			assert.Equal(t, "12:34:56.000", row13)
+			assert.Equal(t, "GRP 45296", row14)
+		})
+	}
+}
+
+// TestGenMoQGroupCC608_NoOp proves that a nil or disabled generator is a
+// complete no-op: the produced bytes are identical to captions-off, and no SEI
+// is present. It also confirms AV1 video is skipped even with captions enabled.
+func TestGenMoQGroupCC608_NoOp(t *testing.T) {
+	load := func(t *testing.T) *Asset {
+		t.Helper()
+		a, err := LoadAsset("../assets/test10s", 1, 1)
+		require.NoError(t, err)
+		return a
+	}
+
+	genGroup := func(t *testing.T, a *Asset, name string) []MoQObject {
+		t.Helper()
+		ct := a.GetTrackByName(name)
+		require.NotNil(t, ct)
+		mg, err := GenMoQGroup(ct, groupNrClock, 1, MoqGroupDurMS, "cmaf")
+		require.NoError(t, err)
+		return mg.MoQObjects
+	}
+
+	equalObjects := func(t *testing.T, want, got []MoQObject) {
+		t.Helper()
+		require.Equal(t, len(want), len(got))
+		for i := range want {
+			assert.Truef(t, bytes.Equal(want[i], got[i]), "object %d differs", i)
+		}
+	}
+
+	// Baseline: no generator installed at all.
+	off := genGroup(t, load(t), "video_400kbps_avc")
+
+	// Disabled generator must be byte-identical to captions-off.
+	disabledAsset := load(t)
+	disabledAsset.SetCC608Generator(cc608.New(cc608.Config{Enabled: false}))
+	equalObjects(t, off, genGroup(t, disabledAsset, "video_400kbps_avc"))
+
+	// Enabled generator must change the AVC bytes (SEI added).
+	onAsset := load(t)
+	onAsset.SetCC608Generator(cc608.New(cc608.Config{Enabled: true}))
+	on := genGroup(t, onAsset, "video_400kbps_avc")
+	require.Equal(t, len(off), len(on))
+	differs := false
+	for i := range off {
+		if !bytes.Equal(off[i], on[i]) {
+			differs = true
+			break
+		}
+	}
+	assert.True(t, differs, "enabled generator should add SEI to AVC video")
+
+	// AV1 must be skipped (unsupported codec) even with captions enabled.
+	av1Off := genGroup(t, load(t), "video_400kbps_av1")
+	av1AssetOn := load(t)
+	av1AssetOn.SetCC608Generator(cc608.New(cc608.Config{Enabled: true}))
+	equalObjects(t, av1Off, genGroup(t, av1AssetOn, "video_400kbps_av1"))
+}

--- a/internal/locmaf_equiv_test.go
+++ b/internal/locmaf_equiv_test.go
@@ -54,7 +54,7 @@ func runIntegrationTrack(t *testing.T, ct *ContentTrack) {
 		if end > uint64(len(ct.Samples)) {
 			return
 		}
-		_, err := ct.GenLocmafChunk(chunkNr, start, end, state)
+		_, err := ct.GenLocmafChunk(chunkNr, start, end, state, nil)
 		require.NoError(t, err)
 	}
 
@@ -68,7 +68,7 @@ func runIntegrationTrack(t *testing.T, ct *ContentTrack) {
 		if end > uint64(len(ct.Samples)) {
 			return
 		}
-		srcFrag, err := ct.createFragment(chunkNr, start, end)
+		srcFrag, err := ct.createFragment(chunkNr, start, end, nil)
 		require.NoError(t, err)
 
 		obj, err := locmaf.EncodeCanonical(nil, srcFrag.Moof, srcFrag.Mdat.Data, encState, moovOf(ct))
@@ -145,7 +145,7 @@ func TestLocmafEncryptedSencRoundTrip(t *testing.T) {
 				// Build the encrypted source fragment exactly like
 				// GenLocmafChunk does internally (createFragment +
 				// encryptFragment).
-				srcFrag, err := ct.createFragment(chunkNr, start, end)
+				srcFrag, err := ct.createFragment(chunkNr, start, end, nil)
 				require.NoError(t, err)
 				encFrag, err := encryptViaTrack(ct, srcFrag)
 				require.NoError(t, err)

--- a/internal/moqgroup.go
+++ b/internal/moqgroup.go
@@ -6,6 +6,8 @@ import (
 	"time"
 
 	"github.com/Eyevinn/locmaf"
+
+	"github.com/Eyevinn/moqlivemock/internal/cc608"
 )
 
 type ObjectWriter func(objectID uint64, data []byte) (n int, err error)
@@ -42,13 +44,18 @@ func GenMoQGroup(track *ContentTrack, groupNr uint64, sampleBatch int,
 		endNr:      endNr,
 		MoQObjects: make([]MoQObject, 0, endNr-startNr),
 	}
+	// Build the group's CTA-608 caption schedule once (per group, not per
+	// chunk) and share it across every chunk of the group. cc stays nil for a
+	// disabled/absent generator, a non-video track, or a non-AVC/HEVC codec, in
+	// which case createFragment does no splicing at all.
+	cc := track.newGroupCCSplice(groupNr, startNr, endNr)
 	v02State := locmaf.NewState()
 	for i := startNr; i < endNr; i += uint64(sampleBatch) {
 		firstSample := i
 		endSample := min(i+uint64(sampleBatch), endNr)
 		switch packaging {
 		case "cmaf":
-			chunk, err := track.GenCMAFChunk(uint32(groupNr), firstSample, endSample)
+			chunk, err := track.GenCMAFChunk(uint32(groupNr), firstSample, endSample, cc)
 			if err != nil {
 				return nil, fmt.Errorf("failed to generate CMAF chunk for group %d, samples %d-%d: %w",
 					groupNr, firstSample, endSample, err)
@@ -57,7 +64,7 @@ func GenMoQGroup(track *ContentTrack, groupNr uint64, sampleBatch int,
 			mq.MoQObjects = append(mq.MoQObjects, chunk)
 		case "locmaf":
 			// "locmaf" packaging is LOCMAF (versioned by locmafVersion).
-			chunk, err := track.GenLocmafChunk(uint32(groupNr), firstSample, endSample, v02State)
+			chunk, err := track.GenLocmafChunk(uint32(groupNr), firstSample, endSample, v02State, cc)
 			if err != nil {
 				return nil, fmt.Errorf("failed to generate locmaf chunk for group %d, samples %d-%d: %w",
 					groupNr, firstSample, endSample, err)
@@ -66,6 +73,27 @@ func GenMoQGroup(track *ContentTrack, groupNr uint64, sampleBatch int,
 		}
 	}
 	return mq, nil
+}
+
+// newGroupCCSplice builds the CTA-608 caption schedule for one MoQ group of the
+// track, covering samples [startNr,endNr). It returns nil (no splicing) unless
+// the track has an enabled caption generator, is an AVC/HEVC video track, and
+// go-608 can build the group. A MoQ group is one wall-clock second, so groupNr
+// is the caption clock anchor in whole seconds (matching cc608.DefaultContent).
+func (t *ContentTrack) newGroupCCSplice(groupNr, startNr, endNr uint64) *ccSplice {
+	if !t.cc608.Enabled() || t.ContentType != "video" || t.SampleDur == 0 || endNr <= startNr {
+		return nil
+	}
+	codec, ok := cc608.CodecFor(t.SpecData.Codec())
+	if !ok {
+		return nil // AV1 and any non-AVC/HEVC codec: no captions.
+	}
+	fps := float64(t.TimeScale) / float64(t.SampleDur)
+	sei := t.cc608.SEISchedule(int64(groupNr), fps, int(endNr-startNr), codec)
+	if sei == nil {
+		return nil
+	}
+	return &ccSplice{GroupStartNr: startNr, SEI: sei, Codec: codec}
 }
 
 // CalcLOCGroupRange returns the [startNr, endNr) sample range for the

--- a/internal/pub/caption.go
+++ b/internal/pub/caption.go
@@ -1,0 +1,83 @@
+package pub
+
+import (
+	"log/slog"
+
+	"github.com/Eyevinn/go-608/carriage"
+
+	"github.com/Eyevinn/moqlivemock/internal"
+	"github.com/Eyevinn/moqlivemock/internal/cc608"
+)
+
+// videoCaptioner injects auto-generated CTA-608 captions into the raw-frame
+// serve paths (LOC and moq-mi), where the publisher hands one coded frame per
+// MoQ object. It computes a per-group SEI schedule and splices the matching SEI
+// in front of each frame's first VCL NALU.
+//
+// The zero value — and a captioner built from a track with captions off, a
+// non-video role, or a non-AVC/HEVC codec — is disabled: schedule returns nil
+// and spliceFrame returns the frame unchanged, so caption injection is a
+// complete no-op. (The CMAF/LOCMAF path does its own, equivalent splicing inside
+// internal.createFragment; this helper only serves the LOC and moq-mi loops.)
+type videoCaptioner struct {
+	gen   *cc608.Generator
+	codec carriage.Codec
+	fps   float64
+	on    bool
+}
+
+// newVideoCaptioner builds a captioner for ct. It is enabled only when ct has an
+// enabled generator, is a video track with valid timing, and uses an AVC or HEVC
+// codec (AV1 and everything else yield a disabled captioner).
+func newVideoCaptioner(ct *internal.ContentTrack) videoCaptioner {
+	gen := ct.CC608Generator()
+	if !gen.Enabled() || ct.ContentType != "video" || ct.SampleDur == 0 || ct.TimeScale == 0 {
+		return videoCaptioner{}
+	}
+	codec, ok := cc608.CodecFor(ct.SpecData.Codec())
+	if !ok {
+		return videoCaptioner{}
+	}
+	return videoCaptioner{
+		gen:   gen,
+		codec: codec,
+		fps:   float64(ct.TimeScale) / float64(ct.SampleDur),
+		on:    true,
+	}
+}
+
+// schedule returns one SEI NAL per frame for the group covering samples
+// [startNr,endNr), whose captions are anchored at anchorSec (whole UNIX seconds,
+// matching cc608.DefaultContent's clock). It returns nil when captions are off,
+// the range is empty, or go-608 cannot build the group — in which case the
+// caller simply skips splicing.
+func (c videoCaptioner) schedule(anchorSec int64, startNr, endNr uint64) [][]byte {
+	if !c.on || endNr <= startNr {
+		return nil
+	}
+	return c.gen.SEISchedule(anchorSec, c.fps, int(endNr-startNr), c.codec)
+}
+
+// spliceFrame returns data with the group's SEI for the frame at sampleNr
+// spliced in front of its first VCL NALU. sei is the whole-group schedule from
+// schedule and groupStartNr is the group's first sample number, so the frame's
+// SEI is sei[sampleNr-groupStartNr]. It returns data unchanged when sei is nil
+// (captions off) or the frame index is out of range; on a splice error it logs
+// and returns the original data so captioning is strictly best-effort and never
+// drops a frame.
+func (c videoCaptioner) spliceFrame(data []byte, sei [][]byte, sampleNr, groupStartNr uint64) []byte {
+	if sei == nil {
+		return data
+	}
+	idx := int(sampleNr - groupStartNr)
+	if idx < 0 || idx >= len(sei) || len(sei[idx]) == 0 {
+		return data
+	}
+	spliced, err := cc608.SpliceSEIBeforeVCL(data, sei[idx], c.codec)
+	if err != nil {
+		slog.Warn("cc608: SEI splice failed, sending frame without captions",
+			"error", err, "sample", sampleNr)
+		return data
+	}
+	return spliced
+}

--- a/internal/pub/caption_test.go
+++ b/internal/pub/caption_test.go
@@ -1,0 +1,168 @@
+package pub
+
+import (
+	"testing"
+
+	"github.com/Eyevinn/go-608/carriage"
+	"github.com/Eyevinn/go-608/cta608"
+	"github.com/Eyevinn/mp4ff/avc"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/Eyevinn/moqlivemock/internal"
+	"github.com/Eyevinn/moqlivemock/internal/cc608"
+)
+
+// groupNrClock is a group number whose wall-clock second is 12:34:56 UTC. The
+// test assets are 25 fps with a 1 s GOP, so for every raw-frame path the caption
+// clock anchor equals the group number, giving a deterministic caption to
+// assert: row 13 = "12:34:56.000", row 14 = "GRP 45296".
+const groupNrClock = 45296
+
+// rowText concatenates the text of the decoded screen row with the given index.
+func rowText(s cta608.Screen, idx int) string {
+	for _, r := range s.Rows {
+		if r.Index != idx {
+			continue
+		}
+		var text string
+		for _, run := range r.Runs {
+			text += run.Text
+		}
+		return text
+	}
+	return ""
+}
+
+// captionedVideoTrack loads test10s, enables captions, and returns the named
+// video track (a copy that carries the installed generator).
+func captionedVideoTrack(t *testing.T, name string) *internal.ContentTrack {
+	t.Helper()
+	asset, err := internal.LoadAsset("../../assets/test10s", 1, 1)
+	require.NoError(t, err)
+	asset.SetCC608Generator(cc608.New(cc608.Config{Enabled: true}))
+	ct := asset.GetTrackByName(name)
+	require.NotNil(t, ct)
+	return ct
+}
+
+// decodeFrames feeds a sequence of per-frame AVCC sample datas through the
+// cta608 decoder and returns the flip count and the last-flip row 13/14 text.
+func decodeFrames(t *testing.T, frames [][]byte, codec carriage.Codec) (flips int, row13, row14 string) {
+	t.Helper()
+	var dec cta608.Decoder
+	for i, data := range frames {
+		nalus, err := avc.GetNalusFromSample(data)
+		require.NoErrorf(t, err, "frame %d", i)
+		f1, _, err := carriage.FieldPairs(nalus, codec)
+		require.NoErrorf(t, err, "frame %d FieldPairs", i)
+		if len(f1) == 0 {
+			continue
+		}
+		require.NoErrorf(t, dec.Feed(f1), "frame %d decode", i)
+		if dec.Changed() {
+			flips++
+			row13 = rowText(dec.Screen(), 13)
+			row14 = rowText(dec.Screen(), 14)
+		}
+	}
+	return flips, row13, row14
+}
+
+// TestVideoCaptioner_LOC mirrors PublishLOCTrack's grouping and splicing exactly
+// (same CalcLOCGroupRange range, same per-frame spliceFrame indexing) and proves
+// the produced frames carry a decodable CC1 caption for both AVC and HEVC.
+func TestVideoCaptioner_LOC(t *testing.T) {
+	cases := []struct {
+		name  string
+		codec carriage.Codec
+	}{
+		{"video_400kbps_avc", carriage.CodecAVC},
+		{"video_400kbps_hevc", carriage.CodecHEVC},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			ct := captionedVideoTrack(t, c.name)
+			cap := newVideoCaptioner(ct)
+			require.True(t, cap.on, "captioner should be enabled for AVC/HEVC")
+			require.Equal(t, c.codec, cap.codec)
+
+			startNr, endNr := internal.CalcLOCGroupRange(ct, groupNrClock, internal.MoqGroupDurMS)
+			require.Equal(t, uint64(25), endNr-startNr)
+			sei := cap.schedule(int64(groupNrClock), startNr, endNr)
+			require.NotNil(t, sei)
+			require.Len(t, sei, 25)
+
+			var frames [][]byte
+			for sampleNr := startNr; sampleNr < endNr; sampleNr++ {
+				_, origNr := ct.CalcSample(sampleNr)
+				frames = append(frames, cap.spliceFrame(ct.Samples[origNr].Data, sei, sampleNr, startNr))
+			}
+			flips, row13, row14 := decodeFrames(t, frames, c.codec)
+			assert.Equal(t, 1, flips, "one pop-on cue per group")
+			assert.Equal(t, "12:34:56.000", row13)
+			assert.Equal(t, "GRP 45296", row14)
+		})
+	}
+}
+
+// TestVideoCaptioner_MoqMI mirrors publishMoqMIVideo's GOP grouping and anchor
+// (anchorSec = startSample*sampleDur/timebase) for the AVC video0 track and
+// proves the produced frames carry a decodable CC1 caption.
+func TestVideoCaptioner_MoqMI(t *testing.T) {
+	ct := captionedVideoTrack(t, "video_400kbps_avc")
+	cap := newVideoCaptioner(ct)
+	require.True(t, cap.on)
+
+	gopLen := uint64(ct.GopLength)
+	require.NotZero(t, gopLen)
+	timebase := uint64(ct.TimeScale)
+	sampleDur := uint64(ct.SampleDur)
+
+	startSample := uint64(groupNrClock) * gopLen
+	endSample := startSample + gopLen
+	anchorSec := int64(startSample * sampleDur / timebase)
+	require.Equal(t, int64(groupNrClock), anchorSec, "1s GOP => anchor second == group number")
+
+	sei := cap.schedule(anchorSec, startSample, endSample)
+	require.NotNil(t, sei)
+	require.Len(t, sei, int(gopLen))
+
+	var frames [][]byte
+	for sampleNr := startSample; sampleNr < endSample; sampleNr++ {
+		_, origNr := ct.CalcSample(sampleNr)
+		frames = append(frames, cap.spliceFrame(ct.Samples[origNr].Data, sei, sampleNr, startSample))
+	}
+	flips, row13, row14 := decodeFrames(t, frames, carriage.CodecAVC)
+	assert.Equal(t, 1, flips)
+	assert.Equal(t, "12:34:56.000", row13)
+	assert.Equal(t, "GRP 45296", row14)
+}
+
+// TestVideoCaptioner_Disabled proves the captioner is a complete no-op when
+// captions are off, on a non-video track, or on an unsupported codec (AV1):
+// schedule returns nil and spliceFrame returns the frame unchanged.
+func TestVideoCaptioner_Disabled(t *testing.T) {
+	asset, err := internal.LoadAsset("../../assets/test10s", 1, 1)
+	require.NoError(t, err)
+
+	// No generator installed at all.
+	ct := asset.GetTrackByName("video_400kbps_avc")
+	require.NotNil(t, ct)
+	cap := newVideoCaptioner(ct)
+	assert.False(t, cap.on)
+	assert.Nil(t, cap.schedule(groupNrClock, 0, 25))
+	orig := ct.Samples[0].Data
+	assert.Equal(t, orig, cap.spliceFrame(orig, nil, 0, 0))
+
+	// Generator enabled, but AV1 is an unsupported caption codec.
+	asset.SetCC608Generator(cc608.New(cc608.Config{Enabled: true}))
+	av1 := asset.GetTrackByName("video_400kbps_av1")
+	require.NotNil(t, av1)
+	assert.False(t, newVideoCaptioner(av1).on, "AV1 must not be captioned")
+
+	// Generator enabled, but audio is not a video track.
+	aud := asset.GetTrackByName("audio_monotonic_128kbps_aac")
+	require.NotNil(t, aud)
+	assert.False(t, newVideoCaptioner(aud).on, "audio must not be captioned")
+}

--- a/internal/pub/moqmi.go
+++ b/internal/pub/moqmi.go
@@ -73,6 +73,10 @@ func publishMoqMIVideo(ctx context.Context, publisher moqtransport.Publisher,
 	currGopNr := uint64(now) / gopDurMS
 	groupNr := currGopNr + 1
 
+	// Optional CTA-608 caption injection (no-op unless -cc608 installed an
+	// enabled generator; moq-mi video0 is AVC, which the captioner supports).
+	captioner := newVideoCaptioner(ct)
+
 	slog.Info("moqmi: publishing video track",
 		"track", moqmiTrackName, "startGroup", groupNr, "gopLen", gopLen)
 
@@ -88,12 +92,18 @@ func publishMoqMIVideo(ctx context.Context, publisher moqtransport.Publisher,
 		}
 		startSample := groupNr * gopLen
 		endSample := startSample + gopLen
+		// A moq-mi video group is one GOP. Anchor the caption clock at the
+		// group's wall-clock start second (samples are epoch-anchored, so
+		// startSample*sampleDur/timebase is that second). sei is nil when off.
+		anchorSec := int64(startSample * sampleDur / timebase)
+		sei := captioner.schedule(anchorSec, startSample, endSample)
 		for objectID, sampleNr := uint64(0), startSample; sampleNr < endSample; objectID, sampleNr = objectID+1, sampleNr+1 {
 			if ctx.Err() != nil {
 				return
 			}
 			_, origNr := ct.CalcSample(sampleNr)
 			sample := ct.Samples[origNr]
+			data := captioner.spliceFrame(sample.Data, sei, sampleNr, startSample)
 			pts := sampleNr * sampleDur
 			ptsMS := int64(pts * 1000 / timebase)
 			waitMS := ptsMS - time.Now().UnixMilli()
@@ -118,7 +128,7 @@ func publishMoqMIVideo(ctx context.Context, publisher moqtransport.Publisher,
 			} else {
 				headers = moqmi.VideoHeaders(meta, nil)
 			}
-			if _, err := sg.WriteObjectWithHeaders(objectID, headers, sample.Data); err != nil {
+			if _, err := sg.WriteObjectWithHeaders(objectID, headers, data); err != nil {
 				slog.Error("moqmi: failed to write video object",
 					"group", groupNr, "object", objectID, "error", err)
 				return

--- a/internal/pub/pub.go
+++ b/internal/pub/pub.go
@@ -401,6 +401,10 @@ func PublishLOCTrack(ctx context.Context, publisher moqtransport.Publisher, asse
 		videoConfig = sd.GenLOCVideoConfig()
 	}
 
+	// Optional CTA-608 caption injection (no-op unless -cc608 installed an
+	// enabled generator on this AVC/HEVC video track).
+	captioner := newVideoCaptioner(ct)
+
 	now := time.Now().UnixMilli()
 	currGroupNr := internal.CurrMoQGroupNr(ct, uint64(now), internal.MoqGroupDurMS)
 	groupNr := currGroupNr + 1 // Start stream on next group
@@ -415,6 +419,9 @@ func PublishLOCTrack(ctx context.Context, publisher moqtransport.Publisher, asse
 			return
 		}
 		startNr, endNr := internal.CalcLOCGroupRange(ct, groupNr, internal.MoqGroupDurMS)
+		// A LOC group is one wall-clock second, so groupNr is the caption clock
+		// anchor in whole seconds. sei is nil (no splicing) when captions are off.
+		sei := captioner.schedule(int64(groupNr), startNr, endNr)
 		slog.Info("writing LOC group", "track", ct.Name, "group", groupNr, "objects", endNr-startNr)
 		objectID := uint64(0)
 		for sampleNr := startNr; sampleNr < endNr; sampleNr++ {
@@ -424,6 +431,9 @@ func PublishLOCTrack(ctx context.Context, publisher moqtransport.Publisher, asse
 			}
 			_, origNr := ct.CalcSample(sampleNr)
 			sample := ct.Samples[origNr]
+			// Splice the frame's CTA-608 SEI before the (optional) videoConfig
+			// prepend, so parameter sets precede the SEI which precedes the VCL.
+			data := captioner.spliceFrame(sample.Data, sei, sampleNr, startNr)
 
 			sampleTime := sampleNr * sampleDur
 			objTimeMS := int64(sampleTime * 1000 / timebase)
@@ -439,11 +449,11 @@ func PublishLOCTrack(ctx context.Context, publisher moqtransport.Publisher, asse
 
 			var payload []byte
 			if videoConfig != nil && sample.IsSync() {
-				payload = make([]byte, 0, len(videoConfig)+len(sample.Data))
+				payload = make([]byte, 0, len(videoConfig)+len(data))
 				payload = append(payload, videoConfig...)
-				payload = append(payload, sample.Data...)
+				payload = append(payload, data...)
 			} else {
-				payload = sample.Data
+				payload = data
 			}
 
 			// Compute sampleTime * 1_000_000 / timebase without uint64 overflow.

--- a/internal/sub/sub_test.go
+++ b/internal/sub/sub_test.go
@@ -103,7 +103,7 @@ func TestDecompressLocmafObjectRoundTrip(t *testing.T) {
 			require.NotNil(t, track)
 
 			state := locmaf.NewState()
-			compressed, err := track.GenLocmafChunk(0, 0, 1, state)
+			compressed, err := track.GenLocmafChunk(0, 0, 1, state, nil)
 			require.NoError(t, err)
 
 			rxState := locmaf.NewState()
@@ -113,7 +113,7 @@ func TestDecompressLocmafObjectRoundTrip(t *testing.T) {
 
 			gotMoof, gotMdat := decodeFragment(t, got)
 
-			expected, err := track.GenCMAFChunk(0, 0, 1)
+			expected, err := track.GenCMAFChunk(0, 0, 1, nil)
 			require.NoError(t, err)
 			expectedMoof, expectedMdat := decodeFragment(t, expected)
 
@@ -187,7 +187,7 @@ func TestDecompressLocmafClearKeyRoundTrip(t *testing.T) {
 					require.NoError(t, err)
 
 					state := locmaf.NewState()
-					compressed, err := protectedTrack.GenLocmafChunk(0, 0, 1, state)
+					compressed, err := protectedTrack.GenLocmafChunk(0, 0, 1, state, nil)
 					require.NoError(t, err)
 
 					rxState := locmaf.NewState()
@@ -207,7 +207,7 @@ func TestDecompressLocmafClearKeyRoundTrip(t *testing.T) {
 					got, err = internal.DecryptFragment(got, decryptInfo, key)
 					require.NoError(t, err)
 
-					expected, err := clearTrack.GenCMAFChunk(0, 0, 1)
+					expected, err := clearTrack.GenCMAFChunk(0, 0, 1, nil)
 					require.NoError(t, err)
 					_, expectedMdat := decodeFragment(t, expected)
 					_, decryptedMdat := decodeFragment(t, got)


### PR DESCRIPTION
## What

Wires the `internal/cc608` generator (added in #114) into mlmpub behind a new **`-cc608`** flag (boolean, default off, global). When enabled, mlmpub injects in-band **CTA-608 CC1** captions into the AVC/HEVC video of **every** packaging that carries it — CMAF and LOCMAF (`cmsf/*`, including the DRM/ECCP encrypted namespaces), LOC (`msf/clear`), and moq-mi (`video0`, AVC-only). Two centered pop-on lines per MoQ group: **row 13 (white)** UTC `HH:MM:SS.mmm`, **row 14 (yellow)** `GRP <groupNr>`.

## How

- **Flag** (`cmd/mlmpub/main.go`): `-cc608` → `asset.SetCC608Generator(cc608.New(cc608.Config{Enabled:true}))` installs the generator on video tracks; a nil generator (the default) is off.
- **CMAF + LOCMAF**: `GenMoQGroup` builds the per-group SEI schedule once and threads a `*ccSplice{GroupStartNr, SEI, Codec}` through `GenCMAFChunk`/`GenLocmafChunk` → `createFragment`, which splices `SEI[sampleNr-GroupStartNr]` into each sample's `Data` **before `AddFullSample`** — i.e. before `encryptFragment`, so DRM/ECCP get captions pre-encryption. mp4ff recomputes trun/mdat sizes (no manual fixups).
- **LOC + moq-mi**: a shared `videoCaptioner` helper (`internal/pub/caption.go`) computes the per-group schedule and splices before payload assembly (LOC: ahead of the videoConfig prepend, so SPS/PPS → SEI → VCL; moq-mi: before `WriteObjectWithHeaders`).
- **Off = a complete no-op**: a nil/disabled generator, non-video tracks, and non-AVC/HEVC codecs (AV1) splice nothing; `SpliceSEIBeforeVCL` allocates a fresh slice, so source samples are never mutated. A test asserts disabled output is byte-identical to captions-off.
- **Clock anchor**: CMAF/LOC use `groupNr` (a group is one wall-clock second); moq-mi derives the anchor second from sample PTS, so it stays correct for non-1 s GOPs.

## Scope

Injection + the flag only. The catalog `accessibility` descriptor (advertising the captions) is a follow-up (#113). Part of #72 (CEA-608/708 support); builds on #114.

## Testing

Decode-round-trip tests (via go-608 `carriage.FieldPairs`) for **CMAF AVC+HEVC**, **LOC AVC+HEVC**, and **moq-mi AVC**, plus no-op and AV1-skip proofs; captions decode to `HH:MM:SS.mmm` / `GRP <n>` with exactly one pop-on flip per group. `go build ./...`, `go vet`, `gofmt -l`, `golangci-lint run` (0 issues), and the full `go test ./...` all green.
