### PR TITLE
feat(cc608): add -cc608mode (paint-on, pop-on, roll-up) with paint-on as the default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   video track with an `accessibility` descriptor
   (`urn:scte:dash:cc:cea-608:2015`, `CC1=eng`); catalogless `moq-mi` signals
   nothing and is in-band only.
+- **`mlmpub -cc608mode paint-on|pop-on`** (default `paint-on`) selects how an
+  in-band CTA-608 caption reaches the screen. Paint-on clears the screen on the
+  group's first frame and then grows the caption two characters per frame, so it
+  is displayed over the second it names — at 25 fps the first characters land on
+  frame 4 and the caption is complete on frame 17 of 25. Pop-on builds the caption
+  invisibly and flips it on whole, which at 25 fps happens on frame 18, leaving
+  the caption reading `GRP n` on screen mostly during group *n+1*. Both modes keep
+  every group independent — a group's whole caption comes from that group's
+  samples alone — which is why paint-on is the default and why go-608's cross-unit
+  `WithFlipAtCueStart` is not used ([#118][issue-118]).
 
 ### Changed
 
@@ -50,8 +60,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   from the package's own `cc608.DefaultContent`, not go-608's default `Config`
   whose UTC line shortened to time-of-day, and the stricter `generate.NumCues`
   still yields one cue for a one-second MoQ group at every broadcast rate. v0.9.0
-  additionally offers paint-on and roll-up caption modes, which moqlivemock does
-  not use yet.
+  additionally offers paint-on and roll-up caption modes; moqlivemock now uses
+  paint-on (see `-cc608mode` above) and not roll-up.
 - Regenerated the AVC and HEVC `assets/test10s` tracks so they also carry the
   new codec overlay line.
 
@@ -520,6 +530,7 @@ Full [MOQ Transport draft-14][moqt-d14] compliance release.
 [moqtransport-eyevinn]: https://github.com/Eyevinn/moqtransport
 [interop-runner]: https://github.com/englishm/moq-interop-runner
 [interop-70]: https://github.com/englishm/moq-interop-runner/issues/70
+[issue-118]: https://github.com/Eyevinn/moqlivemock/issues/118
 [issue-122]: https://github.com/Eyevinn/moqlivemock/issues/122
 [moxygen-173]: https://github.com/facebookexperimental/moxygen/issues/173
 [wp]: https://github.com/Eyevinn/warp-player

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,16 +35,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   video track with an `accessibility` descriptor
   (`urn:scte:dash:cc:cea-608:2015`, `CC1=eng`); catalogless `moq-mi` signals
   nothing and is in-band only.
-- **`mlmpub -cc608mode paint-on|pop-on`** (default `paint-on`) selects how an
-  in-band CTA-608 caption reaches the screen. Paint-on clears the screen on the
-  group's first frame and then grows the caption two characters per frame, so it
-  is displayed over the second it names — at 25 fps the first characters land on
-  frame 4 and the caption is complete on frame 17 of 25. Pop-on builds the caption
-  invisibly and flips it on whole, which at 25 fps happens on frame 18, leaving
-  the caption reading `GRP n` on screen mostly during group *n+1*. Both modes keep
-  every group independent — a group's whole caption comes from that group's
-  samples alone — which is why paint-on is the default and why go-608's cross-unit
-  `WithFlipAtCueStart` is not used ([#118][issue-118]).
+- **`mlmpub -cc608mode paint-on|pop-on|roll-up2|roll-up3|roll-up4`** (default
+  `paint-on`, and bare `roll-up` means `roll-up2`) selects how an in-band CTA-608
+  caption reaches the screen, covering all three CTA-608 presentation styles.
+  Measured at 25 fps in a 25-frame group:
+  - `paint-on` clears the screen on the group's first frame and then grows the
+    caption two characters per frame, so it is displayed over the second it names:
+    the first characters land on frame 4 and the caption is complete on frame 17.
+  - `roll-up2/3/4` type onto the base row the same way but scroll the window up
+    before each line, finishing two frames later (frames 5 and 19) — the cost of
+    the extra carriage return per line. The digit is the window size. Because a
+    group holds one cue and the window is reset per group, the three sizes differ
+    in the RU2/RU3/RU4 mode code on the wire but display identically, which is
+    what makes them useful for exercising a decoder.
+  - `pop-on` builds the caption invisibly and flips it on whole, on frame 18,
+    leaving the caption reading `GRP n` on screen mostly during group *n+1*.
+
+  Every mode keeps each group independent — a group's whole caption comes from
+  that group's samples alone — which is why paint-on is the default and why
+  neither of go-608's cross-unit options is used: `WithFlipAtCueStart` would put a
+  pop-on group's build in its predecessor, and `WithRollUpCarry` would leave a
+  roll-up group's upper rows holding its predecessor's lines ([#118][issue-118]).
 
 ### Changed
 
@@ -60,8 +71,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   from the package's own `cc608.DefaultContent`, not go-608's default `Config`
   whose UTC line shortened to time-of-day, and the stricter `generate.NumCues`
   still yields one cue for a one-second MoQ group at every broadcast rate. v0.9.0
-  additionally offers paint-on and roll-up caption modes; moqlivemock now uses
-  paint-on (see `-cc608mode` above) and not roll-up.
+  additionally offers paint-on and roll-up caption generation, both now reachable
+  through `-cc608mode` (see above).
 - Regenerated the AVC and HEVC `assets/test10s` tracks so they also carry the
   new codec overlay line.
 

--- a/README.md
+++ b/README.md
@@ -187,10 +187,36 @@ rather than as a separate track:
 ./mlmpub -cc608
 ```
 
-One self-contained pop-on caption is generated per MoQ group (one wall-clock
-second), with the UTC time on row 13 (white) and the group number on row 14
-(yellow) — the same self-describing clock as the subtitle tracks, which makes
-caption timing directly verifiable against the picture.
+One self-contained caption is generated per MoQ group (one wall-clock second),
+with the UTC time on row 13 (white) and the group number on row 14 (yellow) — the
+same self-describing clock as the subtitle tracks, which makes caption timing
+directly verifiable against the picture.
+
+### Caption mode
+
+`-cc608mode` selects how the caption reaches the screen. Both modes keep every
+group independent: a group's whole caption is derivable from that group's samples
+alone, so a subscriber joining at an arbitrary group is correct immediately.
+
+| `-cc608mode` | On screen | Frame it lands on (25 fps, 1 s group) |
+|---|---|---|
+| `paint-on` (default) | Screen clears on the group's first frame, then the caption grows two characters per frame and stands for the rest of the group | first characters at frame 4, complete at frame 17 |
+| `pop-on` | Built invisibly, then the whole caption flips on at once — the classic broadcast style | nothing until frame 18, then displayed into the *next* group |
+
+```shell
+./mlmpub -cc608                      # paint-on
+./mlmpub -cc608 -cc608mode pop-on    # classic pop-on
+```
+
+Paint-on is the default because a MoQ group is one second and carries exactly one
+cue, so the visible transition decides the display interval. Its caption is
+displayed over the second it names; pop-on's build drains one byte pair per frame,
+so the flip lands three-quarters through the group and the caption reading
+`GRP n` is mostly on screen during group *n+1*. Aligning pop-on would mean
+spending the previous group's frames on this group's build (go-608's
+`WithFlipAtCueStart`), which is exactly the cross-group dependency that low
+latency and independent groups rule out. The progressive typing doubles as a
+liveness tell.
 
 All three video codecs carry the captions, in every packaging (CMAF, LOCMAF,
 LOC and moq-mi — note that moq-mi video is AVC-only) and including the encrypted

--- a/README.md
+++ b/README.md
@@ -194,18 +194,21 @@ directly verifiable against the picture.
 
 ### Caption mode
 
-`-cc608mode` selects how the caption reaches the screen. Both modes keep every
-group independent: a group's whole caption is derivable from that group's samples
-alone, so a subscriber joining at an arbitrary group is correct immediately.
+`-cc608mode` selects how the caption reaches the screen, covering all three
+CTA-608 presentation styles. Every mode keeps every group independent: a group's
+whole caption is derivable from that group's samples alone, so a subscriber
+joining at an arbitrary group is correct immediately.
 
 | `-cc608mode` | On screen | Frame it lands on (25 fps, 1 s group) |
 |---|---|---|
 | `paint-on` (default) | Screen clears on the group's first frame, then the caption grows two characters per frame and stands for the rest of the group | first characters at frame 4, complete at frame 17 |
+| `roll-up2`, `roll-up3`, `roll-up4` | Types onto the base row the same way, but scrolls the window up before each line instead of clearing the screen. The digit is the window size (RU2/RU3/RU4); bare `roll-up` means `roll-up2` | first characters at frame 5, complete at frame 19 |
 | `pop-on` | Built invisibly, then the whole caption flips on at once — the classic broadcast style | nothing until frame 18, then displayed into the *next* group |
 
 ```shell
-./mlmpub -cc608                      # paint-on
-./mlmpub -cc608 -cc608mode pop-on    # classic pop-on
+./mlmpub -cc608                       # paint-on
+./mlmpub -cc608 -cc608mode roll-up3   # roll-up, 3-row window
+./mlmpub -cc608 -cc608mode pop-on     # classic pop-on
 ```
 
 Paint-on is the default because a MoQ group is one second and carries exactly one
@@ -217,6 +220,22 @@ spending the previous group's frames on this group's build (go-608's
 `WithFlipAtCueStart`), which is exactly the cross-group dependency that low
 latency and independent groups rule out. The progressive typing doubles as a
 liveness tell.
+
+Roll-up animates like paint-on and finishes two frames later, the cost of the
+extra carriage return it sends per line. Two details are worth knowing:
+
+* **The window size changes the wire, not the picture.** With one cue per group
+  and the window reset at each group's first frame, only the two rows a group
+  writes for itself are ever filled, so `roll-up2`, `roll-up3` and `roll-up4`
+  display identically here. What differs is the RU2/RU3/RU4 mode code the
+  decoder receives, which is the point for exercising a decoder against all
+  three.
+* **The window is reset per group, not carried.** go-608 can carry a roll-up
+  window across units (`WithRollUpCarry`), which is how broadcast roll-up fills
+  to its full depth — but the displayed rows would then depend on the preceding
+  groups, and a subscriber joining mid-stream would see a partly filled window.
+  moqlivemock always resets, keeping groups independent in display as well as in
+  data.
 
 All three video codecs carry the captions, in every packaging (CMAF, LOCMAF,
 LOC and moq-mi — note that moq-mi video is AVC-only) and including the encrypted

--- a/cmd/mlmpub/main.go
+++ b/cmd/mlmpub/main.go
@@ -64,6 +64,7 @@ type options struct {
 	laURL            string
 	drmConfigPath    string
 	cc608            bool
+	cc608Mode        string
 	version          bool
 }
 
@@ -96,6 +97,9 @@ func parseOptions(fs *flag.FlagSet, args []string) (*options, error) {
 	fs.StringVar(&opts.drmConfigPath, "drmpath", "", "path to a drm config file")
 	fs.BoolVar(&opts.cc608, "cc608", false,
 		"inject auto-generated CTA-608 CC1 captions into AVC, HEVC and AV1 video")
+	fs.StringVar(&opts.cc608Mode, "cc608mode", "",
+		fmt.Sprintf("CTA-608 caption delivery mode: %s (default %s). Requires -cc608",
+			strings.Join(cc608.ModeNames(), " or "), cc608.ModePaintOn))
 	fs.BoolVar(&opts.version, "version", false, fmt.Sprintf("Get %s version", appName))
 	err := fs.Parse(args[1:])
 	return &opts, err
@@ -190,9 +194,17 @@ func runServer(opts *options) error {
 	// Enable in-band CTA-608 caption injection on video tracks when requested.
 	// A nil generator (the default) is a complete no-op; the codec gate is
 	// applied per track at serve time.
+	ccMode, err := cc608.ParseMode(opts.cc608Mode)
+	if err != nil {
+		return err
+	}
+	if opts.cc608Mode != "" && !opts.cc608 {
+		return fmt.Errorf("-cc608mode %s requires -cc608", opts.cc608Mode)
+	}
 	if opts.cc608 {
-		asset.SetCC608Generator(cc608.New(cc608.Config{Enabled: true}))
-		slog.Info("enabled CTA-608 caption injection (CC1) on AVC, HEVC and AV1 video tracks")
+		asset.SetCC608Generator(cc608.New(cc608.Config{Enabled: true, Mode: ccMode}))
+		slog.Info("enabled CTA-608 caption injection (CC1) on AVC, HEVC and AV1 video tracks",
+			"mode", ccMode)
 	}
 
 	now := time.Now().UnixMilli()

--- a/cmd/mlmpub/main.go
+++ b/cmd/mlmpub/main.go
@@ -98,8 +98,8 @@ func parseOptions(fs *flag.FlagSet, args []string) (*options, error) {
 	fs.BoolVar(&opts.cc608, "cc608", false,
 		"inject auto-generated CTA-608 CC1 captions into AVC, HEVC and AV1 video")
 	fs.StringVar(&opts.cc608Mode, "cc608mode", "",
-		fmt.Sprintf("CTA-608 caption delivery mode: %s (default %s). Requires -cc608",
-			strings.Join(cc608.ModeNames(), " or "), cc608.ModePaintOn))
+		fmt.Sprintf("CTA-608 caption delivery mode: %s (default %s; \"roll-up\" means roll-up2)."+
+			" Requires -cc608", strings.Join(cc608.ModeNames(), ", "), cc608.ModePaintOn))
 	fs.BoolVar(&opts.version, "version", false, fmt.Sprintf("Get %s version", appName))
 	err := fs.Parse(args[1:])
 	return &opts, err

--- a/internal/cc608/cc608.go
+++ b/internal/cc608/cc608.go
@@ -1,11 +1,12 @@
 // Package cc608 generates in-band CTA-608 closed captions for moqlivemock video.
 //
 // It is a thin, serve-path-agnostic wrapper over the Eyevinn/go-608 library. For
-// one MoQ group (== one wall-clock second) it builds a self-contained pop-on
-// caption via go-608's per-unit cue mechanism and returns one caption envelope
-// per video frame. The caller splices each envelope into the frame's coded
-// sample with Splice. Wiring this into the publisher/catalog is a separate
-// concern; this package only produces the caption bytes.
+// one MoQ group (== one wall-clock second) it builds a self-contained caption via
+// go-608's per-unit cue mechanism — painted on progressively or popped on whole,
+// see Mode — and returns one caption envelope per video frame. The caller splices
+// each envelope into the frame's coded sample with Splice. Wiring this into the
+// publisher/catalog is a separate concern; this package only produces the caption
+// bytes.
 //
 // The three supported codecs share one cc_data() payload but not one envelope:
 // AVC and HEVC carry it in an SEI NAL unit, AV1 in a metadata_itu_t_t35 OBU.
@@ -22,11 +23,12 @@ import (
 	"github.com/Eyevinn/go-608/carriage"
 	"github.com/Eyevinn/go-608/cta608"
 	"github.com/Eyevinn/go-608/generate"
+	"github.com/Eyevinn/go-608/schedule"
 )
 
 // targetPeriodMS is the nominal caption update period handed to go-608. A MoQ
 // group is one second (MoqGroupDurMS), so with a 1000 ms period NumCues resolves
-// to exactly one cue per group: one self-contained pop-on caption per group.
+// to exactly one cue per group: one self-contained caption per group.
 const targetPeriodMS = 1000
 
 // Caption rows (1..15, 15 = bottom). The two lines sit near the bottom but leave
@@ -58,6 +60,8 @@ type Config struct {
 	Lang string
 	// Content formats each cue's lines. Nil selects DefaultContent.
 	Content generate.CueContentFunc
+	// Mode selects paint-on or pop-on delivery. The zero value is ModePaintOn.
+	Mode Mode
 }
 
 // Generator produces per-frame CTA-608 caption envelopes for MoQ groups. A nil
@@ -69,6 +73,7 @@ type Generator struct {
 	channel int
 	lang    string
 	content generate.CueContentFunc
+	mode    Mode
 }
 
 // New returns a Generator from cfg, filling in the CC1/"eng"/DefaultContent
@@ -91,6 +96,7 @@ func New(cfg Config) *Generator {
 		channel: channel,
 		lang:    lang,
 		content: content,
+		mode:    cfg.Mode,
 	}
 }
 
@@ -104,12 +110,19 @@ func (g *Generator) Channel() int { return g.channel }
 // Lang returns the advertised caption language tag.
 func (g *Generator) Lang() string { return g.lang }
 
+// Mode returns the caption delivery mode.
+func (g *Generator) Mode() Mode { return g.mode }
+
 // Schedule builds one group's captions and returns one caption envelope per
 // video frame (len == nFrames), ready to splice into the frame's coded sample
 // with Splice: a bare SEI NAL unit for AVC/HEVC, a metadata_itu_t_t35 OBU for
 // AV1. groupNr is the MoQ group number (== unix seconds); the group's captions
 // start at wall-clock groupNr*1000 ms. fps is the video frame rate and nFrames
 // the number of frames in the group.
+//
+// The group's caption is whole and self-contained in either Mode, so the result
+// depends only on this group's number — never on a neighbouring group — which is
+// what lets a subscriber join at an arbitrary group.
 //
 // It returns nil when captions are off (nil or disabled Generator), when
 // nFrames <= 0, when codec is not one of the three supported values, or when
@@ -121,7 +134,17 @@ func (g *Generator) Schedule(groupNr int64, fps float64, nFrames int, codec Code
 		return nil
 	}
 	unit := generate.Unit{Nr: groupNr, StartMS: groupNr * 1000, Frames: nFrames}
-	frames, err := generate.BuildUnitCues(fps, unit, targetPeriodMS, g.content)
+	// The two builders take the same arguments and return the same per-frame
+	// slice; only what the decoder does with the pairs differs. Neither is passed
+	// a cross-unit option (go-608's WithFlipAtCueStart), which is what keeps a
+	// group's caption derivable from that group alone.
+	var frames []schedule.Frame
+	var err error
+	if g.mode == ModePopOn {
+		frames, err = generate.BuildUnitCues(fps, unit, targetPeriodMS, g.content)
+	} else {
+		frames, err = generate.BuildUnitPaintCues(fps, unit, targetPeriodMS, g.content)
+	}
 	if err != nil {
 		return nil
 	}
@@ -140,7 +163,7 @@ func (g *Generator) Schedule(groupNr int64, fps float64, nFrames int, codec Code
 	return out
 }
 
-// DefaultContent is the built-in CueContentFunc: two centered pop-on lines per
+// DefaultContent is the built-in CueContentFunc: two centered lines per
 // cue. Row 13 (white) is the cue's UTC wall-clock time HH:MM:SS.mmm; row 14
 // (yellow) is "GRP <n>" where n is u.Nr, the MoQ group number (== unix seconds),
 // so the caption is a self-describing clock. cueIdx is unused: with one cue per

--- a/internal/cc608/cc608.go
+++ b/internal/cc608/cc608.go
@@ -2,8 +2,8 @@
 //
 // It is a thin, serve-path-agnostic wrapper over the Eyevinn/go-608 library. For
 // one MoQ group (== one wall-clock second) it builds a self-contained caption via
-// go-608's per-unit cue mechanism — painted on progressively or popped on whole,
-// see Mode — and returns one caption envelope per video frame. The caller splices
+// go-608's per-unit cue mechanism — painted on progressively, rolled up, or popped
+// on whole, see Mode — and returns one caption envelope per video frame. The caller splices
 // each envelope into the frame's coded sample with Splice. Wiring this into the
 // publisher/catalog is a separate concern; this package only produces the caption
 // bytes.
@@ -134,15 +134,19 @@ func (g *Generator) Schedule(groupNr int64, fps float64, nFrames int, codec Code
 		return nil
 	}
 	unit := generate.Unit{Nr: groupNr, StartMS: groupNr * 1000, Frames: nFrames}
-	// The two builders take the same arguments and return the same per-frame
-	// slice; only what the decoder does with the pairs differs. Neither is passed
-	// a cross-unit option (go-608's WithFlipAtCueStart), which is what keeps a
-	// group's caption derivable from that group alone.
+	// The three builders take the same arguments (roll-up adds its window size)
+	// and return the same per-frame slice; only what the decoder does with the
+	// pairs differs. None is passed a cross-unit option — not go-608's
+	// WithFlipAtCueStart for pop-on, nor WithRollUpCarry for roll-up — which is
+	// what keeps a group's caption derivable from that group alone.
 	var frames []schedule.Frame
 	var err error
-	if g.mode == ModePopOn {
+	switch rows, isRollUp := g.mode.rollUpRows(); {
+	case isRollUp:
+		frames, err = generate.BuildUnitRollUpCues(fps, unit, targetPeriodMS, rows, g.content)
+	case g.mode == ModePopOn:
 		frames, err = generate.BuildUnitCues(fps, unit, targetPeriodMS, g.content)
-	} else {
+	default:
 		frames, err = generate.BuildUnitPaintCues(fps, unit, targetPeriodMS, g.content)
 	}
 	if err != nil {

--- a/internal/cc608/cc608_test.go
+++ b/internal/cc608/cc608_test.go
@@ -60,6 +60,10 @@ func assertLine(t *testing.T, name string, ln cta608.Line, row int, color cta608
 	}
 }
 
+// allModes is every -cc608mode value. Tests that assert a property all modes must
+// share iterate this, so a mode added later is covered without being remembered.
+var allModes = []Mode{ModePaintOn, ModePopOn, ModeRollUp2, ModeRollUp3, ModeRollUp4}
+
 // decodeSchedule replays a group's envelopes through the full carriage +
 // cta608.Decoder path with a fresh decoder, and reports per frame what the
 // displayed screen held. Feeding one group only makes every assertion built on
@@ -110,11 +114,18 @@ func decodeSchedule(t *testing.T, envelopes [][]byte, codec Codec) (
 }
 
 // TestScheduleRoundTrip builds a group's caption schedule at two frame rates in
-// both modes and decodes it back through the full carriage + cta608.Decoder path
+// every mode and decodes it back through the full carriage + cta608.Decoder path
 // for all three codecs, checking that the group reconstructs the expected CC1
 // caption (round trip) and that returning nFrames envelopes proves no Overran
 // occurred. The AV1 case exercises the metadata-OBU envelope, which carries the
 // identical cc_data() and so must decode to the identical caption.
+//
+// Roll-up matters here beyond the round trip: it is the tightest of the three on
+// the pair budget (a mode entry per cue plus a CR per line), so a caption that
+// grows would fail this first, and its lines are written in Row order onto a
+// scrolling window rather than positioned absolutely — the assertion that rows 13
+// and 14 still end up holding the clock and the group tag is what pins that the
+// window lays out the way the content declares.
 func TestScheduleRoundTrip(t *testing.T) {
 	const groupNr = 45296 // 12:34:56 UTC
 	cases := []struct {
@@ -128,7 +139,7 @@ func TestScheduleRoundTrip(t *testing.T) {
 		{"25fps av1", 25.0, 25, CodecAV1},
 		{"30fps av1", 30.0, 30, CodecAV1},
 	}
-	for _, mode := range []Mode{ModePaintOn, ModePopOn} {
+	for _, mode := range allModes {
 		g := New(Config{Enabled: true, Mode: mode})
 		for _, c := range cases {
 			t.Run(mode.String()+"/"+c.name, func(t *testing.T) {
@@ -163,11 +174,11 @@ func TestScheduleRoundTrip(t *testing.T) {
 }
 
 // TestScheduleModeDisplayTiming pins the difference the mode choice is made for.
-// Both modes finish the caption inside its own group, but paint-on starts putting
-// it on screen in the group's first frames, while pop-on shows nothing until its
-// EOC flips the finished caption on around three-quarters through — so the
-// caption paint-on displays over the second it names, pop-on displays mostly over
-// the following one.
+// Every mode finishes the caption inside its own group, but the progressive modes
+// (paint-on and roll-up) start putting it on screen in the group's first frames,
+// while pop-on shows nothing until its EOC flips the finished caption on around
+// three-quarters through — so a progressive caption is displayed over the second
+// it names, and pop-on's mostly over the following one.
 //
 // The frame numbers are deliberately loose bounds, not exact indices: the point
 // is which half of the group the caption lands in, and an exact index would break
@@ -204,6 +215,35 @@ func TestScheduleModeDisplayTiming(t *testing.T) {
 			wantChanges:   func(n int) bool { return n == 1 },
 			changesDesc:   "exactly one (the whole caption flips on at once)",
 		},
+		// Roll-up types onto a scrolling window, so it animates like paint-on. It
+		// pays a CR per line on top of paint-on's two control pairs, which is why
+		// it may finish later — but still inside its own group. All three window
+		// sizes carry the same two lines and so share these bounds; only the RU
+		// code on the wire differs.
+		{
+			mode:          ModeRollUp2,
+			maxFirstText:  nFrames / 4,
+			minCompleteAt: 1,
+			maxCompleteAt: nFrames - 1,
+			wantChanges:   func(n int) bool { return n > 1 },
+			changesDesc:   "more than one (the base row grows two characters at a time)",
+		},
+		{
+			mode:          ModeRollUp3,
+			maxFirstText:  nFrames / 4,
+			minCompleteAt: 1,
+			maxCompleteAt: nFrames - 1,
+			wantChanges:   func(n int) bool { return n > 1 },
+			changesDesc:   "more than one (the base row grows two characters at a time)",
+		},
+		{
+			mode:          ModeRollUp4,
+			maxFirstText:  nFrames / 4,
+			minCompleteAt: 1,
+			maxCompleteAt: nFrames - 1,
+			wantChanges:   func(n int) bool { return n > 1 },
+			changesDesc:   "more than one (the base row grows two characters at a time)",
+		},
 	} {
 		t.Run(c.mode.String(), func(t *testing.T) {
 			g := New(Config{Enabled: true, Mode: c.mode})
@@ -231,15 +271,21 @@ func TestScheduleModeDisplayTiming(t *testing.T) {
 // TestScheduleSelfContained is the independent-group guarantee: consecutive
 // groups each carry their own whole caption, so a fresh decoder fed one group in
 // isolation — a subscriber joining there — reconstructs that group's caption and
-// no other. Neither mode is passed a cross-unit option, so this must hold for
-// both; it is the property #118's pop-on preload would have traded away.
+// no other. No mode is passed a cross-unit option, so this must hold for every
+// one of them.
+//
+// The two options omitted are the two ways it could break, and each belongs to a
+// different mode: WithFlipAtCueStart would put a pop-on group's build in its
+// predecessor (the trade #118 proposed), and WithRollUpCarry would leave a
+// roll-up group's upper rows holding its predecessor's lines. Running the whole
+// mode set through this is what keeps either from being adopted unnoticed.
 func TestScheduleSelfContained(t *testing.T) {
 	const (
 		firstGroup = 45296 // 12:34:56 UTC
 		fps        = 25.0
 		nFrames    = 25
 	)
-	for _, mode := range []Mode{ModePaintOn, ModePopOn} {
+	for _, mode := range allModes {
 		for _, codec := range []Codec{CodecAVC, CodecHEVC, CodecAV1} {
 			t.Run(mode.String()+"/"+codec.String(), func(t *testing.T) {
 				g := New(Config{Enabled: true, Mode: mode})
@@ -365,9 +411,14 @@ func TestParseMode(t *testing.T) {
 		{"", ModePaintOn, false},
 		{"paint-on", ModePaintOn, false},
 		{"pop-on", ModePopOn, false},
+		{"roll-up2", ModeRollUp2, false},
+		{"roll-up3", ModeRollUp3, false},
+		{"roll-up4", ModeRollUp4, false},
+		{"roll-up", ModeRollUp2, false}, // go608-clock's spelling; 2 is its zero value
 		{"paint_on", 0, true},
 		{"PAINT-ON", 0, true},
-		{"roll-up", 0, true},
+		{"roll-up5", 0, true}, // outside go-608's 2..4 window range
+		{"roll-up1", 0, true},
 	} {
 		got, err := ParseMode(c.in)
 		if c.wantErr {
@@ -389,8 +440,33 @@ func TestParseMode(t *testing.T) {
 	if New(Config{Enabled: true}).Mode() != ModePaintOn {
 		t.Errorf("default Mode = %v, want %v", New(Config{Enabled: true}).Mode(), ModePaintOn)
 	}
-	if names := ModeNames(); len(names) != 2 || names[0] != "paint-on" {
-		t.Errorf("ModeNames() = %v, want the default first", names)
+	if names := ModeNames(); len(names) != 5 || names[0] != "paint-on" {
+		t.Errorf("ModeNames() = %v, want 5 canonical names with the default first", names)
+	}
+	// String must give back the canonical spelling, never the "roll-up" alias.
+	for _, c := range []struct {
+		mode Mode
+		want string
+	}{
+		{ModePaintOn, "paint-on"}, {ModePopOn, "pop-on"},
+		{ModeRollUp2, "roll-up2"}, {ModeRollUp3, "roll-up3"}, {ModeRollUp4, "roll-up4"},
+	} {
+		if got := c.mode.String(); got != c.want {
+			t.Errorf("Mode.String() = %q, want %q", got, c.want)
+		}
+	}
+	// The window size must match the mode's name, since it picks the RU code.
+	for _, c := range []struct {
+		mode     Mode
+		wantRows int
+		wantOK   bool
+	}{
+		{ModeRollUp2, 2, true}, {ModeRollUp3, 3, true}, {ModeRollUp4, 4, true},
+		{ModePaintOn, 0, false}, {ModePopOn, 0, false},
+	} {
+		if rows, ok := c.mode.rollUpRows(); rows != c.wantRows || ok != c.wantOK {
+			t.Errorf("%v.rollUpRows() = %d, %v; want %d, %v", c.mode, rows, ok, c.wantRows, c.wantOK)
+		}
 	}
 	if got := Mode(42).String(); got != "Mode(42)" {
 		t.Errorf("Mode(42).String() = %q", got)

--- a/internal/cc608/cc608_test.go
+++ b/internal/cc608/cc608_test.go
@@ -60,12 +60,61 @@ func assertLine(t *testing.T, name string, ln cta608.Line, row int, color cta608
 	}
 }
 
-// TestScheduleRoundTrip builds a group's caption schedule at two frame rates and
-// decodes it back through the full carriage + cta608.Decoder path for all three
-// codecs, checking that the group's single pop-on flip reconstructs the expected
-// CC1 caption (round trip) and that returning nFrames envelopes proves no
-// Overran occurred. The AV1 case exercises the metadata-OBU envelope, which
-// carries the identical cc_data() and so must decode to the identical caption.
+// decodeSchedule replays a group's envelopes through the full carriage +
+// cta608.Decoder path with a fresh decoder, and reports per frame what the
+// displayed screen held. Feeding one group only makes every assertion built on
+// the result also an assertion that the group is self-contained.
+//
+// firstText is the frame at which any of the caption's characters first reach the
+// screen and completeAt the frame at which both rows are finished; both are -1 if
+// that never happens. The rows are those left displayed by the last frame.
+func decodeSchedule(t *testing.T, envelopes [][]byte, codec Codec) (
+	changes, firstText, completeAt int, gotTime, gotGroup string,
+	timeColor, groupColor cta608.Color,
+) {
+	t.Helper()
+	firstText, completeAt = -1, -1
+	var dec cta608.Decoder
+	for i, env := range envelopes {
+		// A bare envelope is not a coded sample, so feed it to the decoder as the
+		// only thing in one: an AV1 metadata OBU already is a valid (frameless)
+		// OBU sequence, while an SEI NAL unit needs its 4-byte length prefix to
+		// form a NAL stream.
+		sample := env
+		if codec != CodecAV1 {
+			sample = carriage.PrefixNALUs(env)
+		}
+		f1, _, err := FieldPairs(sample, codec)
+		if err != nil {
+			t.Fatalf("frame %d FieldPairs: %v", i, err)
+		}
+		if len(f1) == 0 {
+			continue
+		}
+		if err := dec.Feed(f1); err != nil {
+			t.Fatalf("frame %d decode: %v", i, err)
+		}
+		if dec.Changed() {
+			changes++
+		}
+		gotTime, timeColor, _ = rowText(dec.Screen(), captionRowTime)
+		gotGroup, groupColor, _ = rowText(dec.Screen(), captionRowGroup)
+		if firstText < 0 && (gotTime != "" || gotGroup != "") {
+			firstText = i
+		}
+		if completeAt < 0 && gotTime == "12:34:56.000" && gotGroup == "GRP 45296" {
+			completeAt = i
+		}
+	}
+	return changes, firstText, completeAt, gotTime, gotGroup, timeColor, groupColor
+}
+
+// TestScheduleRoundTrip builds a group's caption schedule at two frame rates in
+// both modes and decodes it back through the full carriage + cta608.Decoder path
+// for all three codecs, checking that the group reconstructs the expected CC1
+// caption (round trip) and that returning nFrames envelopes proves no Overran
+// occurred. The AV1 case exercises the metadata-OBU envelope, which carries the
+// identical cc_data() and so must decode to the identical caption.
 func TestScheduleRoundTrip(t *testing.T) {
 	const groupNr = 45296 // 12:34:56 UTC
 	cases := []struct {
@@ -79,59 +128,141 @@ func TestScheduleRoundTrip(t *testing.T) {
 		{"25fps av1", 25.0, 25, CodecAV1},
 		{"30fps av1", 30.0, 30, CodecAV1},
 	}
-	g := New(Config{Enabled: true})
-	for _, c := range cases {
-		t.Run(c.name, func(t *testing.T) {
-			envelopes := g.Schedule(groupNr, c.fps, c.nFrames, c.codec)
-			if len(envelopes) != c.nFrames {
-				t.Fatalf("got %d envelopes, want %d (nil => build error / Overran)", len(envelopes), c.nFrames)
-			}
+	for _, mode := range []Mode{ModePaintOn, ModePopOn} {
+		g := New(Config{Enabled: true, Mode: mode})
+		for _, c := range cases {
+			t.Run(mode.String()+"/"+c.name, func(t *testing.T) {
+				envelopes := g.Schedule(groupNr, c.fps, c.nFrames, c.codec)
+				if len(envelopes) != c.nFrames {
+					t.Fatalf("got %d envelopes, want %d (nil => build error / Overran)", len(envelopes), c.nFrames)
+				}
 
-			var dec cta608.Decoder
-			flips := 0
-			var gotTime, gotGroup string
-			var timeColor, groupColor cta608.Color
-			for i, env := range envelopes {
-				// A bare envelope is not a coded sample, so feed it to the
-				// decoder as the only thing in one: an AV1 metadata OBU already
-				// is a valid (frameless) OBU sequence, while an SEI NAL unit
-				// needs its 4-byte length prefix to form a NAL stream.
-				sample := env
-				if c.codec != CodecAV1 {
-					sample = carriage.PrefixNALUs(env)
+				changes, _, completeAt, gotTime, gotGroup, timeColor, groupColor :=
+					decodeSchedule(t, envelopes, c.codec)
+				if changes == 0 {
+					t.Fatal("the caption never reached the screen")
 				}
-				f1, _, err := FieldPairs(sample, c.codec)
-				if err != nil {
-					t.Fatalf("frame %d FieldPairs: %v", i, err)
+				if completeAt < 0 {
+					t.Errorf("caption never completed; ended as row13 = %q, row14 = %q", gotTime, gotGroup)
 				}
-				if len(f1) == 0 {
-					continue
+				if gotTime != "12:34:56.000" {
+					t.Errorf("row13 = %q, want %q", gotTime, "12:34:56.000")
 				}
-				if err := dec.Feed(f1); err != nil {
-					t.Fatalf("frame %d decode: %v", i, err)
+				if gotGroup != "GRP 45296" {
+					t.Errorf("row14 = %q, want %q", gotGroup, "GRP 45296")
 				}
-				if dec.Changed() {
-					flips++
-					gotTime, timeColor, _ = rowText(dec.Screen(), captionRowTime)
-					gotGroup, groupColor, _ = rowText(dec.Screen(), captionRowGroup)
+				if timeColor != cta608.White {
+					t.Errorf("row13 color = %v, want white", timeColor)
 				}
+				if groupColor != cta608.Yellow {
+					t.Errorf("row14 color = %v, want yellow", groupColor)
+				}
+			})
+		}
+	}
+}
+
+// TestScheduleModeDisplayTiming pins the difference the mode choice is made for.
+// Both modes finish the caption inside its own group, but paint-on starts putting
+// it on screen in the group's first frames, while pop-on shows nothing until its
+// EOC flips the finished caption on around three-quarters through — so the
+// caption paint-on displays over the second it names, pop-on displays mostly over
+// the following one.
+//
+// The frame numbers are deliberately loose bounds, not exact indices: the point
+// is which half of the group the caption lands in, and an exact index would break
+// on any harmless change to the caption text's length.
+func TestScheduleModeDisplayTiming(t *testing.T) {
+	const (
+		groupNr = 45296
+		fps     = 25.0
+		nFrames = 25
+	)
+	for _, c := range []struct {
+		mode Mode
+		// maxFirstText bounds when any character may first appear, and
+		// minCompleteAt/maxCompleteAt bracket when the caption must be finished.
+		maxFirstText  int
+		minCompleteAt int
+		maxCompleteAt int
+		wantChanges   func(int) bool
+		changesDesc   string
+	}{
+		{
+			mode:          ModePaintOn,
+			maxFirstText:  nFrames / 4, // visible early in its own group
+			minCompleteAt: 1,
+			maxCompleteAt: nFrames - 2, // and finished with frames to spare
+			wantChanges:   func(n int) bool { return n > 1 },
+			changesDesc:   "more than one (the screen grows two characters at a time)",
+		},
+		{
+			mode:          ModePopOn,
+			maxFirstText:  nFrames - 1,
+			minCompleteAt: nFrames / 2, // nothing on screen until the late flip
+			maxCompleteAt: nFrames - 1,
+			wantChanges:   func(n int) bool { return n == 1 },
+			changesDesc:   "exactly one (the whole caption flips on at once)",
+		},
+	} {
+		t.Run(c.mode.String(), func(t *testing.T) {
+			g := New(Config{Enabled: true, Mode: c.mode})
+			envelopes := g.Schedule(groupNr, fps, nFrames, CodecAVC)
+			if len(envelopes) != nFrames {
+				t.Fatalf("got %d envelopes, want %d", len(envelopes), nFrames)
 			}
-			if flips != 1 {
-				t.Fatalf("got %d on-screen flips, want 1 (one cue per group)", flips)
+			changes, firstText, completeAt, _, _, _, _ := decodeSchedule(t, envelopes, CodecAVC)
+
+			if !c.wantChanges(changes) {
+				t.Errorf("screen changed %d times, want %s", changes, c.changesDesc)
 			}
-			if gotTime != "12:34:56.000" {
-				t.Errorf("row13 = %q, want %q", gotTime, "12:34:56.000")
+			if firstText < 0 || firstText > c.maxFirstText {
+				t.Errorf("caption first visible at frame %d, want 0..%d of %d",
+					firstText, c.maxFirstText, nFrames)
 			}
-			if gotGroup != "GRP 45296" {
-				t.Errorf("row14 = %q, want %q", gotGroup, "GRP 45296")
-			}
-			if timeColor != cta608.White {
-				t.Errorf("row13 color = %v, want white", timeColor)
-			}
-			if groupColor != cta608.Yellow {
-				t.Errorf("row14 color = %v, want yellow", groupColor)
+			if completeAt < c.minCompleteAt || completeAt > c.maxCompleteAt {
+				t.Errorf("caption complete at frame %d, want %d..%d of %d",
+					completeAt, c.minCompleteAt, c.maxCompleteAt, nFrames)
 			}
 		})
+	}
+}
+
+// TestScheduleSelfContained is the independent-group guarantee: consecutive
+// groups each carry their own whole caption, so a fresh decoder fed one group in
+// isolation — a subscriber joining there — reconstructs that group's caption and
+// no other. Neither mode is passed a cross-unit option, so this must hold for
+// both; it is the property #118's pop-on preload would have traded away.
+func TestScheduleSelfContained(t *testing.T) {
+	const (
+		firstGroup = 45296 // 12:34:56 UTC
+		fps        = 25.0
+		nFrames    = 25
+	)
+	for _, mode := range []Mode{ModePaintOn, ModePopOn} {
+		for _, codec := range []Codec{CodecAVC, CodecHEVC, CodecAV1} {
+			t.Run(mode.String()+"/"+codec.String(), func(t *testing.T) {
+				g := New(Config{Enabled: true, Mode: mode})
+				for offset, want := range []struct{ time, group string }{
+					{"12:34:56.000", "GRP 45296"},
+					{"12:34:57.000", "GRP 45297"},
+					{"12:34:58.000", "GRP 45298"},
+				} {
+					groupNr := int64(firstGroup + offset)
+					envelopes := g.Schedule(groupNr, fps, nFrames, codec)
+					if len(envelopes) != nFrames {
+						t.Fatalf("group %d: got %d envelopes, want %d", groupNr, len(envelopes), nFrames)
+					}
+					// A fresh decoder per group: no state carried in from the
+					// previous one, as for a subscriber joining at this group.
+					_, _, _, gotTime, gotGroup, _, _ := decodeSchedule(t, envelopes, codec)
+					if gotTime != want.time || gotGroup != want.group {
+						t.Errorf("group %d decoded to %q / %q, want %q / %q",
+							groupNr, gotTime, gotGroup, want.time, want.group)
+					}
+				}
+			})
+		}
 	}
 }
 
@@ -221,4 +352,47 @@ func rowText(s cta608.Screen, idx int) (text string, color cta608.Color, ok bool
 		return text, color, true
 	}
 	return "", cta608.ColDefault, false
+}
+
+// TestParseMode covers the -cc608mode flag values, including the empty string a
+// caller passes for an unset flag, which must select the default.
+func TestParseMode(t *testing.T) {
+	for _, c := range []struct {
+		in      string
+		want    Mode
+		wantErr bool
+	}{
+		{"", ModePaintOn, false},
+		{"paint-on", ModePaintOn, false},
+		{"pop-on", ModePopOn, false},
+		{"paint_on", 0, true},
+		{"PAINT-ON", 0, true},
+		{"roll-up", 0, true},
+	} {
+		got, err := ParseMode(c.in)
+		if c.wantErr {
+			if err == nil {
+				t.Errorf("ParseMode(%q) = %v, want an error", c.in, got)
+			}
+			continue
+		}
+		if err != nil {
+			t.Errorf("ParseMode(%q): %v", c.in, err)
+			continue
+		}
+		if got != c.want {
+			t.Errorf("ParseMode(%q) = %v, want %v", c.in, got, c.want)
+		}
+	}
+
+	// The zero Mode must be the default, so Config{Enabled: true} means paint-on.
+	if New(Config{Enabled: true}).Mode() != ModePaintOn {
+		t.Errorf("default Mode = %v, want %v", New(Config{Enabled: true}).Mode(), ModePaintOn)
+	}
+	if names := ModeNames(); len(names) != 2 || names[0] != "paint-on" {
+		t.Errorf("ModeNames() = %v, want the default first", names)
+	}
+	if got := Mode(42).String(); got != "Mode(42)" {
+		t.Errorf("Mode(42).String() = %q", got)
+	}
 }

--- a/internal/cc608/mode.go
+++ b/internal/cc608/mode.go
@@ -1,0 +1,81 @@
+package cc608
+
+import "fmt"
+
+// Mode selects how a group's caption reaches the screen. Both modes produce one
+// self-contained cue per MoQ group and differ only in what the decoder does with
+// the pairs as they arrive.
+//
+// The distinction matters because a MoQ group is one wall-clock second and
+// carries exactly one cue, so a caption's display interval is decided entirely
+// by where inside its group the visible transition falls:
+//
+//   - ModePaintOn writes onto the displayed screen, two characters per frame, so
+//     the caption starts appearing on the group's first frame and is complete for
+//     the group's tail. Display therefore coincides with the second the caption
+//     names.
+//   - ModePopOn builds in non-displayed memory and flips the whole caption on
+//     with an EOC. The build drains one pair per frame, so the flip lands around
+//     frame 18 of 25 and the caption is displayed from three-quarters through the
+//     group it names until the same point in the next one. Aligning it would mean
+//     spending the previous group's frames on this group's build (go-608's
+//     WithFlipAtCueStart), which is exactly the cross-group dependency the
+//     independent-group model avoids.
+//
+// Both keep every group independently decodable: a subscriber joining at an
+// arbitrary group gets that group's whole caption from that group's samples.
+type Mode int
+
+const (
+	// ModePaintOn paints the caption on progressively, two characters per frame,
+	// after clearing the screen on the group's first frame. The default: display
+	// lines up with the group, and the visible typing doubles as a liveness tell.
+	ModePaintOn Mode = iota
+	// ModePopOn builds the caption in non-displayed memory and flips it on whole,
+	// the classic broadcast style. Displayed late relative to its own group; see
+	// the Mode doc.
+	ModePopOn
+)
+
+// modeNames pairs each Mode with its flag spelling. The slice, not a map, so
+// ModeNames' output order is fixed and puts the default first.
+var modeNames = []struct {
+	mode Mode
+	name string
+}{
+	{ModePaintOn, "paint-on"},
+	{ModePopOn, "pop-on"},
+}
+
+func (m Mode) String() string {
+	for _, mn := range modeNames {
+		if mn.mode == m {
+			return mn.name
+		}
+	}
+	return fmt.Sprintf("Mode(%d)", int(m))
+}
+
+// ParseMode maps a flag value onto a Mode. An empty string selects the default
+// (ModePaintOn) so that a caller can pass an unset flag straight through.
+func ParseMode(s string) (Mode, error) {
+	if s == "" {
+		return ModePaintOn, nil
+	}
+	for _, mn := range modeNames {
+		if mn.name == s {
+			return mn.mode, nil
+		}
+	}
+	return 0, fmt.Errorf("unknown CTA-608 caption mode %q, expected one of %v", s, ModeNames())
+}
+
+// ModeNames lists the accepted flag values, default first, for flag help and
+// error messages.
+func ModeNames() []string {
+	names := make([]string, 0, len(modeNames))
+	for _, mn := range modeNames {
+		names = append(names, mn.name)
+	}
+	return names
+}

--- a/internal/cc608/mode.go
+++ b/internal/cc608/mode.go
@@ -2,9 +2,9 @@ package cc608
 
 import "fmt"
 
-// Mode selects how a group's caption reaches the screen. Both modes produce one
-// self-contained cue per MoQ group and differ only in what the decoder does with
-// the pairs as they arrive.
+// Mode selects how a group's caption reaches the screen. Every mode produces one
+// self-contained cue per MoQ group and they differ only in what the decoder does
+// with the pairs as they arrive.
 //
 // The distinction matters because a MoQ group is one wall-clock second and
 // carries exactly one cue, so a caption's display interval is decided entirely
@@ -14,6 +14,10 @@ import "fmt"
 //     the caption starts appearing on the group's first frame and is complete for
 //     the group's tail. Display therefore coincides with the second the caption
 //     names.
+//   - ModeRollUp2/3/4 type onto the base row the same way, but scroll the window
+//     up before each line instead of clearing the whole screen. Same timing as
+//     paint-on; what differs is the RU2/RU3/RU4 mode code on the wire and the
+//     window it asks the decoder to keep.
 //   - ModePopOn builds in non-displayed memory and flips the whole caption on
 //     with an EOC. The build drains one pair per frame, so the flip lands around
 //     frame 18 of 25 and the caption is displayed from three-quarters through the
@@ -22,8 +26,11 @@ import "fmt"
 //     WithFlipAtCueStart), which is exactly the cross-group dependency the
 //     independent-group model avoids.
 //
-// Both keep every group independently decodable: a subscriber joining at an
-// arbitrary group gets that group's whole caption from that group's samples.
+// All of them keep every group independently decodable: a subscriber joining at
+// an arbitrary group gets that group's whole caption from that group's samples.
+// For roll-up that takes go-608's default window reset — the unit clears the
+// window on its own first frame — rather than WithRollUpCarry, which would make a
+// group's picture depend on its predecessors.
 type Mode int
 
 const (
@@ -35,16 +42,40 @@ const (
 	// the classic broadcast style. Displayed late relative to its own group; see
 	// the Mode doc.
 	ModePopOn
+	// ModeRollUp2 types the caption into a 2-row roll-up window (RU2).
+	ModeRollUp2
+	// ModeRollUp3 is ModeRollUp2 with a 3-row window (RU3).
+	ModeRollUp3
+	// ModeRollUp4 is ModeRollUp2 with a 4-row window (RU4).
+	ModeRollUp4
 )
 
-// modeNames pairs each Mode with its flag spelling. The slice, not a map, so
-// ModeNames' output order is fixed and puts the default first.
+// modeNames pairs each Mode with its canonical flag spelling. The slice, not a
+// map, so ModeNames' output order is fixed and puts the default first.
 var modeNames = []struct {
 	mode Mode
 	name string
 }{
 	{ModePaintOn, "paint-on"},
 	{ModePopOn, "pop-on"},
+	{ModeRollUp2, "roll-up2"},
+	{ModeRollUp3, "roll-up3"},
+	{ModeRollUp4, "roll-up4"},
+}
+
+// rollUpRows returns the roll-up window size for a roll-up Mode, and ok=false for
+// the pop-on and paint-on modes, which have no window.
+func (m Mode) rollUpRows() (rows int, ok bool) {
+	switch m {
+	case ModeRollUp2:
+		return 2, true
+	case ModeRollUp3:
+		return 3, true
+	case ModeRollUp4:
+		return 4, true
+	default:
+		return 0, false
+	}
 }
 
 func (m Mode) String() string {
@@ -57,21 +88,28 @@ func (m Mode) String() string {
 }
 
 // ParseMode maps a flag value onto a Mode. An empty string selects the default
-// (ModePaintOn) so that a caller can pass an unset flag straight through.
+// (ModePaintOn) so that a caller can pass an unset flag straight through. Bare
+// "roll-up" means "roll-up2", matching go-608's own go608-clock, whose -mode takes
+// roll-up[2-4] with 2 as the zero value.
 func ParseMode(s string) (Mode, error) {
 	if s == "" {
 		return ModePaintOn, nil
+	}
+	if s == "roll-up" {
+		return ModeRollUp2, nil
 	}
 	for _, mn := range modeNames {
 		if mn.name == s {
 			return mn.mode, nil
 		}
 	}
-	return 0, fmt.Errorf("unknown CTA-608 caption mode %q, expected one of %v", s, ModeNames())
+	return 0, fmt.Errorf("unknown CTA-608 caption mode %q, expected one of %v (or \"roll-up\" for roll-up2)",
+		s, ModeNames())
 }
 
-// ModeNames lists the accepted flag values, default first, for flag help and
-// error messages.
+// ModeNames lists the canonical flag values, default first, for flag help and
+// error messages. The "roll-up" alias is deliberately left out: it is accepted,
+// but listing it would suggest a fourth distinct mode.
 func ModeNames() []string {
 	names := make([]string, 0, len(modeNames))
 	for _, mn := range modeNames {

--- a/internal/cc608_wiring_test.go
+++ b/internal/cc608_wiring_test.go
@@ -46,10 +46,20 @@ func mdatData(t *testing.T, chunk []byte) []byte {
 	return mdat.Data
 }
 
-// decodeGroupCaption feeds a whole group's per-object captions through the
-// cta608 decoder in order and returns the number of on-screen flips plus the
-// text of rows 13 and 14 at the last flip.
-func decodeGroupCaption(t *testing.T, objects []MoQObject, codec cc608.Codec) (flips int, row13, row14 string) {
+// decodeGroupCaption feeds a whole group's per-object captions through a fresh
+// cta608 decoder in order and returns how many times the displayed screen
+// changed plus the text of rows 13 and 14 as the group leaves it.
+//
+// The decoder is fresh per call and is fed one group's objects only, so a passing
+// assertion is also proof the group is self-contained: whatever the caption reads
+// at the end was derived from that group's samples alone, which is what lets a
+// subscriber join at an arbitrary group.
+//
+// The screen is read at the end rather than at a change, because the number of
+// changes is mode-dependent: pop-on flips its caption on once, while paint-on
+// grows it two characters at a time and so changes the screen repeatedly. Both
+// leave the same finished caption displayed.
+func decodeGroupCaption(t *testing.T, objects []MoQObject, codec cc608.Codec) (changes int, row13, row14 string) {
 	t.Helper()
 	var dec cta608.Decoder
 	for i, obj := range objects {
@@ -60,12 +70,10 @@ func decodeGroupCaption(t *testing.T, objects []MoQObject, codec cc608.Codec) (f
 		}
 		require.NoErrorf(t, dec.Feed(f1), "object %d decode", i)
 		if dec.Changed() {
-			flips++
-			row13 = rowText(dec.Screen(), 13)
-			row14 = rowText(dec.Screen(), 14)
+			changes++
 		}
 	}
-	return flips, row13, row14
+	return changes, rowText(dec.Screen(), 13), rowText(dec.Screen(), 14)
 }
 
 // rowText concatenates the text of the decoded screen row with the given index.
@@ -85,27 +93,30 @@ func rowText(s cta608.Screen, idx int) string {
 
 // TestGenMoQGroupCC608_CMAF verifies that with an enabled generator installed
 // via SetCC608Generator, a CMAF-packaged video group carries a decodable CTA-608
-// CC1 caption for AVC, HEVC and AV1. It also confirms one flip per group (one
-// pop-on cue per wall-clock second).
+// CC1 caption for AVC, HEVC and AV1, in both caption modes. The mode reaching the
+// serve path at all is the point of covering both here; how each one gets the
+// caption on screen is pinned in the cc608 package's own tests.
 func TestGenMoQGroupCC608_CMAF(t *testing.T) {
-	for _, c := range captionCodecCases {
-		t.Run(c.name, func(t *testing.T) {
-			asset, err := LoadAsset("../assets/test10s", 1, 1)
-			require.NoError(t, err)
-			asset.SetCC608Generator(cc608.New(cc608.Config{Enabled: true}))
+	for _, mode := range []cc608.Mode{cc608.ModePaintOn, cc608.ModePopOn} {
+		for _, c := range captionCodecCases {
+			t.Run(mode.String()+"/"+c.name, func(t *testing.T) {
+				asset, err := LoadAsset("../assets/test10s", 1, 1)
+				require.NoError(t, err)
+				asset.SetCC608Generator(cc608.New(cc608.Config{Enabled: true, Mode: mode}))
 
-			ct := asset.GetTrackByName(c.name)
-			require.NotNil(t, ct)
+				ct := asset.GetTrackByName(c.name)
+				require.NotNil(t, ct)
 
-			mg, err := GenMoQGroup(ct, groupNrClock, 1, MoqGroupDurMS, "cmaf")
-			require.NoError(t, err)
-			require.Equal(t, 25, len(mg.MoQObjects), "25 fps => 25 objects in a 1s group")
+				mg, err := GenMoQGroup(ct, groupNrClock, 1, MoqGroupDurMS, "cmaf")
+				require.NoError(t, err)
+				require.Equal(t, 25, len(mg.MoQObjects), "25 fps => 25 objects in a 1s group")
 
-			flips, row13, row14 := decodeGroupCaption(t, mg.MoQObjects, c.codec)
-			assert.Equal(t, 1, flips, "one pop-on cue per group")
-			assert.Equal(t, "12:34:56.000", row13)
-			assert.Equal(t, "GRP 45296", row14)
-		})
+				changes, row13, row14 := decodeGroupCaption(t, mg.MoQObjects, c.codec)
+				assert.Positive(t, changes, "the caption must reach the screen")
+				assert.Equal(t, "12:34:56.000", row13)
+				assert.Equal(t, "GRP 45296", row14)
+			})
+		}
 	}
 }
 
@@ -209,8 +220,8 @@ func TestGenMoQGroupCC608_LOCMAF(t *testing.T) {
 				chunks[i] = chunk
 			}
 
-			flips, row13, row14 := decodeGroupCaption(t, chunks, c.codec)
-			assert.Equal(t, 1, flips, "one pop-on cue per group")
+			changes, row13, row14 := decodeGroupCaption(t, chunks, c.codec)
+			assert.Positive(t, changes, "the caption must reach the screen")
 			assert.Equal(t, "12:34:56.000", row13)
 			assert.Equal(t, "GRP 45296", row14)
 		})
@@ -271,8 +282,8 @@ func TestGenMoQGroupCC608_EncryptedPreEncryption(t *testing.T) {
 				dec[i] = plain
 			}
 
-			flips, row13, row14 := decodeGroupCaption(t, dec, c.codec)
-			assert.Equal(t, 1, flips, "one pop-on cue per group after decryption")
+			changes, row13, row14 := decodeGroupCaption(t, dec, c.codec)
+			assert.Positive(t, changes, "the caption must reach the screen after decryption")
 			assert.Equal(t, "12:34:56.000", row13)
 			assert.Equal(t, "GRP 45296", row14)
 		})

--- a/internal/cc608_wiring_test.go
+++ b/internal/cc608_wiring_test.go
@@ -97,7 +97,7 @@ func rowText(s cta608.Screen, idx int) string {
 // serve path at all is the point of covering both here; how each one gets the
 // caption on screen is pinned in the cc608 package's own tests.
 func TestGenMoQGroupCC608_CMAF(t *testing.T) {
-	for _, mode := range []cc608.Mode{cc608.ModePaintOn, cc608.ModePopOn} {
+	for _, mode := range []cc608.Mode{cc608.ModePaintOn, cc608.ModePopOn, cc608.ModeRollUp3} {
 		for _, c := range captionCodecCases {
 			t.Run(mode.String()+"/"+c.name, func(t *testing.T) {
 				asset, err := LoadAsset("../assets/test10s", 1, 1)

--- a/internal/pub/caption_test.go
+++ b/internal/pub/caption_test.go
@@ -44,9 +44,15 @@ func captionedVideoTrack(t *testing.T, name string) *internal.ContentTrack {
 	return ct
 }
 
-// decodeFrames feeds a sequence of per-frame coded samples through the cta608
-// decoder and returns the flip count and the last-flip row 13/14 text.
-func decodeFrames(t *testing.T, frames [][]byte, codec cc608.Codec) (flips int, row13, row14 string) {
+// decodeFrames feeds a sequence of per-frame coded samples through a fresh cta608
+// decoder and returns how many times the displayed screen changed plus the row
+// 13/14 text the last frame leaves on it.
+//
+// The screen is read at the end rather than at a change because the change count
+// is mode-dependent: pop-on flips its caption on once, paint-on grows it two
+// characters at a time. Both leave the same finished caption displayed, which is
+// what these tests are about.
+func decodeFrames(t *testing.T, frames [][]byte, codec cc608.Codec) (changes int, row13, row14 string) {
 	t.Helper()
 	var dec cta608.Decoder
 	for i, data := range frames {
@@ -57,12 +63,10 @@ func decodeFrames(t *testing.T, frames [][]byte, codec cc608.Codec) (flips int, 
 		}
 		require.NoErrorf(t, dec.Feed(f1), "frame %d decode", i)
 		if dec.Changed() {
-			flips++
-			row13 = rowText(dec.Screen(), 13)
-			row14 = rowText(dec.Screen(), 14)
+			changes++
 		}
 	}
-	return flips, row13, row14
+	return changes, rowText(dec.Screen(), 13), rowText(dec.Screen(), 14)
 }
 
 // TestVideoCaptioner_LOC mirrors PublishLOCTrack's grouping and splicing exactly
@@ -95,8 +99,8 @@ func TestVideoCaptioner_LOC(t *testing.T) {
 				_, origNr := ct.CalcSample(sampleNr)
 				frames = append(frames, cap.spliceFrame(ct.Samples[origNr].Data, sched, sampleNr, startNr))
 			}
-			flips, row13, row14 := decodeFrames(t, frames, c.codec)
-			assert.Equal(t, 1, flips, "one pop-on cue per group")
+			changes, row13, row14 := decodeFrames(t, frames, c.codec)
+			assert.Positive(t, changes, "the caption must reach the screen")
 			assert.Equal(t, "12:34:56.000", row13)
 			assert.Equal(t, "GRP 45296", row14)
 		})
@@ -130,8 +134,8 @@ func TestVideoCaptioner_MoqMI(t *testing.T) {
 		_, origNr := ct.CalcSample(sampleNr)
 		frames = append(frames, cap.spliceFrame(ct.Samples[origNr].Data, sched, sampleNr, startSample))
 	}
-	flips, row13, row14 := decodeFrames(t, frames, cc608.CodecAVC)
-	assert.Equal(t, 1, flips)
+	changes, row13, row14 := decodeFrames(t, frames, cc608.CodecAVC)
+	assert.Positive(t, changes, "the caption must reach the screen")
 	assert.Equal(t, "12:34:56.000", row13)
 	assert.Equal(t, "GRP 45296", row14)
 }


### PR DESCRIPTION
Adds `-cc608mode` to `mlmpub`, covering all three CTA-608 presentation styles, with **paint-on as the default**. Addresses #118 by a different route than that issue proposes — see below.

**Stacked on #124** (the go-608 v0.9.0 bump, which `BuildUnitPaintCues` / `BuildUnitRollUpCues` need). Base is `chore/go-608-v0.9.0`, so this diff is only the caption change; GitHub will retarget to `main` when #124 merges.

## The modes

Measured at 25 fps in a 25-frame group (`TestScheduleModeDisplayTiming`):

| `-cc608mode` | On screen | First chars | Complete | Net effect |
|---|---|---|---|---|
| `paint-on` (default) | Clears the screen on the group's first frame, then grows the caption two characters per frame | frame 4 | frame 17 | displayed over the second it names |
| `roll-up2/3/4` | Types onto the base row the same way, scrolling the window before each line | frame 5 | frame 19 | as paint-on, two frames later (the extra CR per line) |
| `pop-on` | Built invisibly, flipped on whole | frame 18 | frame 18 | `GRP n` on screen mostly during group *n+1* |

Bare `roll-up` means `roll-up2`, matching go-608's `go608-clock`. Roll-up fits the pair budget at every broadcast rate from 23.976 to 60 fps, verified across all three window sizes.

## Why paint-on is the default

A MoQ group is one wall-clock second and carries exactly one cue, so where inside the group the visible transition falls decides the caption's entire display interval. Pop-on's build drains one byte pair per frame, so its `EOC` cannot land earlier without borrowing frames from somewhere. That is exactly what #118 proposed (`WithFlipAtCueStart`, scheduling group *N+1*'s build across group *N*'s frames) — and it buys alignment by giving up self-containment: a subscriber joining at group *N* would get that group's `EOC` without the preceding build and show nothing for up to a second.

The progressive modes get alignment **without** that trade. Per go-608's contract for paint-on: *"no cue's data crosses a unit boundary… a receiver that joins mid-stream is correct from the first cue boundary it sees."*

So for low latency with independent groups this looks like the better answer to #118 than the cross-group preload — **#118 may be closeable rather than implementable**. Your call.

## Independence, and the two options deliberately not used

Every mode keeps each group's caption derivable from that group's samples alone. That took omitting one cross-unit option per mode family, and they fail differently:

- `WithFlipAtCueStart` (pop-on) would put a group's build in its predecessor.
- `WithRollUpCarry` (roll-up) would leave a group's upper rows holding its predecessor's lines. moqlivemock uses go-608's default per-unit window reset instead, so roll-up is self-contained in *display* as well as data.

Carry is not exposed at all — it would break the property the whole mode set is built around.

**Consequence worth knowing:** with one cue per group and the window reset each group, only the two rows a group writes for itself are ever filled, so `roll-up2`, `roll-up3` and `roll-up4` display identically. What differs is the RU2/RU3/RU4 mode code on the wire — which is precisely what makes all three worth having in a test service.

## Implementation

- `cc608.Mode` in the new `internal/cc608/mode.go`: `ModePaintOn` (zero value), `ModePopOn`, `ModeRollUp2/3/4`, with `ParseMode`/`ModeNames`. The roll-up window size is carried by the Mode value itself (`rollUpRows`) rather than a separate `rows` field, so an out-of-range window is unrepresentable and the zero value stays paint-on.
- `Generator.Schedule` dispatches to `BuildUnitPaintCues`, `BuildUnitRollUpCues` or `BuildUnitCues` — same arguments, same return, none passed a cross-unit option.
- `-cc608mode` without `-cc608` is an error, not a silently ignored flag; an unknown value lists the accepted ones.

## Tests

The existing decode tests asserted "one flip per group", which is pop-on specific — the progressive modes legitimately change the screen 11–12 times as text grows. The three decode helpers (`internal`, `internal/pub`, `internal/cc608`) now read the screen the group *leaves behind*, identical across modes, and the mode-specific behaviour is pinned where it belongs. Mode-parameterised tests iterate an `allModes` slice so a mode added later is covered by construction:

- `TestScheduleModeDisplayTiming` — the table above, as loose bounds (which half of the group), not exact indices.
- `TestScheduleSelfContained` — 3 consecutive groups × 5 modes × 3 codecs, each decoded by a **fresh** decoder fed that group alone: the join-at-any-group guarantee, and the regression test for either cross-unit option being adopted unnoticed.
- `TestScheduleRoundTrip` — all 5 modes. For roll-up this also pins that lines written in `Row` order onto a scrolling window still land on rows 13/14, and that the tightest mode on the pair budget doesn't overrun.
- `TestGenMoQGroupCC608_CMAF` — paint-on, pop-on and roll-up3 through the real serve path.
- `TestParseMode` — every value, the `roll-up` alias, the empty-string default, canonical `String()` round-tripping, `rollUpRows`, and that `roll-up1`/`roll-up5` are rejected.

## Verification

`go build`, `go vet`, `golangci-lint` (0 issues) and the full `go test ./...` pass with `GOWORK=off`. Checked against a running `mlmpub` that each value selects the right mode (`mode=roll-up2` for bare `roll-up`, `mode=roll-up3`, `mode=roll-up4`, …) and that both error paths fire.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
