### PR TITLE
feat(mlmrel): package the relay for the moq-interop-runner

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+.git
+venv
+out
+**/*.log
+**/*.mlog
+**/*.qlog

--- a/.github/workflows/docker-mlmrel.yml
+++ b/.github/workflows/docker-mlmrel.yml
@@ -1,0 +1,51 @@
+name: Docker mlmrel
+
+on:
+  push:
+    branches: [main]
+    tags: ["v*"]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Log in to GHCR
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # :latest moves on every push to the default branch rather than only on
+      # a semver tag; docker-mlmtest.yml explains the release-push failure
+      # that motivated it. The interop runner pulls :latest.
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/eyevinn/mlmrel
+          tags: |
+            type=ref,event=branch
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=sha
+            type=raw,value=latest,enable={{is_default_branch}}
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: Dockerfile.mlmrel
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   any JSON exists, and the pub, sub and relay handlers take the predicate as
   a `QlogFilter` field.
 - `-loglevel` on mlmpub, matching mlmsub and mlmrel.
+- `Dockerfile.mlmrel` and `entrypoint-relay.sh`: an mlmrel image for the
+  moq-interop-runner's relay role, following its conventions (`MOQT_ROLE`,
+  `MOQT_PORT`, `MOQT_CERT`, `MOQT_KEY`, `MOQT_MLOG_DIR`; non-root, `ss`-based
+  health check), published by CI as `ghcr.io/eyevinn/mlmrel` like mlmtest.
+  The qlog goes into the mlog directory when the container can write there,
+  and to stderr otherwise.
 
 ### Fixed
 

--- a/Dockerfile.mlmrel
+++ b/Dockerfile.mlmrel
@@ -1,0 +1,31 @@
+FROM golang:1.25 AS build
+WORKDIR /src
+COPY go.mod go.sum ./
+RUN go mod download
+COPY . .
+RUN CGO_ENABLED=0 go build -o /mlmrel ./cmd/mlmrel
+
+# The runner's healthcheck and entrypoint need a shell and ss (iproute2),
+# so the runtime image is debian-slim rather than distroless.
+FROM debian:bookworm-slim
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ca-certificates \
+    iproute2 \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY --from=build /mlmrel /usr/local/bin/mlmrel
+COPY entrypoint-relay.sh /usr/local/bin/run_endpoint.sh
+RUN chmod +x /usr/local/bin/run_endpoint.sh && mkdir -p /mlog /certs
+
+ENV MOQT_ROLE=relay
+ENV MOQT_PORT=4443
+
+EXPOSE 4443/udp
+
+HEALTHCHECK --interval=5s --timeout=3s --start-period=5s \
+  CMD sh -c 'ss -uln | grep -q ":${MOQT_PORT:-4443}" || exit 1'
+
+RUN useradd -r -u 1000 -g nogroup moq
+USER moq
+
+ENTRYPOINT ["/usr/local/bin/run_endpoint.sh"]

--- a/entrypoint-relay.sh
+++ b/entrypoint-relay.sh
@@ -1,0 +1,73 @@
+#!/bin/bash
+# entrypoint-relay.sh - wrapper for mlmrel in the moq-interop-runner
+# Translates the runner's MOQT_* environment variables to mlmrel flags.
+#
+# Expected environment:
+#   MOQT_ROLE     - Role to run: relay (required, only relay supported)
+#   MOQT_PORT     - UDP port to listen on (default: 4443)
+#   MOQT_CERT     - TLS certificate path (default: /certs/cert.pem)
+#   MOQT_KEY      - TLS private key path (default: /certs/priv.key)
+#   MOQT_MLOG_DIR - Directory for mlog/qlog files (default: /mlog)
+#
+# Expected mounts:
+#   /certs/cert.pem - TLS certificate
+#   /certs/priv.key - TLS private key
+#
+# Exit codes:
+#   0   - Clean shutdown (SIGTERM)
+#   1   - Configuration error
+#   127 - Unsupported role
+
+set -euo pipefail
+
+ROLE="${MOQT_ROLE:-relay}"
+PORT="${MOQT_PORT:-4443}"
+CERT="${MOQT_CERT:-/certs/cert.pem}"
+KEY="${MOQT_KEY:-/certs/priv.key}"
+MLOG_DIR="${MOQT_MLOG_DIR:-/mlog}"
+
+case "$ROLE" in
+  relay)
+    echo "Starting mlmrel on port $PORT"
+    echo "  Cert: $CERT"
+    echo "  Key:  $KEY"
+    echo "  Mlog: $MLOG_DIR"
+
+    if [ ! -f "$CERT" ]; then
+      echo "ERROR: Certificate not found at $CERT" >&2
+      echo "Make sure /certs is mounted with cert.pem and priv.key" >&2
+      exit 1
+    fi
+    if [ ! -f "$KEY" ]; then
+      echo "ERROR: Private key not found at $KEY" >&2
+      exit 1
+    fi
+
+    # The runner bind-mounts the mlog directory from the host and runs the
+    # container as uid 1000, so on a host where the directory belongs to
+    # another user it is read-only for us. A log destination must not keep
+    # the relay from starting: fall back to stderr, which docker captures.
+    if [ -w "$MLOG_DIR" ]; then
+      QLOG="$MLOG_DIR/mlmrel_server.mlog"
+    else
+      echo "WARNING: $MLOG_DIR is not writable; qlog goes to stderr" >&2
+      QLOG="-"
+    fi
+
+    # -pending-wait lets subscribe-before-announce succeed: the SUBSCRIBE
+    # arrives before the publisher's PUBLISH_NAMESPACE and is held briefly
+    # instead of being rejected outright.
+    exec mlmrel \
+      -addr "0.0.0.0:$PORT" \
+      -cert "$CERT" \
+      -key "$KEY" \
+      -pending-wait 1s \
+      -qlog "$QLOG"
+    ;;
+
+  *)
+    echo "Role '$ROLE' not supported by mlmrel" >&2
+    echo "Supported roles: relay" >&2
+    exit 127
+    ;;
+esac


### PR DESCRIPTION
`Dockerfile.mlmrel` builds mlmrel into a `debian:bookworm-slim` image that runs as uid 1000 — not distroless, because the moq-interop-runner's health check needs `sh` and `ss`. `entrypoint-relay.sh` maps the runner's environment contract (`MOQT_ROLE`, `MOQT_PORT`, `MOQT_CERT`, `MOQT_KEY`, `MOQT_MLOG_DIR`) to mlmrel flags, exits 127 for any role but `relay`, and passes `-pending-wait 1s` so that the `subscribe-before-announce` case is genuinely forwarded rather than answered with an immediate REQUEST_ERROR.

The runner bind-mounts the mlog directory from the host and forces uid 1000 in the container. On a host where that directory belongs to another user (GitHub-hosted runners, for one) it is not writable, and mlmrel treats a qlog it cannot open as fatal. The entrypoint therefore writes the qlog into the mlog directory when it can and otherwise warns and sends it to stderr, where `docker logs` keeps it — the same best-effort stance the moq-rs relay takes with its per-connection mlogs. `.dockerignore` keeps local qlogs, media output and the venv out of the build context.

`docker-mlmrel.yml` publishes `ghcr.io/eyevinn/mlmrel` exactly as `docker-mlmtest.yml` publishes mlmtest, including moving `:latest` on every push to main. On pull requests it only builds.

Verified: the six moq-interop-runner relay cases pass locally against mlmtest with this image (`make test RELAY_IMAGE=mlmrel:dev CLIENT_IMAGE=mlmtest:dev RELAY_URL=moqt://relay:4443`), and the relay's mlog lands in the runner's `mlog/relay/`. With the mlog directory made unwritable (root-owned tmpfs, container uid 1000) the relay warns, starts, and a real mlmtest session's qlog records show up in `docker logs`.

After this merges and the package is made public, the registration PR to the interop runner adds `roles.relay.docker` to the `moqlivemock` entry with a `moqt://relay:4443` URL, since mlmtest dials raw QUIC.

Part of #135.
