### PR TITLE
Move the LOC Timestamp property to 0x10 (draft-ietf-moq-loc-04)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,12 +16,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   streams whose closing replaces UNANNOUNCE, and a publisher now sees a
   subscriber leave -- publish loops end on the subscription's context rather
   than the session's. `InitialMaxRequestID` is gone with MAX_REQUEST_ID.
-- **The LOC Timestamp Object Property moves from `0x06` to `0x0A`**, per
-  draft-ietf-moq-loc-03. MOQT's Properties registry allocates `0x06` to
-  SUBGROUP_DELIVERY_TIMEOUT, which is Track scope only, so a `0x06` Object
-  Property makes the track malformed from draft-18 onwards and the subscription
-  is refused. draft-16 had no scope rule for extension headers, so the collision
-  was silently tolerated until the new parser enforced it.
+- **The LOC Timestamp Object Property moves from `0x06` to `0x10`**, per
+  draft-ietf-moq-loc-04. `0x06` became unusable under draft-18: MOQT's
+  Properties registry allocates it to SUBGROUP_DELIVERY_TIMEOUT, which is Track
+  scope only, so a `0x06` Object Property makes the track malformed and the
+  subscription is refused. draft-16 had no scope rule for extension headers, so
+  the collision was silently tolerated until the new parser enforced it.
+  The codepoint moved twice on the way: draft-03 assigned `0x0A` and draft-04
+  reassigned it to `0x10` as the registry table settled. `0x0A` was briefly on
+  `main` and in no release, so only a build from that window speaks it.
 - The ALPN lists are no longer hard-coded -- `moqtransport.SupportedALPNs` is the
   single source, and `mlmtest`'s table runs over it rather than a literal list.
 - moq-mi header construction moves in from `moqtransport` to `internal/moqmi`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,9 +36,12 @@ Consequences worth knowing:
   long as its stream, and ending that stream is the message. A publisher learns
   a subscriber has gone from `Subscription.Context()` being cancelled.
 - Extension headers are now Object Properties, with a registry and per-property
-  scope. The LOC Timestamp property is **0x0A** (draft-ietf-moq-loc-03), not
-  0x06: MOQT allocates 0x06 to SUBGROUP_DELIVERY_TIMEOUT, which is Track scope
-  only, so a 0x06 Object Property makes the track malformed.
+  scope. The LOC Timestamp property is **0x10** (draft-ietf-moq-loc-04). It has
+  moved twice: 0x06 was unusable because MOQT allocates it to
+  SUBGROUP_DELIVERY_TIMEOUT, which is Track scope only, so a 0x06 Object
+  Property makes the track malformed; draft-03 moved it to 0x0A and draft-04
+  moved it again to 0x10 as the registry table settled. Check the draft before
+  assuming this one.
 - The PROPERTIES bit lives in the subgroup header and covers every Object on
   the stream, so a subgroup carrying properties must be opened with
   `moqtransport.WithObjectProperties()`.

--- a/internal/pub/pub.go
+++ b/internal/pub/pub.go
@@ -386,16 +386,18 @@ func PublishTrack(ctx context.Context, publisher *moqtransport.Subscription,
 	}
 }
 
-// LOC extension header property IDs from draft-ietf-moq-loc-03 §2.3.1.
+// LOC Object Property IDs from draft-ietf-moq-loc-04 §2.3.1.
 const (
 	// locPropTimestamp is the LOC Timestamp property: microseconds since the
 	// Unix epoch when no Timescale property is present.
 	//
-	// draft-ietf-moq-loc-03 moved it from 0x06 to 0x0A. It had to: MOQT's
-	// Properties registry allocates 0x06 to SUBGROUP_DELIVERY_TIMEOUT, which
-	// is Track scope only, so a 0x06 Object Property is a malformed track from
-	// draft-18 onwards and gets the session closed.
-	locPropTimestamp = 0x0A
+	// The codepoint has moved twice. draft-ietf-moq-loc-03 moved it from 0x06
+	// to 0x0A because MOQT's Properties registry allocates 0x06 to
+	// SUBGROUP_DELIVERY_TIMEOUT, which is Track scope only, so a 0x06 Object
+	// Property is a malformed track from draft-18 onwards. draft-04 then moved
+	// it again to 0x10, publishing a settled registry table where -03 still
+	// carried "IANA, please assign" on its neighbours.
+	locPropTimestamp = 0x10
 )
 
 // PublishLOCTrack publishes LOC media track data (one raw frame per object) in MoQ groups,

