### PR TITLE
fix(mlmrel): answer requests the relay cannot honor or the upstream never answers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   draft-18 does not define, as moxygen's `LargestGroup` (250) is -- is now
   answered with REQUEST_ERROR NOT_SUPPORTED instead of being left open until
   the subscriber gives up.
+- mlmrel: `-upstream-timeout` (default 5s) bounds the wait for the upstream's
+  answer to a forwarded SUBSCRIBE or proxied FETCH; when it expires the
+  downstream request is rejected with TIMEOUT. Without it a publisher that
+  never answers -- imquic's test client in the subscribe-before-announce
+  case is one -- left the subscriber hanging for as long as it cared to wait.
 - mlmrel: a subscriber whose attach raced the end of its track -- the
   upstream finishing between the subscription resolving the shared track and
   registering with it -- joined a dead track and never received PUBLISH_DONE,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- mlmrel: a SUBSCRIBE the relay cannot accept -- one carrying a filter type
+  draft-18 does not define, as moxygen's `LargestGroup` (250) is -- is now
+  answered with REQUEST_ERROR NOT_SUPPORTED instead of being left open until
+  the subscriber gives up.
 - mlmrel: a subscriber whose attach raced the end of its track -- the
   upstream finishing between the subscription resolving the shared track and
   registering with it -- joined a dead track and never received PUBLISH_DONE,

