### PR TITLE
feat(cc608): advertise CTA-608 in catalogs + decode-round-trip verification

### DIFF
--- a/internal/asset.go
+++ b/internal/asset.go
@@ -640,11 +640,14 @@ func (a *Asset) GenCMAFCatalogEntry(namespace string, prot ProtectionType,
 				base.Role = "video"
 				base.Framerate = Ptr(frameRate)
 				// Advertise CTA-608 captions only when an enabled generator is
-				// installed for this track (i.e. -cc608 was set), so the catalog
+				// installed for this track (i.e. -cc608 was set) AND the codec
+				// actually carries the SEI (AVC/HEVC) — never AV1 — so the catalog
 				// never claims captions that are not in the elementary stream.
+				// This mirrors the injection gate in newGroupCCSplice exactly, so
+				// the catalog advertises captions iff they are really injected.
 				// The value is copied into both the CMAF and LOCMAF variants
 				// below, which is correct: the SEI rides in the shared bitstream.
-				if ct.CC608Generator().Enabled() {
+				if _, ok := cc608.CodecFor(ct.SpecData.Codec()); ok && ct.CC608Generator().Enabled() {
 					base.Accessibility = cta608CC1Eng
 				}
 				switch sd := ct.SpecData.(type) {
@@ -846,9 +849,11 @@ func (a *Asset) GenLOCCatalogEntry(generatedAtMS int64) (*Catalog, error) {
 				track.Role = "video"
 				track.Framerate = Ptr(frameRate)
 				// Advertise CTA-608 captions only when an enabled generator is
-				// installed for this track (i.e. -cc608 was set), so the catalog
+				// installed for this track (i.e. -cc608 was set) AND the codec
+				// actually carries the SEI (AVC/HEVC) — never AV1 — so the catalog
 				// never claims captions that are not in the elementary stream.
-				if ct.CC608Generator().Enabled() {
+				// Mirrors the injection gate in newGroupCCSplice.
+				if _, ok := cc608.CodecFor(ct.SpecData.Codec()); ok && ct.CC608Generator().Enabled() {
 					track.Accessibility = cta608CC1Eng
 				}
 				switch sd := ct.SpecData.(type) {

--- a/internal/asset.go
+++ b/internal/asset.go
@@ -129,7 +129,7 @@ func (a *Asset) GetSubtitleTrackByName(name string) *SubtitleTrack {
 // video content track of the asset. Audio and subtitle tracks are untouched.
 // Passing a nil or disabled generator leaves captioning off (a complete no-op);
 // the actual AVC/HEVC-vs-other codec gate is applied later at serve time via
-// cc608.CodecFor, so AV1 video tracks simply produce no captions.
+// cc608.CodecFor, so AV1 video tracks do not get captions yet.
 func (a *Asset) SetCC608Generator(gen *cc608.Generator) {
 	for gi := range a.Groups {
 		for ti := range a.Groups[gi].Tracks {
@@ -641,7 +641,7 @@ func (a *Asset) GenCMAFCatalogEntry(namespace string, prot ProtectionType,
 				base.Framerate = Ptr(frameRate)
 				// Advertise CTA-608 captions only when an enabled generator is
 				// installed for this track (i.e. -cc608 was set) AND the codec
-				// actually carries the SEI (AVC/HEVC) — never AV1 — so the catalog
+				// actually carries the SEI (AVC/HEVC) — not yet AV1 — so the catalog
 				// never claims captions that are not in the elementary stream.
 				// This mirrors the injection gate in newGroupCCSplice exactly, so
 				// the catalog advertises captions iff they are really injected.
@@ -850,7 +850,7 @@ func (a *Asset) GenLOCCatalogEntry(generatedAtMS int64) (*Catalog, error) {
 				track.Framerate = Ptr(frameRate)
 				// Advertise CTA-608 captions only when an enabled generator is
 				// installed for this track (i.e. -cc608 was set) AND the codec
-				// actually carries the SEI (AVC/HEVC) — never AV1 — so the catalog
+				// actually carries the SEI (AVC/HEVC) — not yet AV1 — so the catalog
 				// never claims captions that are not in the elementary stream.
 				// Mirrors the injection gate in newGroupCCSplice.
 				if _, ok := cc608.CodecFor(ct.SpecData.Codec()); ok && ct.CC608Generator().Enabled() {

--- a/internal/asset.go
+++ b/internal/asset.go
@@ -46,6 +46,13 @@ const (
 	ProtectionECCP                // ClearKey / ECCP (explicit key over HTTP)
 )
 
+// cta608CC1Eng is the catalog accessibility descriptor advertised on a video
+// track when in-band CTA-608 captions are enabled for it. It signals a single
+// CEA-608 service, CC1, in English, using the SCTE DASH accessibility scheme
+// (draft-ietf-moq-msf-01 Section 5.2.44). It is shared by both the CMAF and
+// LOCMAF variants of a captioned rendition; treat it as read-only.
+var cta608CC1Eng = []Accessibility{{Scheme: "urn:scte:dash:cc:cea-608:2015", Value: "CC1=eng"}}
+
 type ContentTrack struct {
 	Name                    string
 	ContentType             string
@@ -632,6 +639,14 @@ func (a *Asset) GenCMAFCatalogEntry(namespace string, prot ProtectionType,
 			case "video":
 				base.Role = "video"
 				base.Framerate = Ptr(frameRate)
+				// Advertise CTA-608 captions only when an enabled generator is
+				// installed for this track (i.e. -cc608 was set), so the catalog
+				// never claims captions that are not in the elementary stream.
+				// The value is copied into both the CMAF and LOCMAF variants
+				// below, which is correct: the SEI rides in the shared bitstream.
+				if ct.CC608Generator().Enabled() {
+					base.Accessibility = cta608CC1Eng
+				}
 				switch sd := ct.SpecData.(type) {
 				case *AVCData:
 					if sd.width != 0 {
@@ -830,6 +845,12 @@ func (a *Asset) GenLOCCatalogEntry(generatedAtMS int64) (*Catalog, error) {
 			case "video":
 				track.Role = "video"
 				track.Framerate = Ptr(frameRate)
+				// Advertise CTA-608 captions only when an enabled generator is
+				// installed for this track (i.e. -cc608 was set), so the catalog
+				// never claims captions that are not in the elementary stream.
+				if ct.CC608Generator().Enabled() {
+					track.Accessibility = cta608CC1Eng
+				}
 				switch sd := ct.SpecData.(type) {
 				case *AVCData:
 					if sd.width != 0 {

--- a/internal/catalog.go
+++ b/internal/catalog.go
@@ -248,6 +248,19 @@ type Track struct {
 	// The ID is used as a key in the root-level field ContentProtection.
 	// Optional field at the track level, only used when the track is protected.
 	ContentProtectionRefIDs []string `json:"contentProtectionRefIDs,omitempty"`
+
+	// Accessibility describes accessibility features carried by the track as an
+	// array of {scheme, value} descriptors (draft-ietf-moq-msf-01 Section 5.2.44).
+	// Optional field at the track level; omitted when the track carries no such
+	// features. moqlivemock uses it to advertise in-band CTA-608 captions.
+	Accessibility []Accessibility `json:"accessibility,omitempty"`
+}
+
+// Accessibility is a single accessibility descriptor at the track level
+// (draft-ietf-moq-msf-01 Section 5.2.44): a scheme identifier and its value.
+type Accessibility struct {
+	Scheme string `json:"scheme"`
+	Value  string `json:"value"`
 }
 
 // ContentProtection contains all information needed to create DRM request

--- a/internal/cc608/cc608.go
+++ b/internal/cc608/cc608.go
@@ -145,8 +145,9 @@ func DefaultContent(_ int, cueStartMS int64) generate.UnitCue {
 
 // CodecFor maps a representation codec string to the go-608 carriage codec:
 // "avc*" -> CodecAVC, "hev*"/"hvc*" -> CodecHEVC. It returns ok=false for any
-// other codec (AV1, audio, unknown) — captions are only defined for AVC/HEVC.
-// The returned Codec is meaningless when ok is false; always check ok.
+// other codec (AV1, audio, unknown): CTA-608 SEI carriage is wired for AVC/HEVC
+// today, and AV1 is not yet supported. The returned Codec is meaningless when
+// ok is false; always check ok.
 func CodecFor(codecStr string) (carriage.Codec, bool) {
 	switch {
 	case strings.HasPrefix(codecStr, "avc"):

--- a/internal/cc608_catalog_test.go
+++ b/internal/cc608_catalog_test.go
@@ -1,0 +1,112 @@
+package internal
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/Eyevinn/moqlivemock/internal/cc608"
+)
+
+// requireCC608Accessibility asserts that tr advertises exactly one CTA-608
+// accessibility descriptor: the SCTE DASH CEA-608 scheme with the CC1/English
+// value. It is the wire-visible contract of the -cc608 feature at the catalog
+// level (draft-ietf-moq-msf-01 Section 5.2.44).
+func requireCC608Accessibility(t *testing.T, tr *Track) {
+	t.Helper()
+	require.Lenf(t, tr.Accessibility, 1, "track %q accessibility count", tr.Name)
+	assert.Equalf(t, "urn:scte:dash:cc:cea-608:2015", tr.Accessibility[0].Scheme,
+		"track %q accessibility scheme", tr.Name)
+	assert.Equalf(t, "CC1=eng", tr.Accessibility[0].Value,
+		"track %q accessibility value", tr.Name)
+}
+
+// requireNoAccessibility asserts that no track in the catalog advertises any
+// accessibility descriptor (the omitempty field must be entirely absent).
+func requireNoAccessibility(t *testing.T, tracks []Track) {
+	t.Helper()
+	for i := range tracks {
+		assert.Emptyf(t, tracks[i].Accessibility,
+			"track %q must not advertise accessibility", tracks[i].Name)
+	}
+}
+
+// TestCatalogCC608Accessibility_CMSF verifies issue #113 for the unified
+// MSF/CMSF catalog: with an enabled generator installed, every video track
+// (both its CMAF and LOCMAF variant) carries the CTA-608 accessibility
+// descriptor while audio and subtitle tracks carry none; and without an
+// enabled generator the field is absent everywhere (the gating).
+func TestCatalogCC608Accessibility_CMSF(t *testing.T) {
+	// Captions on: video tracks (both packagings) advertise CTA-608, others don't.
+	on, err := LoadAsset("../assets/test10s", 1, 1)
+	require.NoError(t, err)
+	on.SetCC608Generator(cc608.New(cc608.Config{Enabled: true}))
+	catOn, err := on.GenCMAFCatalogEntry("cmsf/clear", ProtectionNone, 1234567890000)
+	require.NoError(t, err)
+
+	sawCMAFVideo, sawLOCMAFVideo := false, false
+	for i := range catOn.Tracks {
+		tr := &catOn.Tracks[i]
+		if tr.Role == "video" {
+			requireCC608Accessibility(t, tr)
+			switch tr.Packaging {
+			case "cmaf":
+				sawCMAFVideo = true
+			case "locmaf":
+				sawLOCMAFVideo = true
+			}
+			continue
+		}
+		assert.Emptyf(t, tr.Accessibility,
+			"non-video track %q must not advertise captions", tr.Name)
+	}
+	assert.True(t, sawCMAFVideo, "expected at least one CMAF video track")
+	assert.True(t, sawLOCMAFVideo, "expected at least one LOCMAF video track")
+
+	// Captions off (no generator installed): the descriptor is absent everywhere.
+	off, err := LoadAsset("../assets/test10s", 1, 1)
+	require.NoError(t, err)
+	catOff, err := off.GenCMAFCatalogEntry("cmsf/clear", ProtectionNone, 1234567890000)
+	require.NoError(t, err)
+	requireNoAccessibility(t, catOff.Tracks)
+
+	// A disabled generator is equivalent to no generator: still absent.
+	dis, err := LoadAsset("../assets/test10s", 1, 1)
+	require.NoError(t, err)
+	dis.SetCC608Generator(cc608.New(cc608.Config{Enabled: false}))
+	catDis, err := dis.GenCMAFCatalogEntry("cmsf/clear", ProtectionNone, 1234567890000)
+	require.NoError(t, err)
+	requireNoAccessibility(t, catDis.Tracks)
+}
+
+// TestCatalogCC608Accessibility_LOC verifies issue #113 for the MSF/LOC catalog:
+// with an enabled generator every LOC video track advertises the CTA-608
+// descriptor and audio tracks carry none; without one the field is absent.
+func TestCatalogCC608Accessibility_LOC(t *testing.T) {
+	on, err := LoadAsset("../assets/test10s", 1, 1)
+	require.NoError(t, err)
+	on.SetCC608Generator(cc608.New(cc608.Config{Enabled: true}))
+	catOn, err := on.GenLOCCatalogEntry(1700000000000)
+	require.NoError(t, err)
+
+	sawVideo := false
+	for i := range catOn.Tracks {
+		tr := &catOn.Tracks[i]
+		if tr.Role == "video" {
+			requireCC608Accessibility(t, tr)
+			sawVideo = true
+			continue
+		}
+		assert.Emptyf(t, tr.Accessibility,
+			"non-video track %q must not advertise captions", tr.Name)
+	}
+	assert.True(t, sawVideo, "expected at least one LOC video track")
+
+	// Captions off: absent everywhere.
+	off, err := LoadAsset("../assets/test10s", 1, 1)
+	require.NoError(t, err)
+	catOff, err := off.GenLOCCatalogEntry(1700000000000)
+	require.NoError(t, err)
+	requireNoAccessibility(t, catOff.Tracks)
+}

--- a/internal/cc608_catalog_test.go
+++ b/internal/cc608_catalog_test.go
@@ -45,16 +45,25 @@ func TestCatalogCC608Accessibility_CMSF(t *testing.T) {
 	catOn, err := on.GenCMAFCatalogEntry("cmsf/clear", ProtectionNone, 1234567890000)
 	require.NoError(t, err)
 
-	sawCMAFVideo, sawLOCMAFVideo := false, false
+	sawCMAFVideo, sawLOCMAFVideo, sawAV1Excluded := false, false, false
 	for i := range catOn.Tracks {
 		tr := &catOn.Tracks[i]
 		if tr.Role == "video" {
-			requireCC608Accessibility(t, tr)
-			switch tr.Packaging {
-			case "cmaf":
-				sawCMAFVideo = true
-			case "locmaf":
-				sawLOCMAFVideo = true
+			if _, ok := cc608.CodecFor(tr.Codec); ok {
+				// AVC/HEVC carry the SEI, so they advertise CTA-608.
+				requireCC608Accessibility(t, tr)
+				switch tr.Packaging {
+				case "cmaf":
+					sawCMAFVideo = true
+				case "locmaf":
+					sawLOCMAFVideo = true
+				}
+			} else {
+				// AV1 (no SEI CTA-608 carriage) must not advertise captions it
+				// never carries, even with -cc608 set.
+				assert.Emptyf(t, tr.Accessibility,
+					"non-caption-codec video track %q (%s) must not advertise captions", tr.Name, tr.Codec)
+				sawAV1Excluded = true
 			}
 			continue
 		}
@@ -63,6 +72,7 @@ func TestCatalogCC608Accessibility_CMSF(t *testing.T) {
 	}
 	assert.True(t, sawCMAFVideo, "expected at least one CMAF video track")
 	assert.True(t, sawLOCMAFVideo, "expected at least one LOCMAF video track")
+	assert.True(t, sawAV1Excluded, "expected at least one AV1 video track excluded from captions")
 
 	// Captions off (no generator installed): the descriptor is absent everywhere.
 	off, err := LoadAsset("../assets/test10s", 1, 1)
@@ -90,18 +100,25 @@ func TestCatalogCC608Accessibility_LOC(t *testing.T) {
 	catOn, err := on.GenLOCCatalogEntry(1700000000000)
 	require.NoError(t, err)
 
-	sawVideo := false
+	sawVideo, sawAV1Excluded := false, false
 	for i := range catOn.Tracks {
 		tr := &catOn.Tracks[i]
 		if tr.Role == "video" {
-			requireCC608Accessibility(t, tr)
-			sawVideo = true
+			if _, ok := cc608.CodecFor(tr.Codec); ok {
+				requireCC608Accessibility(t, tr)
+				sawVideo = true
+			} else {
+				assert.Emptyf(t, tr.Accessibility,
+					"non-caption-codec video track %q (%s) must not advertise captions", tr.Name, tr.Codec)
+				sawAV1Excluded = true
+			}
 			continue
 		}
 		assert.Emptyf(t, tr.Accessibility,
 			"non-video track %q must not advertise captions", tr.Name)
 	}
-	assert.True(t, sawVideo, "expected at least one LOC video track")
+	assert.True(t, sawVideo, "expected at least one AVC/HEVC LOC video track")
+	assert.True(t, sawAV1Excluded, "expected at least one AV1 LOC video track excluded from captions")
 
 	// Captions off: absent everywhere.
 	off, err := LoadAsset("../assets/test10s", 1, 1)

--- a/internal/cc608_wiring_test.go
+++ b/internal/cc608_wiring_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/Eyevinn/go-608/carriage"
 	"github.com/Eyevinn/go-608/cta608"
+	"github.com/Eyevinn/locmaf"
 	"github.com/Eyevinn/mp4ff/avc"
 	"github.com/Eyevinn/mp4ff/mp4"
 	"github.com/stretchr/testify/assert"
@@ -161,4 +162,106 @@ func TestGenMoQGroupCC608_NoOp(t *testing.T) {
 	av1AssetOn := load(t)
 	av1AssetOn.SetCC608Generator(cc608.New(cc608.Config{Enabled: true}))
 	equalObjects(t, av1Off, genGroup(t, av1AssetOn, "video_400kbps_av1"))
+}
+
+// TestGenMoQGroupCC608_LOCMAF verifies the CTA-608 SEI survives the LOCMAF
+// encode/decode round-trip: with captions on, a LOCMAF-packaged video group is
+// decoded back into canonical CMAF chunks (the mdat payload is preserved
+// untouched by LOCMAF), and the recovered elementary stream still carries a
+// decodable CC1 caption for both AVC and HEVC.
+func TestGenMoQGroupCC608_LOCMAF(t *testing.T) {
+	cases := []struct {
+		name  string
+		codec carriage.Codec
+	}{
+		{"video_400kbps_avc", carriage.CodecAVC},
+		{"video_400kbps_hevc", carriage.CodecHEVC},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			asset, err := LoadAsset("../assets/test10s", 1, 1)
+			require.NoError(t, err)
+			asset.SetCC608Generator(cc608.New(cc608.Config{Enabled: true}))
+
+			ct := asset.GetTrackByName(c.name)
+			require.NotNil(t, ct)
+
+			mg, err := GenMoQGroup(ct, groupNrClock, 1, MoqGroupDurMS, "locmaf")
+			require.NoError(t, err)
+			require.Equal(t, 25, len(mg.MoQObjects), "25 fps => 25 objects in a 1s group")
+
+			// Decode each LOCMAF object back into a canonical CMAF chunk. The
+			// LOCMAF codec preserves the mdat payload (and thus the spliced SEI)
+			// byte-for-byte, so the reconstructed chunk is decodable exactly like
+			// the native CMAF path.
+			moov := ct.SpecData.GetInit().Moov
+			decState := locmaf.NewState()
+			chunks := make([]MoQObject, len(mg.MoQObjects))
+			for i, obj := range mg.MoQObjects {
+				eff, raw, err := locmaf.Decode(obj, decState, moov)
+				require.NoErrorf(t, err, "object %d decode", i)
+				require.Nil(t, raw)
+				chunk, err := locmaf.ReconstructCanonical(moov, eff)
+				require.NoErrorf(t, err, "object %d reconstruct", i)
+				chunks[i] = chunk
+			}
+
+			flips, row13, row14 := decodeGroupCaption(t, chunks, c.codec)
+			assert.Equal(t, 1, flips, "one pop-on cue per group")
+			assert.Equal(t, "12:34:56.000", row13)
+			assert.Equal(t, "GRP 45296", row14)
+		})
+	}
+}
+
+// TestGenMoQGroupCC608_EncryptedPreEncryption proves the CTA-608 SEI is spliced
+// BEFORE encryption: createFragment splices the SEI in front of each frame's VCL
+// NALU, and only then does GenCMAFChunk call encryptFragment, so the caption
+// rides inside the encrypted payload. It builds an ECCP/ClearKey-protected AVC
+// track with captions on, generates an encrypted CMAF group, decrypts every
+// object with the known key, and decodes the CC1 caption back out. The
+// pre-decrypt objects are also confirmed to differ from their plaintext, so the
+// caption really travels through real ciphertext rather than a clear payload.
+func TestGenMoQGroupCC608_EncryptedPreEncryption(t *testing.T) {
+	kidStr := "39112233445566778899aabbccddeeff"
+	keyStr := "40112233445566778899aabbccddeeff"
+	ivStr := "41112233445566778899aabbccddeeff"
+
+	eccp, err := ParseCENCflags("cbcs", kidStr, keyStr, ivStr, "http://localhost:8081/clearkey")
+	require.NoError(t, err)
+	asset, err := LoadAssetWithProtection("../assets/test10s", 1, 1, nil, eccp)
+	require.NoError(t, err)
+	asset.SetCC608Generator(cc608.New(cc608.Config{Enabled: true}))
+
+	ct := asset.GetTrackByName("video_400kbps_avc_eccp")
+	require.NotNil(t, ct, "protected AVC track must exist")
+	require.NotEmpty(t, ct.contentProtectionRefIDs, "track must be encrypted")
+
+	mg, err := GenMoQGroup(ct, groupNrClock, 1, MoqGroupDurMS, "cmaf")
+	require.NoError(t, err)
+	require.Equal(t, 25, len(mg.MoQObjects), "25 fps => 25 objects in a 1s group")
+
+	// Recover the CENC DecryptInfo from the (encrypted) init segment, then
+	// decrypt every object with the known content key.
+	initData, err := ct.SpecData.GenCMAFInitData()
+	require.NoError(t, err)
+	_, _, ipd, err := DecryptInit(initData)
+	require.NoError(t, err)
+
+	dec := make([]MoQObject, len(mg.MoQObjects))
+	sawCiphertext := false
+	for i, obj := range mg.MoQObjects {
+		plain, err := DecryptFragment(obj, ipd, eccp.cenc.key)
+		require.NoErrorf(t, err, "decrypt object %d", i)
+		if !bytes.Equal(obj, plain) {
+			sawCiphertext = true
+		}
+		dec[i] = plain
+	}
+	require.True(t, sawCiphertext, "objects must actually be encrypted on the wire")
+
+	flips, row13, row14 := decodeGroupCaption(t, dec, carriage.CodecAVC)
+	assert.Equal(t, 1, flips, "one pop-on cue per group after decryption")
+	assert.Equal(t, "12:34:56.000", row13)
+	assert.Equal(t, "GRP 45296", row14)
 }

--- a/internal/moqgroup.go
+++ b/internal/moqgroup.go
@@ -86,7 +86,7 @@ func (t *ContentTrack) newGroupCCSplice(groupNr, startNr, endNr uint64) *ccSplic
 	}
 	codec, ok := cc608.CodecFor(t.SpecData.Codec())
 	if !ok {
-		return nil // AV1 and any non-AVC/HEVC codec: no captions.
+		return nil // AV1 (SEI carriage not yet wired) and other codecs: no captions.
 	}
 	fps := float64(t.TimeScale) / float64(t.SampleDur)
 	sei := t.cc608.SEISchedule(int64(groupNr), fps, int(endNr-startNr), codec)

--- a/internal/pub/caption.go
+++ b/internal/pub/caption.go
@@ -28,7 +28,8 @@ type videoCaptioner struct {
 
 // newVideoCaptioner builds a captioner for ct. It is enabled only when ct has an
 // enabled generator, is a video track with valid timing, and uses an AVC or HEVC
-// codec (AV1 and everything else yield a disabled captioner).
+// codec (AV1 is not yet supported, so it and everything else yield a disabled
+// captioner).
 func newVideoCaptioner(ct *internal.ContentTrack) videoCaptioner {
 	gen := ct.CC608Generator()
 	if !gen.Enabled() || ct.ContentType != "video" || ct.SampleDur == 0 || ct.TimeScale == 0 {


### PR DESCRIPTION
## What

Completes the CTA-608 caption feature (#72): the catalog now advertises the captions, and full decode-round-trip verification lands. Builds on #114 (the `cc608` package) and #115 (serve-path injection).

### Catalog `accessibility` signaling (#113)
- Adds `Track.Accessibility` (`[]{scheme, value}`, per draft-ietf-moq-msf-01 §5.2.44) to the catalog model.
- Both generators — CMSF `GenCMAFCatalogEntry` and MSF/LOC `GenLOCCatalogEntry` — emit `{scheme: "urn:scte:dash:cc:cea-608:2015", value: "CC1=eng"}` on video tracks (the CMAF and LOCMAF variants share it, since the SEI rides in the shared elementary stream). moq-mi is catalogless (nothing).
- **Gated** on an enabled generator (`-cc608`) **and** an AVC/HEVC codec — mirroring the injection gate — so the catalog advertises captions **iff** they are actually in the bitstream. AV1 tracks (no SEI CTA-608 carriage) never advertise.

### Verification (#112)
- Catalog-signaling tests: the descriptor is present on AVC/HEVC video (both packagings) iff `-cc608`, and absent for AV1, audio, and the captions-off case.
- LOCMAF decode round-trip (AVC + HEVC).
- Encrypted (ECCP/ClearKey) round-trip: generate an encrypted CMAF group, confirm real ciphertext, decrypt with the content key, then decode the CC1 back — proving the SEI is spliced **before** encryption.
- (CMAF/LOC/moq-mi AVC+HEVC round-trips already landed in #115.)

## Testing

`go build ./...`, `go vet`, `gofmt -l`, `golangci-lint run` (0 issues), and the full `go test ./...` — all green.