--- a/internal/sub/loc.go
+++ b/internal/sub/loc.go
@@ -11,12 +11,12 @@ import (
 	"github.com/Eyevinn/mp4ff/aac"
 )
 
-// LOC property IDs from draft-ietf-moq-loc-03 §2.3.1.
+// LOC property IDs from draft-ietf-moq-loc-04 §2.3.1.
 const (
-	locPropTimestamp = 0x0A
+	locPropTimestamp = 0x10
 )
 
-// locTimestampMicros returns the LOC Timestamp (ID 0x0A) from the object's
+// locTimestampMicros returns the LOC Timestamp (ID 0x10) from the object's
 // extension headers, interpreted as microseconds since the Unix epoch
 // (the default when no Timescale property is present, per LOC-03 §2.3.1.1).
 func locTimestampMicros(headers moqtransport.KVPList) (uint64, bool) {


### PR DESCRIPTION
Aligns the LOC Timestamp Object Property with
[draft-ietf-moq-loc-04](https://datatracker.ietf.org/doc/html/draft-ietf-moq-loc-04)
§2.3.1.1, which moves it to **`0x10`**.

### The codepoint has moved twice

| draft | ID | why |
|---|---|---|
| `draft-ietf-moq-loc-02` | `0x06` | unusable under MOQT draft-18 — the Properties registry allocates `0x06` to SUBGROUP_DELIVERY_TIMEOUT, which is **Track scope only**, so a `0x06` Object Property makes the track malformed |
| `draft-ietf-moq-loc-03` | `0x0A` | renumbered for that reason — **what `main` speaks today** |
| **`draft-ietf-moq-loc-04`** | **`0x10`** | moved again as the registry table settled; -03 still carried "IANA, please assign" on the neighbouring properties, -04 publishes them assigned |

`0x0A` landed on `main` in #129 and is in **no release**, so only a build from
that window speaks it. The published `ghcr.io/eyevinn/mlmtest:main` is one such
build; `:latest` is still v0.12.0 and predates all of this.

### Why this matters before the interop event

A mismatch here is **silent**. The property is simply absent to the reader, so
it does not error — it surfaces as a missing or nonsensical latency. Verified by
pointing a `0x10` warp-player at a `0x0A` mlmpub built from `main`:

```
Video Buffer   0 ms
Audio Buffer   0 ms
Latency        1716646042585 ms
Playback Rate  0.970x        (the latency controller flailing)
```

A peer on -04 and a build on -03 would disagree about every capture timestamp
and neither side would report a problem.

### Verification

`go build ./...`, `go test -race ./...` and `golangci-lint` all clean. Verified
end to end in Chromium against a matching draft-18 warp-player, both sides on
`0x10`:

| namespace | engine | video buffer | audio buffer | latency |
|---|---|---|---|---|
| `msf/clear` | WebCodecs / LOC | 250 ms | 266 ms | **294 ms** |
| `cmsf/clear` | MSE / CMAF | 286 ms | 289 ms | **305 ms** |

Zero console errors. The latency figure is *derived from* the capture timestamp,
so a sane non-zero value is direct evidence the property is being read at its
new ID rather than silently defaulting.

### Also here

`CLAUDE.md` and the `[Unreleased]` changelog entry now describe the move as
`0x06` → `0x10` and note the `0x0A` step, since a reader of the eventual release
notes never saw `0x0A` ship.

### Follow-up, not in this PR

The matching warp-player change is on a local `feat/draft-18` branch and is not
yet up. Sequencing that matters for the Sep-3 interop: this should land before
the release that finally moves `mlmtest:latest`, or the interop image would go
out on the superseded codepoint.