--- a/cmd/mlmrel/main.go
+++ b/cmd/mlmrel/main.go
@@ -51,6 +51,7 @@ type options struct {
 	cacheGroups int
 	queueLen    int
 	linger      time.Duration
+	upstreamTO  time.Duration
 	qlogfile    string
 	qlogEvents  string
 	loglevel    string
@@ -78,6 +79,9 @@ func parseOptions(fs *flag.FlagSet, args []string) (*options, error) {
 		"per-subscriber object queue length; on overflow the subscriber skips to the next group boundary")
 	fs.DurationVar(&opts.linger, "linger", 2*time.Second,
 		"how long an upstream subscription survives its last downstream subscriber")
+	fs.DurationVar(&opts.upstreamTO, "upstream-timeout", 5*time.Second,
+		"how long a forwarded SUBSCRIBE or proxied FETCH waits for the upstream's answer "+
+			"before the requester gets a TIMEOUT error; 0 waits indefinitely")
 	fs.StringVar(&opts.qlogfile, "qlog", defaultQlogFileName, "qlog file to write to. Use '-' for stderr")
 	fs.StringVar(&opts.qlogEvents, "qlog-events", "all",
 		fmt.Sprintf("qlog event classes to write: all, or a comma-separated subset of %s",
@@ -177,6 +181,7 @@ func runServer(ctx context.Context, opts *options) error {
 	h.CacheGroups = opts.cacheGroups
 	h.QueueLen = opts.queueLen
 	h.Linger = opts.linger
+	h.UpstreamTimeout = opts.upstreamTO
 	if opts.upstream != "" {
 		go runUpstream(ctx, h, opts.upstream)
 	}

--- a/entrypoint-relay.sh
+++ b/entrypoint-relay.sh
@@ -56,12 +56,16 @@ case "$ROLE" in
 
     # -pending-wait lets subscribe-before-announce succeed: the SUBSCRIBE
     # arrives before the publisher's PUBLISH_NAMESPACE and is held briefly
-    # instead of being rejected outright.
+    # instead of being rejected outright. -upstream-timeout keeps a publisher
+    # that never answers the forwarded SUBSCRIBE from taking the subscriber
+    # down with it: that case gives the whole exchange 3.5 s and accepts a
+    # REQUEST_ERROR, so the answer has to come well inside that.
     exec mlmrel \
       -addr "0.0.0.0:$PORT" \
       -cert "$CERT" \
       -key "$KEY" \
       -pending-wait 1s \
+      -upstream-timeout 1s \
       -qlog "$QLOG"
     ;;
 

--- a/internal/relay/fetch.go
+++ b/internal/relay/fetch.go
@@ -104,8 +104,13 @@ func reorderGroupsDescending(objects []*moqtransport.Object) {
 // markers all survive.
 func (h *Handler) proxyFetch(r *moqtransport.FetchRequest, upstream *moqtransport.Session) {
 	start, end := r.Range()
-	fs, err := upstream.Fetch(r.Context(), r.Namespace(), r.Track(), start, end,
+	ctx, cancel := h.upstreamContext(r.Context())
+	fs, err := upstream.Fetch(ctx, r.Namespace(), r.Track(), start, end,
 		moqtransport.WithFetchGroupOrder(r.GroupOrder()))
+	if err != nil {
+		err = h.upstreamError(ctx, err)
+	}
+	cancel()
 	if err != nil {
 		code := moqtransport.RequestErrorDoesNotExist
 		reason := "upstream fetch failed"

--- a/internal/relay/forward.go
+++ b/internal/relay/forward.go
@@ -97,8 +97,15 @@ func (rt *relayTrack) serveSubscriber(r *moqtransport.SubscribeRequest) {
 	}
 	subscription, err := r.Accept(opts...)
 	if err != nil {
+		// Accept decodes the request's parameters, so a SUBSCRIBE the relay
+		// cannot honor -- one naming a filter type draft-18 does not define,
+		// say -- fails here with the request still unanswered. Answer it:
+		// the subscriber should hear of the refusal now, not at its timeout.
 		slog.Error("failed to accept subscription", "error", err,
 			"namespace", rt.namespace, "track", rt.track)
+		if rerr := r.Reject(moqtransport.RequestErrorNotSupported, err.Error()); rerr != nil {
+			slog.Debug("failed to reject subscription", "error", rerr)
+		}
 		rt.release()
 		return
 	}

--- a/internal/relay/relay.go
+++ b/internal/relay/relay.go
@@ -11,6 +11,8 @@ package relay
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"io"
 	"log/slog"
 	"strings"
@@ -45,6 +47,12 @@ type Handler struct {
 	// Linger is how long an upstream subscription survives its last
 	// downstream subscriber, so bouncing clients do not thrash the upstream.
 	Linger time.Duration
+	// UpstreamTimeout bounds how long a forwarded SUBSCRIBE or a proxied FETCH
+	// waits for the upstream's answer. When it expires the downstream request
+	// is rejected with TIMEOUT rather than left open for as long as the
+	// subscriber cares to wait: a publisher that never answers must not take
+	// its subscribers down with it. Zero waits indefinitely.
+	UpstreamTimeout time.Duration
 
 	mu            sync.Mutex
 	announcements map[nsKey]*announcement
@@ -79,16 +87,41 @@ type nsAnnouncer struct {
 // NewHandler creates a relay session handler writing its qlog to logfh.
 func NewHandler(logfh io.Writer) *Handler {
 	return &Handler{
-		Logfh:         logfh,
-		CacheGroups:   3,
-		QueueLen:      256,
-		Linger:        2 * time.Second,
-		announcements: make(map[nsKey]*announcement),
-		waiters:       make(map[nsKey][]chan *announcement),
-		tracks:        make(map[trackKey]*relayTrack),
-		sessions:      make(map[*moqtransport.Session]*sessionState),
-		announcers:    make(map[*nsAnnouncer]struct{}),
+		Logfh:           logfh,
+		CacheGroups:     3,
+		QueueLen:        256,
+		Linger:          2 * time.Second,
+		UpstreamTimeout: 5 * time.Second,
+		announcements:   make(map[nsKey]*announcement),
+		waiters:         make(map[nsKey][]chan *announcement),
+		tracks:          make(map[trackKey]*relayTrack),
+		sessions:        make(map[*moqtransport.Session]*sessionState),
+		announcers:      make(map[*nsAnnouncer]struct{}),
 	}
+}
+
+// upstreamContext bounds a wait for an upstream answer by UpstreamTimeout. In
+// moqtransport the context passed to Subscribe or Fetch governs only the
+// request's establishment -- an established subscription or fetch lives on
+// the session -- so the caller cancels it as soon as the answer is in.
+func (h *Handler) upstreamContext(parent context.Context) (context.Context, context.CancelFunc) {
+	if h.UpstreamTimeout <= 0 {
+		return context.WithCancel(parent)
+	}
+	return context.WithTimeout(parent, h.UpstreamTimeout)
+}
+
+// upstreamError maps the expiry of an upstreamContext to the REQUEST_ERROR
+// the downstream request should carry and leaves any other error alone. It
+// must run before the context is cancelled, which replaces the deadline error.
+func (h *Handler) upstreamError(ctx context.Context, err error) error {
+	if errors.Is(ctx.Err(), context.DeadlineExceeded) {
+		return &moqtransport.RequestError{
+			Code:   moqtransport.RequestErrorTimeout,
+			Reason: fmt.Sprintf("upstream did not answer within %v", h.UpstreamTimeout),
+		}
+	}
+	return err
 }
 
 // nsKey is a namespace tuple flattened to a comparable map key. The separator

--- a/internal/relay/relay_test.go
+++ b/internal/relay/relay_test.go
@@ -587,3 +587,68 @@ func TestEndOfGroupBitForwarded(t *testing.T) {
 		shutdown(psConn, pcConn, ssConn, scConn)
 	})
 }
+
+// TestUpstreamTimeout: a publisher that never answers the forwarded SUBSCRIBE
+// costs the subscriber UpstreamTimeout, not its own patience. It gets a
+// TIMEOUT, the upstream request is cancelled, and the failed attempt leaves
+// no track behind, so the next SUBSCRIBE tries upstream afresh.
+func TestUpstreamTimeout(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		h := relay.NewHandler(io.Discard)
+		h.UpstreamTimeout = time.Second
+
+		var cancelled atomic.Int32
+		pubSession := &moqtransport.Session{
+			Implementation: "mlmrel-test-publisher",
+			SubscribeHandler: moqtransport.SubscribeHandlerFunc(func(r *moqtransport.SubscribeRequest) {
+				<-r.Context().Done() // never answers
+				cancelled.Add(1)
+			}),
+		}
+		psConn, pcConn := connectSession(t, h, pubSession)
+		subSession, ssConn, scConn := connect(t, h)
+
+		_, err := pubSession.PublishNamespace(t.Context(), testNamespace)
+		require.NoError(t, err)
+
+		for attempt := range 2 {
+			start := time.Now()
+			_, err = subSession.Subscribe(t.Context(), testNamespace, "test-track")
+			requireRequestError(t, err, moqtransport.RequestErrorTimeout)
+			require.Equal(t, time.Second, time.Since(start), "attempt %d", attempt)
+			synctest.Wait()
+			require.Equal(t, int32(attempt+1), cancelled.Load(), "upstream request not cancelled")
+		}
+
+		shutdown(psConn, pcConn, ssConn, scConn)
+	})
+}
+
+// TestFetchProxiedUpstreamTimeout: the same bound applies to a proxied FETCH
+// whose upstream never answers.
+func TestFetchProxiedUpstreamTimeout(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		h := relay.NewHandler(io.Discard)
+		h.UpstreamTimeout = time.Second
+
+		pubSession := &moqtransport.Session{
+			Implementation: "mlmrel-test-publisher",
+			FetchHandler: moqtransport.FetchHandlerFunc(func(r *moqtransport.FetchRequest) {
+				<-r.Context().Done() // never answers
+			}),
+		}
+		psConn, pcConn := connectSession(t, h, pubSession)
+		subSession, ssConn, scConn := connect(t, h)
+
+		_, err := pubSession.PublishNamespace(t.Context(), testNamespace)
+		require.NoError(t, err)
+
+		start := time.Now()
+		_, err = subSession.Fetch(t.Context(), testNamespace, "test-track",
+			moqtransport.Location{Group: 0, Object: 0}, moqtransport.Location{Group: 0, Object: 1})
+		requireRequestError(t, err, moqtransport.RequestErrorTimeout)
+		require.Equal(t, time.Second, time.Since(start))
+
+		shutdown(psConn, pcConn, ssConn, scConn)
+	})
+}

--- a/internal/relay/track.go
+++ b/internal/relay/track.go
@@ -183,7 +183,12 @@ func (rt *relayTrack) lingerFire() {
 // run subscribes upstream and fans every received object out to the
 // subscribers and into the cache. It is the only writer of rt.remote/rt.err.
 func (rt *relayTrack) run() {
-	remote, err := rt.upstream.Subscribe(rt.ctx, rt.namespace, rt.track)
+	ctx, cancel := rt.h.upstreamContext(rt.ctx)
+	remote, err := rt.upstream.Subscribe(ctx, rt.namespace, rt.track)
+	if err != nil {
+		err = rt.h.upstreamError(ctx, err)
+	}
+	cancel()
 	if err != nil {
 		rt.err = err
 		rt.mu.Lock()


### PR DESCRIPTION
Two things the first local run of mlmrel against every registered draft-18 client in the moq-interop-runner turned up. Both are cases of a request the relay left unanswered, so the requester failed on its own timeout instead of on the relay's word.

**A SUBSCRIBE the relay cannot accept is now rejected.** `SubscribeRequest.Accept` decodes the request's parameters, so a SUBSCRIBE carrying something the relay cannot honor fails there with the request still open, and the relay only logged it. moxygen's interop client sends SUBSCRIPTION_FILTER type 250 -- its `LargestGroup`, which draft-18 does not define (only 0x1--0x4 are) -- and its subscribers heard nothing until they gave up. The relay now answers with REQUEST_ERROR NOT_SUPPORTED and the decode error as the reason. The filter type itself is moxygen's to fix; against this relay the refusal now arrives in milliseconds with a reason they can read.

**`-upstream-timeout` bounds the wait for an upstream answer.** A forwarded SUBSCRIBE or a proxied FETCH waited for the announcing session's answer for as long as the downstream requester cared to wait. imquic's client showed the cost: in its subscribe-before-announce case the publisher connection receives the forwarded SUBSCRIBE and never answers it (its accept callback only runs for the announce-subscribe case), so the subscriber hung until the case timed out -- although a REQUEST_ERROR would have passed it, and does against relays that answer the subscriber themselves. The wait is now bounded (default 5s; the interop entrypoint passes 1s, inside that case's 3.5s budget), and on expiry the downstream request gets TIMEOUT while the upstream request is cancelled. In moqtransport the context passed to `Subscribe` and `Fetch` governs only the request's establishment, so bounding it does not touch an established subscription or fetch. Two synctest tests pin the timing, the code and the upstream cancellation for both request types.

Verified with the rebuilt image in the runner: mlmtest 6/6 as before; imquic 5/6 → 6/6; moxygen 4/6 → 5/6, the remaining failure being its filter type, now reported in 18 ms. Full suite and lint green.

Part of #135.
