### PR TITLE
ci: move :latest on every push to main, not only on a release tag

### DIFF
--- a/.github/workflows/docker-mlmtest.yml
+++ b/.github/workflows/docker-mlmtest.yml
@@ -26,6 +26,15 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      # The last tag entry moves :latest on every push to the default branch.
+      #
+      # metadata-action's default latest=auto only moves :latest for a semver
+      # tag, so a single failed release push strands it until the next release.
+      # That is what happened at v0.13.0: GHCR secondary rate limiting aborted
+      # the push part-way -- after :0.13.0, before :0.13 and :latest -- and
+      # :latest then sat on v0.12.0 for 25 days with nothing to report it. The
+      # interop runner pulls :latest, so a stale tag there silently decides what
+      # the matrix actually tests.
       - name: Extract metadata
         id: meta
         uses: docker/metadata-action@v5
@@ -36,6 +45,7 @@ jobs:
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=sha
+            type=raw,value=latest,enable={{is_default_branch}}
 
       - name: Build and push
         uses: docker/build-push-action@v6


### PR DESCRIPTION
Adds one tag pattern so `:latest` moves on every push to the default branch:

```yaml
type=raw,value=latest,enable={{is_default_branch}}
```

### Why

`docker/metadata-action`'s default `latest=auto` moves `:latest` for a **semver
tag and nothing else**. So a single failed release push strands it until the
*next* release, with nothing to report the gap.

That is not hypothetical — it is the current state of the registry. At v0.13.0
the push hit GHCR **secondary rate limiting** part-way through its tag list and
aborted:

```
> pushing ghcr.io/eyevinn/mlmtest:0.13
ERROR: denied: permission_denied ... 403 Forbidden
  "message": "You have exceeded a secondary rate limit."
```

The tag list corroborates exactly where it died:

| tag | state |
|---|---|
| `0.13.0` | pushed |
| `0.13` | **missing to this day** — aborted here |
| `latest` | never reached; still points at **v0.12.0** |

So `:latest` has been two releases behind for 25 days. Note the 403 is
throttling, not an access problem — the same afternoon's earlier pushes
succeeded, and the run on `main` of 2026-08-30 pushed fine.

### Why it matters beyond tidiness

`moqlivemock` is registered in
[englishm/moq-interop-runner](https://github.com/englishm/moq-interop-runner)'s
`implementations.json` as `ghcr.io/eyevinn/mlmtest:latest`. A stale tag there
silently decides which build the interop matrix actually tests — so the draft-18
work would not reach the matrix at all until a release happened to succeed.

With this change `:latest` tracks `main` continuously and no single push can
strand it.

### Note on placement

The rationale sits **above** the step rather than inside the `tags:` block.
That block is a YAML block scalar handed to the action verbatim, so `#` lines
there would arrive as tag patterns rather than comments. Verified that the
action receives exactly the five intended patterns and nothing else.
