### PR TITLE
chore(release): prepare v0.14.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.14.0] - 2026-08-31
+
+MoQ Transport draft-18, and drafts 14 and 16 are gone. From draft-17 the ALPN
+is the whole of version negotiation, so this release talks to draft-18 peers
+and to nothing else -- `v0.13.x` remains the line for draft-14/16. The LOC
+Timestamp Object Property also moves to `0x10` to follow
+[draft-ietf-moq-loc-04][loc-04].
+
+Both changes are wire changes, and both fail quietly rather than loudly: a
+draft-16 peer cannot complete the ALPN handshake at all, and a peer on an older
+LOC draft simply finds no timestamp where it expects one.
+
 ### Changed
 
 - **Migrated to MoQ Transport draft-18** (`moqtransport` v0.11.0). Drafts 14 and
@@ -17,7 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   subscriber leave -- publish loops end on the subscription's context rather
   than the session's. `InitialMaxRequestID` is gone with MAX_REQUEST_ID.
 - **The LOC Timestamp Object Property moves from `0x06` to `0x10`**, per
-  draft-ietf-moq-loc-04. `0x06` became unusable under draft-18: MOQT's
+  [draft-ietf-moq-loc-04][loc-04]. `0x06` became unusable under draft-18: MOQT's
   Properties registry allocates it to SUBGROUP_DELIVERY_TIMEOUT, which is Track
   scope only, so a `0x06` Object Property makes the track malformed and the
   subscription is refused. draft-16 had no scope rule for extension headers, so
@@ -550,7 +562,7 @@ Full [MOQ Transport draft-14][moqt-d14] compliance release.
 
 - Configuration options for `audiobatch` and `videobatch` to control how many frames should be sent in every MoQ object/CMAF chunk
 - systemd service script and helpers for mlmpub
