### PR TITLE
docs: trim derivable content from CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,16 +11,8 @@ moqlivemock is a Go-based MoQ (Media over QUIC) live streaming mock implementati
 
 ## Architecture
 
-### Key Components
+### LOCMAF Codec Module
 
-- `cmd/mlmpub/` - Publisher application serving media tracks (video, audio, subtitles)
-- `cmd/mlmsub/` - Subscriber application receiving media
-- `cmd/mlmtest/` - Interop test client for [moq-interop-runner](https://github.com/englishm/moq-interop-runner)
-- `internal/` - Shared internal packages:
-  - `asset.go` - Asset loading and track management
-  - `catalog.go` - MSF/CMSF catalog generation (CMAF, LOC, LOCMAF packaging)
-  - `subtitle.go` - Dynamic subtitle generation (WVTT/STPP)
-  - `moqgroup.go` - MoQ group/object handling
 - LOCMAF encode/decode comes from `github.com/Eyevinn/locmaf` (the reusable
   codec module; one packaging version at a time, reported by `locmaf.Version`).
   See `docs/LOCMAF.md`; the normative spec is the IETF draft
@@ -30,9 +22,6 @@ moqlivemock is a Go-based MoQ (Media over QUIC) live streaming mock implementati
 
 Uses `github.com/Eyevinn/moqtransport` (forked from mengelbart/moqtransport) with draft-14 and draft-16 support.
 Version negotiation uses ALPN (`moqt-16` for draft-16, `moq-00` for draft-14) and `WT-Available-Protocols` for WebTransport.
-- Session creation: `&moqtransport.Session{Handler: ..., SubscribeHandler: ...}`
-- Call `session.Run(conn)` to start
-- Subscriptions use separate `SubscribeHandler` interface
 
 ### Multi-Namespace Architecture
 
@@ -74,61 +63,18 @@ LOC (raw codec frames, one per object) and moq-mi (catalogless):
 - `msf/clear` — LOC packaging (AVC, HEVC, and AV1 video + AAC/Opus audio)
 - `moq-mi/clear` — moq-mi packaging with fixed track names `video0` / `audio0`
 
-Key types in `internal/pub/pub.go`:
-- `NamespaceEntry` — pairs a namespace tuple with its catalog
-- `Handler.Namespaces []NamespaceEntry` — all announced namespaces
-
-Key types in `internal/asset.go`:
-- `ProtectionType` — enum: `ProtectionNone`, `ProtectionDRM`, `ProtectionECCP`
-- `ContentTrack.Protection` — identifies how a track is encrypted
-- `Asset.Drm` / `Asset.Eccp` — independent DRM configs
-
-`GenCMAFCatalogEntry(namespace, protectionType, timestamp)` generates a unified
-CMSF catalog (CMAF + LOCMAF variants, shared init data) filtered to the
-specified protection type.
-
-### Handler Pattern
-
-Publishers implement:
-- `Handler` - for ANNOUNCE messages
-- `SubscribeHandler` - for SUBSCRIBE messages (returns `*SubscribeResponseWriter`)
-- `FetchHandler` - for FETCH messages (returns `*FetchResponseWriter`)
-
-Subscribers implement:
-- `Handler` - for ANNOUNCE messages (accept/reject)
-- `SubscribeHandler` - for SUBSCRIBE messages (typically reject as they don't publish)
-
 ### Subtitle Tracks
 
-Subtitles are dynamically generated (not loaded from files) showing UTC time and group number:
-- **WVTT** (WebVTT in CMAF) - codec: `wvtt`, uses `mp4.VttcBox`/`mp4.PaylBox`
-- **STPP** (TTML in CMAF) - codec: `stpp.ttml.im1t`, uses Go templates (`stpptime.xml`)
-
-Key types in `internal/subtitle.go`:
-- `SubtitleTrack` - track configuration (format, language, timing)
-- `SubtitleData` - implements `CodecSpecificData` interface for init segments
-- `GenSubtitleGroup()` - generates MoQ group with CMAF media segment
-
-Configuration via mlmpub flags:
-- `-subswvtt "en,sv"` - comma-separated WVTT languages (default: "sv")
-- `-subsstpp "en,sv"` - comma-separated STPP languages (default: "en")
+Subtitles are dynamically generated (not loaded from files), showing UTC time
+and group number, as WVTT (WebVTT in CMAF) or STPP (TTML in CMAF).
 
 Track naming: `subs_wvtt_{lang}`, `subs_stpp_{lang}`
 
 ### Content Protection
 
-Two independent encryption modes, both optional and can be active simultaneously:
-
-**ClearKey/ECCP** (explicit key flags):
-- `-kid` — key ID (32 hex chars)
-- `-iv` — initialization vector (16 or 32 hex chars)
-- `-cenckey` — encryption key (32 hex chars, defaults to kid if omitted)
-- `-scheme` — `cenc` or `cbcs`
-- `-laurl` — external license URL for the catalog (falls back to `http://localhost:{sideport}/clearkey`)
-- `-sideport` — HTTP port serving `/fingerprint` and `/clearkey` endpoints
-
-**Commercial DRM** (CPIX config file):
-- `-drmpath` — path to config JSON (format: `assets/testdrm/drm_config_test.json`)
+ClearKey/ECCP (explicit `-kid`/`-iv` flags) and commercial DRM (a CPIX config
+via `-drmpath`) are two independent modes: both are optional and both can be
+active at the same time, in which case a rendition is published three times.
 
 Track naming: clear tracks have no suffix, DRM tracks get `_drm`, ECCP tracks get `_eccp`.
 
@@ -156,34 +102,11 @@ AV1 tracks that round-trip correctly.
 
 `mlmtest` is an interop test client for [moq-interop-runner](https://github.com/englishm/moq-interop-runner).
 It connects to a server/relay and runs protocol-level test cases with both draft-14 and draft-16, outputting TAP v14 results.
+`go run ./cmd/mlmtest -l` lists the test cases.
 
-**Test cases:**
-1. `setup-only` — connect, exchange SETUP, close
-2. `announce-only` — PUBLISH_NAMESPACE, wait for REQUEST_OK, close
-3. `publish-namespace-done` — PUBLISH_NAMESPACE, REQUEST_OK, PUBLISH_NAMESPACE_DONE, close
-4. `subscribe-error` — SUBSCRIBE to non-existent track, expect REQUEST_ERROR
-5. `announce-subscribe` — publisher announces, subscriber subscribes via relay
-6. `subscribe-before-announce` — subscriber subscribes first, publisher announces 500ms later
+moq-interop-runner drives it through environment variables rather than flags:
 
-**Usage:**
 ```bash
-# Run all tests against a relay
-go run ./cmd/mlmtest -r moqt://relay:443 -tls-disable-verify
-
-# Run a specific test
-go run ./cmd/mlmtest -r moqt://relay:443 -t setup-only
-
-# List available tests
-go run ./cmd/mlmtest -l
-
-# Environment variables (used by moq-interop-runner)
 RELAY_URL=moqt://relay:443 TESTCASE=setup-only TLS_DISABLE_VERIFY=1 go run ./cmd/mlmtest
-```
-
-## Testing
-
-The `internal/` package contains unit tests. Run with:
-```bash
-go test ./internal/...
 ```
 


### PR DESCRIPTION
Drops ~3.7 kB of `CLAUDE.md` (8752 → 5427 chars, roughly 830 tokens off every session that touches this repo) by cutting what a session can reconstruct from the code itself, and keeps everything it cannot.

## Cut

| Section | Why |
|---|---|
| `### Key Components` directory listing | `ls cmd/ internal/` |
| moqtransport API bullets (`&Session{…}`, `session.Run`) | copied from moqtransport's own source |
| Key types in `pub.go` / `asset.go`, `GenCMAFCatalogEntry` signature | grep the source |
| `### Handler Pattern` interface list | copied from source |
| Subtitle type list and the `-subswvtt` / `-subsstpp` flags | `mlmpub --help` and source |
| Content-protection flag enumeration | `mlmpub --help` |
| mlmtest's six test cases and its usage examples | `go run ./cmd/mlmtest -l`, which the file itself points at |
| `## Testing` (`go test ./internal/...`) | the standard invocation |

## Kept

Everything that is a gotcha, a rationale or a directive: the ALPN mapping, the whole multi-namespace and CMSF dual-entry / shared-`initRef` design and its `MSF_COMPRESSION` follow-up, the one-packaging-version-at-a-time rule with "cite the version-independent draft URL", the entire **Video Codecs** section (parameter sets in the init segment for FairPlay, why LOC keeps `av01` as-is, the AV1 CENC binding), subtitles-are-generated-not-loaded plus the track-naming conventions, the two-independent-encryption-modes fact with the `_drm` / `_eccp` suffixes, and mlmtest's `RELAY_URL` / `TESTCASE` / `TLS_DISABLE_VERIFY` contract with moq-interop-runner.

Two sections were compressed rather than deleted, so the non-obvious half survives: the `make` targets now say they live in `moqlivemock/Makefile`, and the mlmtest section keeps the environment-variable form that moq-interop-runner actually drives.

Docs only — no code or behaviour change.
