### PR TITLE
fix(mlmpub): serve the configured content key from /clearkey

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Regenerated the AVC and HEVC `assets/test10s` tracks so they also carry the
   new codec overlay line.
 
+### Fixed
+
+- `mlmpub`'s `/clearkey` license endpoint served the requested KID back as the
+  content key, ignoring `-cenckey`. Any run that set `-cenckey` therefore
+  published content encrypted with the real key while handing players the KID,
+  so EME decrypted with the wrong key and the decoder failed on the first
+  packet. It now serves the configured content key, base64url-encoded per the
+  EME ClearKey request format, and answers 404 for a KID it has no key for
+  instead of echoing it ([#122][issue-122]).
+
 ## [0.12.0] - 2026-07-06
 
 Catalog retrieval now uses a relative joining FETCH, aligned to the live edge.
@@ -505,5 +515,6 @@ Full [MOQ Transport draft-14][moqt-d14] compliance release.
 [moqtransport-eyevinn]: https://github.com/Eyevinn/moqtransport
 [interop-runner]: https://github.com/englishm/moq-interop-runner
 [interop-70]: https://github.com/englishm/moq-interop-runner/issues/70
+[issue-122]: https://github.com/Eyevinn/moqlivemock/issues/122
 [moxygen-173]: https://github.com/facebookexperimental/moxygen/issues/173
 [wp]: https://github.com/Eyevinn/warp-player

--- a/README.md
+++ b/README.md
@@ -343,7 +343,11 @@ moqlivemock supports two independent content protection modes that can run simul
 Use `-kid`, `-iv`, and optionally `-cenckey` flags. If no cenc key is provided, the
 key-id is used as the key. The ClearKey license endpoint is served at `/clearkey` on
 the side server, so `-sideport` must be set. For production behind a reverse proxy,
-use `-laurl` to specify the external license URL announced in the catalog. The ClearKey license server always returns the key id as the cenc key, so `-kid` must match `-cenckey`.
+use `-laurl` to specify the external license URL announced in the catalog.
+
+`/clearkey` serves the configured content key — `-cenckey` when set, otherwise the
+key-id — for the configured `-kid`, and answers 404 for any other key-id. `-kid`
+and `-cenckey` may therefore differ.
 
 ```sh
 # Local development

--- a/cmd/mlmpub/handler.go
+++ b/cmd/mlmpub/handler.go
@@ -5,13 +5,16 @@ import (
 	"crypto/sha256"
 	"crypto/tls"
 	"crypto/x509"
+	"encoding/base64"
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"log/slog"
 	"net/http"
+	"strings"
 	"time"
 
+	"github.com/Eyevinn/moqlivemock/internal"
 	"github.com/Eyevinn/moqlivemock/internal/pub"
 	"github.com/Eyevinn/moqtransport/quicmoq"
 	"github.com/Eyevinn/moqtransport/webtransportmoq"
@@ -25,6 +28,10 @@ type server struct {
 	tlsConfig *tls.Config
 	handler   *pub.Handler
 	sidePort  int
+	// eccp is the ClearKey/ECCP config the content is encrypted with, and the
+	// source of the key served by /clearkey. Nil when -kid/-iv are not set, in
+	// which case /clearkey has no key to hand out.
+	eccp *internal.DRMInfo
 }
 
 func (s *server) runServer(ctx context.Context) error {
@@ -127,58 +134,84 @@ func (s *server) startSideServer() {
 		slog.Debug("Served fingerprint", "fingerprint", fingerprint)
 	}))
 
-	mux.HandleFunc("/clearkey", withCORS(func(w http.ResponseWriter, r *http.Request) {
-		if r.Method != http.MethodPost {
-			http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
-			return
-		}
-
-		var req struct {
-			Kids []string `json:"kids"`
-		}
-		err := json.NewDecoder(r.Body).Decode(&req)
-		if err != nil {
-			http.Error(w, "failed to decode request body", http.StatusBadRequest)
-			return
-		}
-
-		type keyInfo struct {
-			Kty string `json:"kty"`
-			K   string `json:"k"`
-			Kid string `json:"kid"`
-		}
-		type clearKeyResponse struct {
-			Keys []keyInfo `json:"keys"`
-			Type string    `json:"type"`
-		}
-
-		var keys []keyInfo
-		for _, kid := range req.Kids {
-			keys = append(keys, keyInfo{
-				Kty: "oct",
-				K:   kid,
-				Kid: kid,
-			})
-		}
-
-		response := clearKeyResponse{
-			Keys: keys,
-			Type: "temporary",
-		}
-		w.Header().Set("Content-Type", "application/json")
-		err = json.NewEncoder(w).Encode(response)
-		if err != nil {
-			slog.Error("failed to encode ClearKey response", "error", err)
-			return
-		}
-		slog.Info("Served ClearKey license")
-	}))
+	mux.HandleFunc("/clearkey", withCORS(s.serveClearKey))
 
 	addr := fmt.Sprintf(":%d", s.sidePort)
 	slog.Info("Starting HTTP side server", "addr", addr)
 	if err := http.ListenAndServe(addr, mux); err != nil {
 		slog.Error("side server failed", "error", err)
 	}
+}
+
+// serveClearKey answers an EME ClearKey license request (a POST of
+// {"kids":[...]}) with the content key each requested KID is actually encrypted
+// with, per https://www.w3.org/TR/encrypted-media/#clear-key-request-format.
+//
+// The KIDs arrive base64url-encoded and the response's k/kid must be base64url
+// without padding. A requested KID that this publisher has no key for is
+// omitted; if that leaves no keys at all the request gets 404 rather than an
+// empty key list, so a misconfigured run fails loudly instead of handing the
+// player a license it cannot use.
+func (s *server) serveClearKey(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	var req struct {
+		Kids []string `json:"kids"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, "failed to decode request body", http.StatusBadRequest)
+		return
+	}
+
+	type keyInfo struct {
+		Kty string `json:"kty"`
+		K   string `json:"k"`
+		Kid string `json:"kid"`
+	}
+	type clearKeyResponse struct {
+		Keys []keyInfo `json:"keys"`
+		Type string    `json:"type"`
+	}
+
+	keys := make([]keyInfo, 0, len(req.Kids))
+	for _, kidB64 := range req.Kids {
+		kid, err := decodeBase64URL(kidB64)
+		if err != nil {
+			slog.Warn("ClearKey request has an undecodable kid", "kid", kidB64, "error", err)
+			continue
+		}
+		key, ok := s.eccp.ContentKeyForKID(kid)
+		if !ok {
+			slog.Warn("ClearKey request for an unknown kid", "kid", kidB64)
+			continue
+		}
+		keys = append(keys, keyInfo{
+			Kty: "oct",
+			K:   base64.RawURLEncoding.EncodeToString(key),
+			Kid: base64.RawURLEncoding.EncodeToString(kid),
+		})
+	}
+	if len(keys) == 0 {
+		http.Error(w, "no key for the requested kids", http.StatusNotFound)
+		slog.Warn("Served no ClearKey license", "requestedKids", req.Kids)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(clearKeyResponse{Keys: keys, Type: "temporary"}); err != nil {
+		slog.Error("failed to encode ClearKey response", "error", err)
+		return
+	}
+	slog.Info("Served ClearKey license", "keys", len(keys))
+}
+
+// decodeBase64URL decodes a base64url KID, tolerating the "=" padding that the
+// spec forbids but some clients still send.
+func decodeBase64URL(s string) ([]byte, error) {
+	return base64.RawURLEncoding.DecodeString(strings.TrimRight(s, "="))
 }
 
 func (s *server) getCertificateFingerprint() string {

--- a/cmd/mlmpub/handler_test.go
+++ b/cmd/mlmpub/handler_test.go
@@ -1,0 +1,145 @@
+package main
+
+import (
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/Eyevinn/moqlivemock/internal"
+)
+
+const (
+	testKID = "11223344556677889900aabbccddeeff"
+	testKey = "ffeeddccbbaa00998877665544332211"
+	testIV  = "0123456789abcdef0123456789abcdef"
+)
+
+type clearKeyResp struct {
+	Keys []struct {
+		Kty string `json:"kty"`
+		K   string `json:"k"`
+		Kid string `json:"kid"`
+	} `json:"keys"`
+	Type string `json:"type"`
+}
+
+// b64 is the base64url-without-padding form of a hex-encoded KID or key, which
+// is how both travel in an EME ClearKey exchange.
+func b64(t *testing.T, hexStr string) string {
+	t.Helper()
+	raw, err := hex.DecodeString(hexStr)
+	require.NoError(t, err)
+	return base64.RawURLEncoding.EncodeToString(raw)
+}
+
+func testServer(t *testing.T, kidStr, keyStr string) *server {
+	t.Helper()
+	eccp, err := internal.ParseCENCflags("cbcs", kidStr, keyStr, testIV, "http://localhost:8081/clearkey")
+	require.NoError(t, err)
+	require.NotNil(t, eccp)
+	return &server{eccp: eccp}
+}
+
+func postClearKey(t *testing.T, s *server, body string) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodPost, "/clearkey", strings.NewReader(body))
+	rec := httptest.NewRecorder()
+	s.serveClearKey(rec, req)
+	return rec
+}
+
+// TestServeClearKeyServesConfiguredKey is the regression test for #122: the
+// endpoint used to echo the requested KID back as the content key, so any run
+// with -cenckey set served a license that could not decrypt the content.
+func TestServeClearKeyServesConfiguredKey(t *testing.T) {
+	s := testServer(t, testKID, testKey)
+
+	rec := postClearKey(t, s, `{"kids":["`+b64(t, testKID)+`"],"type":"temporary"}`)
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var resp clearKeyResp
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	require.Len(t, resp.Keys, 1)
+	require.Equal(t, "oct", resp.Keys[0].Kty)
+	require.Equal(t, b64(t, testKID), resp.Keys[0].Kid)
+	require.Equal(t, b64(t, testKey), resp.Keys[0].K, "k must be the configured -cenckey")
+	require.NotEqual(t, resp.Keys[0].Kid, resp.Keys[0].K, "k must not be the KID echoed back")
+	require.Equal(t, "temporary", resp.Type)
+}
+
+// TestServeClearKeyKIDIsKeyWhenNoCencKey covers the -cenckey-omitted case, where
+// ParseCENCflags defaults the key to the KID: k and kid then legitimately match,
+// which is why the bug went unnoticed.
+func TestServeClearKeyKIDIsKeyWhenNoCencKey(t *testing.T) {
+	s := testServer(t, testKID, "")
+
+	rec := postClearKey(t, s, `{"kids":["`+b64(t, testKID)+`"]}`)
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var resp clearKeyResp
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	require.Len(t, resp.Keys, 1)
+	require.Equal(t, b64(t, testKID), resp.Keys[0].K)
+}
+
+// TestServeClearKeyPaddedKID accepts the "=" padding the spec forbids but some
+// clients send anyway, and normalizes it away in the response.
+func TestServeClearKeyPaddedKID(t *testing.T) {
+	s := testServer(t, testKID, testKey)
+	padded := base64.URLEncoding.EncodeToString(mustHex(t, testKID))
+	require.Contains(t, padded, "=", "the 16-byte KID must pad, or this test proves nothing")
+
+	rec := postClearKey(t, s, `{"kids":["`+padded+`"]}`)
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var resp clearKeyResp
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	require.Len(t, resp.Keys, 1)
+	require.Equal(t, b64(t, testKID), resp.Keys[0].Kid, "response kid must be unpadded")
+	require.Equal(t, b64(t, testKey), resp.Keys[0].K)
+}
+
+// TestServeClearKeyUnknownKID checks an unknown KID is a 404 rather than an
+// echo: serving a key for content this publisher did not encrypt is exactly the
+// failure #122 describes.
+func TestServeClearKeyUnknownKID(t *testing.T) {
+	s := testServer(t, testKID, testKey)
+
+	other := b64(t, "aabbccddeeff00112233445566778899")
+	rec := postClearKey(t, s, `{"kids":["`+other+`"]}`)
+	require.Equal(t, http.StatusNotFound, rec.Code)
+	require.NotContains(t, rec.Body.String(), other, "an unknown kid must not be echoed back as a key")
+}
+
+// TestServeClearKeyNoECCP covers -sideport without -kid/-iv: there is no key to
+// serve, and a nil *DRMInfo must not panic.
+func TestServeClearKeyNoECCP(t *testing.T) {
+	s := &server{}
+	rec := postClearKey(t, s, `{"kids":["`+b64(t, testKID)+`"]}`)
+	require.Equal(t, http.StatusNotFound, rec.Code)
+}
+
+func TestServeClearKeyBadRequests(t *testing.T) {
+	s := testServer(t, testKID, testKey)
+
+	rec := postClearKey(t, s, `not json`)
+	require.Equal(t, http.StatusBadRequest, rec.Code)
+
+	req := httptest.NewRequest(http.MethodGet, "/clearkey", nil)
+	rec = httptest.NewRecorder()
+	s.serveClearKey(rec, req)
+	require.Equal(t, http.StatusMethodNotAllowed, rec.Code)
+}
+
+func mustHex(t *testing.T, s string) []byte {
+	t.Helper()
+	raw, err := hex.DecodeString(s)
+	require.NoError(t, err)
+	return raw
+}

