### PR TITLE
chore(deps): bump go-608 to v0.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,12 +41,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Bumped `github.com/Eyevinn/mp4ff` to v0.55.0 for the AV1 API
   (`SequenceHeader`, `SetAV1Descriptor`, the AV1 CENC binding, and the
   CTA-608 metadata-OBU helpers).
-- Bumped `github.com/Eyevinn/go-608` to v0.8.0 for AV1 CTA-608 carriage and its
+- Bumped `github.com/Eyevinn/go-608` to v0.9.0 for AV1 CTA-608 carriage and its
   now-exported sample splice, which replaces moqlivemock's local copy. v0.8.0
   makes a unit's number and start time independent inputs
   (`generate.BuildUnitCues` takes a `generate.Unit`), so the caption content
   function now reads the group number from `Unit.Nr` instead of deriving it from
-  the cue timestamp.
+  the cue timestamp. Neither v0.9.0 change reaches moqlivemock: its captions come
+  from the package's own `cc608.DefaultContent`, not go-608's default `Config`
+  whose UTC line shortened to time-of-day, and the stricter `generate.NumCues`
+  still yields one cue for a one-second MoQ group at every broadcast rate. v0.9.0
+  additionally offers paint-on and roll-up caption modes, which moqlivemock does
+  not use yet.
 - Regenerated the AVC and HEVC `assets/test10s` tracks so they also carry the
   new codec overlay line.
 

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/stretchr/testify v1.11.1
 )
 
-require github.com/Eyevinn/go-608 v0.8.0
+require github.com/Eyevinn/go-608 v0.9.0
 
 require (
 	github.com/Eyevinn/locmaf v0.1.1

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
 github.com/Dash-Industry-Forum/livesim2 v1.9.0 h1:7NTv3f+9gszh9mX7p6ltaTJmLlR400S+R4pjWrzpLKQ=
 github.com/Dash-Industry-Forum/livesim2 v1.9.0/go.mod h1:AtqFe2WBX6TSoHlpHw7Hh/IWttqDRnoN+VnysQyssiA=
-github.com/Eyevinn/go-608 v0.8.0 h1:zAVPHlbsYatu4sT44PPnJSyPGohOApguMsre9yq3zhU=
-github.com/Eyevinn/go-608 v0.8.0/go.mod h1:Rs0dVVIrIgSaFYYV0QfeZOXlYgkr0XV9ri0bA63j4pA=
+github.com/Eyevinn/go-608 v0.9.0 h1:vpU6s74i0bj5rjrUiqT2Qbf4abEwLRNHBdx4FU0RZE0=
+github.com/Eyevinn/go-608 v0.9.0/go.mod h1:Rs0dVVIrIgSaFYYV0QfeZOXlYgkr0XV9ri0bA63j4pA=
 github.com/Eyevinn/locmaf v0.1.1 h1:0tjMb18hnjUD52bby6VDeMYZYb1+CWZfI8o3M4JgTPQ=
 github.com/Eyevinn/locmaf v0.1.1/go.mod h1:uFlF7DXkDA1Y866/1wtsxX4J8LB45TDNofaqZ3/e8s8=
 github.com/Eyevinn/moqtransport v0.9.0 h1:LOPeLozXu6NJ9cUZ42uOlUbDnYhTi7l9HofDZ9kMxJM=


### PR DESCRIPTION
Bumps `github.com/Eyevinn/go-608` from v0.8.0 to [v0.9.0](https://github.com/Eyevinn/go-608/releases/tag/v0.9.0).

Drop-in: no moqlivemock code changes, and the CTA-608 round-trip tests decode the same captions as before.

## Why neither v0.9.0 behaviour change reaches us

- **The default UTC caption line shortened to time-of-day (`15:04:05Z`).** That is go-608's default `Config`; moqlivemock renders its captions with the package's own `cc608.DefaultContent` (`HH:MM:SS.mmm` on row 13, `GRP <n>` on row 14) and never uses go-608's. The existing tests still assert `12:34:56.000` / `GRP 45296`.
- **`generate.NumCues` now floors instead of rounding.** A MoQ group is `round(fps)` frames, so the unit is 1000 ms (25/30/50/60 fps) or 1001 ms (30000/1001), and both the old and new division give one cue against `targetPeriodMS = 1000`. Unchanged.

## Budget check

v0.9.0's notes flag the per-unit builders as tight enough that go-608's *former* default caption no longer fit at 23.976 fps — which is why that default changed. Since we keep our own content function, I checked `cc608.DefaultContent` against every broadcast rate v0.9.0 supports (23.976, 24, 25, 29.97, 30, 50, 59.94, 60 fps × AVC/HEVC/AV1): `Schedule` returns a non-nil schedule for all of them, so nothing overruns. Our two lines are shorter than the old default that broke.

Paint-on and roll-up caption generation are new in v0.9.0 and unused here. `generate.WithFlipAtCueStart` — the API #118 needs — is unaffected by this bump.

## Verification

`go build`, `go vet`, `golangci-lint` (0 issues), `go mod tidy` clean, and the full `go test ./...` all pass with `GOWORK=off` (the CI-equivalent module resolution), and the build also passes inside the go workspace.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