-- fingerprint endpoint of mlmpub to be used with WebTransport browser clients like [warp-player[wp]
+- fingerprint endpoint of mlmpub to be used with WebTransport browser clients like [warp-player][wp]
 - Certificate validation and auto-generation for WebTransport-compatible certificates (ECDSA, 14-day validity)
 
 ## [0.2.0] - 2025-04-28
@@ -581,27 +593,29 @@ Full [MOQ Transport draft-14][moqt-d14] compliance release.
 
 - initial version of the repo
 
-[Unreleased]: https://github.com/Eyevinn/moqlivemock/releases/tag/v0.13.0...HEAD
-[0.13.0]: https://github.com/Eyevinn/moqlivemock/releases/tag/v0.12.0...v0.13.0
-[0.12.0]: https://github.com/Eyevinn/moqlivemock/releases/tag/v0.11.1...v0.12.0
-[0.11.1]: https://github.com/Eyevinn/moqlivemock/releases/tag/v0.11.0...v0.11.1
-[0.11.0]: https://github.com/Eyevinn/moqlivemock/releases/tag/v0.10.0...v0.11.0
-[0.10.0]: https://github.com/Eyevinn/moqlivemock/releases/tag/v0.9.0...v0.10.0
-[0.9.0]: https://github.com/Eyevinn/moqlivemock/releases/tag/v0.8.0...v0.9.0
-[0.8.0]: https://github.com/Eyevinn/moqlivemock/releases/tag/v0.7.0...v0.8.0
-[0.7.0]: https://github.com/Eyevinn/moqlivemock/releases/tag/v0.6.1...v0.7.0
-[0.6.1]: https://github.com/Eyevinn/moqlivemock/releases/tag/v0.6.0...v0.6.1
-[0.6.0]: https://github.com/Eyevinn/moqlivemock/releases/tag/v0.5.0...v0.6.0
-[0.5.0]: https://github.com/Eyevinn/moqlivemock/releases/tag/v0.4.0...v0.5.0
-[0.4.0]: https://github.com/Eyevinn/moqlivemock/releases/tag/v0.3.0...v0.4.0
-[0.3.0]: https://github.com/Eyevinn/moqlivemock/releases/tag/v0.2.0...v0.3.0
-[0.2.0]: https://github.com/Eyevinn/moqlivemock/releases/tag/v0.1.0...v0.2.0
+[Unreleased]: https://github.com/Eyevinn/moqlivemock/compare/v0.14.0...HEAD
+[0.14.0]: https://github.com/Eyevinn/moqlivemock/compare/v0.13.0...v0.14.0
+[0.13.0]: https://github.com/Eyevinn/moqlivemock/compare/v0.12.0...v0.13.0
+[0.12.0]: https://github.com/Eyevinn/moqlivemock/compare/v0.11.1...v0.12.0
+[0.11.1]: https://github.com/Eyevinn/moqlivemock/compare/v0.11.0...v0.11.1
+[0.11.0]: https://github.com/Eyevinn/moqlivemock/compare/v0.10.0...v0.11.0
+[0.10.0]: https://github.com/Eyevinn/moqlivemock/compare/v0.9.0...v0.10.0
+[0.9.0]: https://github.com/Eyevinn/moqlivemock/compare/v0.8.0...v0.9.0
+[0.8.0]: https://github.com/Eyevinn/moqlivemock/compare/v0.7.0...v0.8.0
+[0.7.0]: https://github.com/Eyevinn/moqlivemock/compare/v0.6.1...v0.7.0
+[0.6.1]: https://github.com/Eyevinn/moqlivemock/compare/v0.6.0...v0.6.1
+[0.6.0]: https://github.com/Eyevinn/moqlivemock/compare/v0.5.0...v0.6.0
+[0.5.0]: https://github.com/Eyevinn/moqlivemock/compare/v0.4.0...v0.5.0
+[0.4.0]: https://github.com/Eyevinn/moqlivemock/compare/v0.3.0...v0.4.0
+[0.3.0]: https://github.com/Eyevinn/moqlivemock/compare/v0.2.0...v0.3.0
+[0.2.0]: https://github.com/Eyevinn/moqlivemock/compare/v0.1.0...v0.2.0
 [0.1.0]: https://github.com/Eyevinn/moqlivemock/releases/tag/v0.1.0
 
 [catalog]: https://moq-wg.github.io/warp-streaming-format/draft-ietf-moq-warp.html
 [msf-00]: https://datatracker.ietf.org/doc/draft-ietf-moq-msf/00/
 [msf-01]: https://datatracker.ietf.org/doc/draft-ietf-moq-msf/01/
 [loc]: https://datatracker.ietf.org/doc/html/draft-mzanaty-moq-loc
+[loc-04]: https://datatracker.ietf.org/doc/draft-ietf-moq-loc/04/
 [moq-mi]: https://datatracker.ietf.org/doc/html/draft-cenzano-moq-media-interop
 [moqt-d11]: https://datatracker.ietf.org/doc/draft-ietf-moq-transport/11/
 [moqt-d14]: https://datatracker.ietf.org/doc/draft-ietf-moq-transport/14/

--- a/internal/version.go
+++ b/internal/version.go
@@ -8,8 +8,8 @@ import (
 )
 
 var (
-	commitVersion string = "0.13.0"     // Should be updated during build
-	commitDate    string = "1786010400" // commitDate in Epoch seconds (can be filled/updated in during build)
+	commitVersion string = "0.14.0"     // Should be updated during build
+	commitDate    string = "1788170400" // commitDate in Epoch seconds (can be filled/updated in during build)
 )
 
 // GetVersion - get version, commitHash and  commitDate depending on what is inserted


### PR DESCRIPTION
Cuts the `[0.14.0]` CHANGELOG entry and bumps the version constant to `0.14.0`
(`commitDate` `1788170400`, 2026-08-31 12:00 +02:00, matching the noon-local
convention of previous releases).

### What ships

Four commits since `v0.13.0`:

| | |
|---|---|
| `c9737aa` | Migrate to moqtransport draft-18 |
| `17d9bc3` | Restore qlog, and make `-qlog` select the file |
| `ca78c2d` | Depend on the released moqtransport v0.11.0 (this PR moves it to v0.11.1) |
| `1172b64` | Move the LOC Timestamp property to `0x10` ([draft-ietf-moq-loc-04](https://datatracker.ietf.org/doc/draft-ietf-moq-loc/04/)) |

### Why a minor rather than a patch

Drafts 14 and 16 are dropped. From draft-17 the ALPN is the whole of version
negotiation, so this release talks to draft-18 peers and to nothing else.
Pre-1.0, that belongs in the minor. **`v0.13.x` remains the line for
draft-14/16.**

### Both changes fail quietly

This is the part worth having in the release notes, and it leads the entry:

- A **draft-16 peer cannot complete the ALPN handshake at all** — it does not
  get far enough to report a version mismatch.
- A peer on an **older LOC draft simply finds no timestamp** where it expects
  one. Observed against a `0x0A` build: `0 ms` buffers and a latency of
  `1716646042585 ms`, with no error anywhere.

The `0x0A` of draft-ietf-moq-loc-03 was on `main` only and never in a release,
so this is the first release in which that property's codepoint changes at all
— from `0x06` straight to `0x10` as far as any released build is concerned.

### CHANGELOG link list repaired

Not strictly release work, but it is the file this PR touches and the rot was
load-bearing:

- **All fifteen compare links were 404s.** They pointed at
  `/releases/tag/vX...vY`, which is not a GitHub URL — the compare form is
  `/compare/vX...vY`. Verified by fetching every one; only `[0.1.0]`, which
  names a single tag rather than a range, resolved. They now use `/compare/`
  and return 200.
- **`[0.14.0]` added**, and `[Unreleased]` repointed at `v0.14.0...HEAD` — it
  had the same malformed `/releases/tag/v0.13.0...HEAD` form.
- **`[loc-04]` added** for draft-ietf-moq-loc-04, in the revision-pinned style
  of `[msf-01]` and `[moqt-d14]`, and used from both v0.14.0 mentions. `[loc]`
  is deliberately left pointing at `draft-mzanaty-moq-loc`: only older entries
  reference it and they genuinely meant the pre-adoption individual draft, so
  repointing it would falsify them.
- **A bracket closed** in the 0.3.0 entry, where `[warp-player[wp]` rendered as
  literal text. Every reference-style link in the file now resolves to a
  definition, and every definition is used.

The two `v0.14.0` links 404 until the release is tagged, which is expected for a
release-prep change.

### Also takes moqtransport v0.11.1 — the qlog payload cap

The draft-18 rewrite put whole Object payloads in the qlog at the subgroup,
datagram and FETCH sites, so a qlog of a media session was a copy of the media.
Measured on a 90-second publisher session:

| | before | after |
|---|---|---|
| qlog size | 50.4 MB / 90 s | **0.41 MB / 20 s** |
| share that is payload hex | 85% | **13%** |

It appends indefinitely, so a long-running publisher or an interop container
fills a disk. Payloads are now capped at 20 bytes while `object_payload_length`
keeps the true size — verified in the log: an Object still reports
`object_payload_length: 25220` with 20 bytes of `data`. Control messages are
deliberately not truncated.

[moqtransport v0.11.1](https://github.com/Eyevinn/moqtransport/releases/tag/v0.11.1)
was cut for this; it is a qlog-only change with no API, dependency or wire
impact.

`mlmpub -h` also said the logs were "currently massive" in a sentence that broke
off mid-clause without saying where they went. It now states that a qlog is
always written, that it cannot be turned off, and which flag names the file.

### Verification

`go build ./...`, `go test ./...` and the pre-commit hooks pass. The substance
was verified end to end before its own PRs merged: draft-18 over real QUIC on
all four namespaces (#129), and both render pipelines in Chromium against a
matching draft-18 warp-player with `0x10` on both sides (#130).

### Sequencing

Merge **#131** (`:latest` tracks `main`) before tagging this. Without it,
`:latest` only moves on the semver tag, and a repeat of the v0.13.0 GHCR
throttling would strand it again — which is how it ended up 25 days and two
releases stale, still pointing at v0.12.0 today. With #131 in, the `main` push
moves `:latest` regardless of what the tag push does.