--- a/cmd/mlmpub/main.go
+++ b/cmd/mlmpub/main.go
@@ -297,6 +297,7 @@ func runServer(opts *options) error {
 		tlsConfig: tlsConfig,
 		handler:   h,
 		sidePort:  opts.sidePort,
+		eccp:      eccp,
 	}
 
 	return s.runServer(ctx)

--- a/internal/drm.go
+++ b/internal/drm.go
@@ -1,6 +1,7 @@
 package internal
 
 import (
+	"bytes"
 	"encoding/base64"
 	"encoding/hex"
 	"fmt"
@@ -28,8 +29,27 @@ type DRMInfo struct {
 
 // CENCInfo contains information unique to CENC and is not signaled in the catalog
 type CENCInfo struct {
+	kid []byte
 	key []byte
 	iv  []byte
+}
+
+// ContentKeyForKID returns the CENC content key configured for kid, or ok=false
+// when d holds no key for it. kid is the raw 16-byte key ID.
+//
+// This is what a ClearKey license endpoint must answer with: the configured
+// content key (-cenckey), which equals the KID only when -cenckey was omitted.
+// Handing back the KID for a stream encrypted with a different key gives EME a
+// wrong key and the decoder garbage, so an unknown KID has to be a miss rather
+// than an echo.
+func (d *DRMInfo) ContentKeyForKID(kid []byte) (key []byte, ok bool) {
+	if d == nil || d.cenc == nil || len(d.cenc.kid) == 0 {
+		return nil, false
+	}
+	if !bytes.Equal(kid, d.cenc.kid) {
+		return nil, false
+	}
+	return d.cenc.key, true
 }
 
 // ConfigureDRMFromFile reads a DRM config file and returns a *DRMInfo struct.
@@ -90,6 +110,7 @@ func ConfigureDRMFromFile(configpath string) (*DRMInfo, error) {
 	}
 
 	cenc := &CENCInfo{
+		kid: contentKey.KeyID,
 		key: contentKey.Key,
 		iv:  contentKey.ExplicitIV,
 	}
@@ -153,6 +174,7 @@ func ParseCENCflags(scheme, kidStr, keyStr, ivStr, laURL string) (*DRMInfo, erro
 	}
 
 	cenc := &CENCInfo{
+		kid: kid,
 		key: key,
 		iv:  iv,
 	}


### PR DESCRIPTION
Fixes #122.

## Problem

`/clearkey` built its response by echoing each requested KID back as the content key:

```go
keys = append(keys, keyInfo{Kty: "oct", K: kid, Kid: kid})
```

So any run with `-cenckey` set published content encrypted with the real key while the license handed out the KID. EME decrypted with the wrong key and the decoder was fed garbage — `PIPELINE_ERROR_DECODE` on the first audio packet, nothing rendered. It looked correct only because `-cenckey` defaults to the KID when omitted, which is the case every existing example uses.

## Fix

- `CENCInfo` now tracks the KID alongside the key, and `DRMInfo.ContentKeyForKID(kid)` looks up the content key for a requested KID. Nil-safe, so `-sideport` without `-kid`/`-iv` doesn't panic.
- `/clearkey` decodes the request's base64url KIDs (tolerating the `=` padding the EME spec forbids but clients still send), looks each one up, and returns `k`/`kid` re-encoded base64url-unpadded per the spec.
- An unrecognised KID is omitted, and a request with no known KIDs gets **404** instead of an empty key list — serving a key for content this publisher did not encrypt is the very failure being fixed, so it should be loud.
- The handler moved out of the `startSideServer` closure into `server.serveClearKey` so it is testable.

## Verification

Unit tests in `cmd/mlmpub/handler_test.go` cover the `-cenckey` case, the KID-as-key default, a padded KID, an unknown KID, no-ECCP, and malformed requests. Re-introducing the old `K: kid` line fails two of them.

End to end with the reproduce from the issue:

```console
$ curl -s -X POST http://127.0.0.1:8099/clearkey -d '{"kids":["ESIzRFVmd4iZAKq7zN3u_w"],"type":"temporary"}'
{"keys":[{"kty":"oct","k":"_-7dzLuqAJmId2ZVRDMiEQ","kid":"ESIzRFVmd4iZAKq7zN3u_w"}],"type":"temporary"}
#                             ^^^^ base64url of the configured -cenckey ffee..2211, was the KID before

$ curl -s -o /dev/null -w '%{http_code}\n' -X POST http://127.0.0.1:8099/clearkey -d '{"kids":["qrvM3e7_ABEiM0RVZneImQ"]}'
404
```

`go build`, `go vet`, `golangci-lint` (0 issues) and the full `go test ./...` pass with `GOWORK=off`.

## Docs

`README.md` documented the bug as a constraint — *"The ClearKey license server always returns the key id as the cenc key, so `-kid` must match `-cenckey`"*. That restriction is gone, and the section now describes what the endpoint actually serves. CHANGELOG entry added under Unreleased → Fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
